### PR TITLE
Fix Hyper-V data exchange for Linux

### DIFF
--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/UploadFileForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/UploadFileForwarder.cs
@@ -46,8 +46,9 @@ public sealed class UploadFileForwarder(string path, string fileName, ulong leng
         {
             // Reset the file in case we are overwriting it
             _fileStream!.SetLength(0);
-            using var memoryOwner = MemoryPool<byte>.Shared.Rent((int)(2 * SshChannel.DefaultMaxPacketSize));
-            var buffer = memoryOwner.Memory;
+            const int bufferSize = (int)(2 * SshChannel.DefaultMaxPacketSize);
+            using var memoryOwner = MemoryPool<byte>.Shared.Rent(bufferSize);
+            var buffer = memoryOwner.Memory[..bufferSize];
             while (_fileStream.Length < expectedLength)
             {
                 var bytesRead = await sshStream.ReadAsync(buffer, _cts.Token);

--- a/src/Eryph.GuestServices.HvDataExchange.Guest/LinuxGuestDataExchange.cs
+++ b/src/Eryph.GuestServices.HvDataExchange.Guest/LinuxGuestDataExchange.cs
@@ -94,7 +94,7 @@ public class LinuxGuestDataExchange : IGuestDataExchange
         fileStream.SetLength(values.Count * MaxKvpSize);
 
         using var bufferOwner = MemoryPool<byte>.Shared.Rent(MaxKvpSize);
-        var buffer = bufferOwner.Memory;
+        var buffer = bufferOwner.Memory[..MaxKvpSize];
 
         foreach (var kvp in values)
         {


### PR DESCRIPTION
This PR fixes the incorrect use of memory buffers which caused the Hyper-V data exchange to write invalid data on Linux.