### PR TITLE
Configurable shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,5 +262,7 @@ __pycache__/
 /docker/docker-compose-services/store/mysql
 /store/mysql
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 src/Eryph.GuestServices.Service/Properties/PublishProfiles/FolderProfile.pubxml
 src/Eryph.GuestServices.Tool/Properties/PublishProfiles/FolderProfile.pubxml
+test/e2e/TEST-pesterResults.xml

--- a/Eryph.GuestServices.sln
+++ b/Eryph.GuestServices.sln
@@ -31,6 +31,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eryph.GuestServices.HvDataE
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eryph.GuestServices.Tool.Tests", "test\Eryph.GuestServices.Tool.Tests\Eryph.GuestServices.Tool.Tests.csproj", "{FBCB2C2E-AB30-4367-A259-7B30D4C3398B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eryph.GuestServices.Service.Tests", "test\Eryph.GuestServices.Service.Tests\Eryph.GuestServices.Service.Tests.csproj", "{13D3A1EF-A9E2-47E2-984C-507C37AE6A35}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -185,6 +187,18 @@ Global
 		{FBCB2C2E-AB30-4367-A259-7B30D4C3398B}.Release|x64.Build.0 = Release|Any CPU
 		{FBCB2C2E-AB30-4367-A259-7B30D4C3398B}.Release|x86.ActiveCfg = Release|Any CPU
 		{FBCB2C2E-AB30-4367-A259-7B30D4C3398B}.Release|x86.Build.0 = Release|Any CPU
+		{13D3A1EF-A9E2-47E2-984C-507C37AE6A35}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13D3A1EF-A9E2-47E2-984C-507C37AE6A35}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13D3A1EF-A9E2-47E2-984C-507C37AE6A35}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{13D3A1EF-A9E2-47E2-984C-507C37AE6A35}.Debug|x64.Build.0 = Debug|Any CPU
+		{13D3A1EF-A9E2-47E2-984C-507C37AE6A35}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{13D3A1EF-A9E2-47E2-984C-507C37AE6A35}.Debug|x86.Build.0 = Debug|Any CPU
+		{13D3A1EF-A9E2-47E2-984C-507C37AE6A35}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13D3A1EF-A9E2-47E2-984C-507C37AE6A35}.Release|Any CPU.Build.0 = Release|Any CPU
+		{13D3A1EF-A9E2-47E2-984C-507C37AE6A35}.Release|x64.ActiveCfg = Release|Any CPU
+		{13D3A1EF-A9E2-47E2-984C-507C37AE6A35}.Release|x64.Build.0 = Release|Any CPU
+		{13D3A1EF-A9E2-47E2-984C-507C37AE6A35}.Release|x86.ActiveCfg = Release|Any CPU
+		{13D3A1EF-A9E2-47E2-984C-507C37AE6A35}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -202,6 +216,7 @@ Global
 		{7A67A6EF-DD16-4A4E-9EFB-1B8CDA5D87D2} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{035F7479-0A05-310F-4E11-A4BA13E77FEE} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{FBCB2C2E-AB30-4367-A259-7B30D4C3398B} = {05E9B947-5A63-40BB-880E-DBD388C498CD}
+		{13D3A1EF-A9E2-47E2-984C-507C37AE6A35} = {05E9B947-5A63-40BB-880E-DBD388C498CD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C56A3222-9C44-4134-967D-CEC0E50E55D5}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ While Windows Server 2025 ships with OpenSSH by default, native Hyper-V socket s
 - **SSH-based access**: Standard SSH protocol over Hyper-V transport
 - **File transfer capabilities**: Upload/download files and directories to/from VMs
 - **Pseudo-terminal support**: Interactive shell sessions
+- **Configurable shell**: Override the shell spawned for SSH sessions per VM (e.g. `pwsh.exe` instead of Windows PowerShell)
 - **Public key authentication**: Secure key-based authentication
 - **Easy installation**: Simple installer scripts for both platforms
 
@@ -167,6 +168,28 @@ egs-tool download-directory <VM-ID> <remote-directory> <local-directory> --recur
 egs-tool upload-file <VM-ID> <local-file> <remote-file> --overwrite
 ```
 
+#### 5. Configure the Shell
+
+By default, interactive SSH sessions land in `powershell.exe` on Windows VMs
+and the user's `$SHELL` (or `/bin/bash`) on Linux VMs. The default can be
+overridden per VM:
+
+```powershell
+# Use PowerShell 7 instead of Windows PowerShell
+egs-tool set-shell <VM-ID> --command pwsh.exe
+
+# With arguments (note the '=' — Spectre.Console.Cli treats space-separated
+# '-'-prefixed values as new flags)
+egs-tool set-shell <VM-ID> --command pwsh.exe --arguments="-NoLogo -NoProfile"
+
+# Clear the override and return to the default
+egs-tool set-shell <VM-ID> --reset
+```
+
+The override takes effect on the next SSH session. SSH clients can also
+send the `SHELL` / `SHELL_ARGS` environment variables per-session (e.g.
+`ssh -o "SetEnv=SHELL=pwsh.exe" …`); the per-VM override always wins.
+
 ### Eryph Platform Usage
 
 When used with eryph, the guest services are typically installed via genes:
@@ -256,6 +279,7 @@ The guest services use SSH public key authentication:
 | `upload-directory <VM-ID> <local> <remote>` | Upload directory to VM | VM GUID, local dir, remote dir |
 | `download-file <VM-ID> <remote> <local>` | Download single file from VM | VM GUID, remote file, local file |
 | `download-directory <VM-ID> <remote> <local>` | Download directory from VM | VM GUID, remote dir, local dir |
+| `set-shell <VM-ID>` | Configure the shell spawned for SSH sessions | VM GUID, `--command`/`--arguments` or `--reset` |
 
 **Flags for file/directory commands:**
 - `--overwrite`: Overwrite existing files/directories

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,11 @@ jobs:
     displayName: dotnet test
     inputs:
       command: test
-      projects: '**/test/**/*.csproj'
+      # The test/e2e/ tree is for the Pester-driven flow that needs an eryph
+      # host. CI doesn't have one, so skip it.
+      projects: |
+        **/test/**/*.csproj
+        !**/test/e2e/**/*.csproj
       arguments: '--configuration $(buildConfiguration) --runtime win-x64 --collect "Code coverage" --no-build'
 
   - task: DotNetCoreCLI@2
@@ -124,10 +128,12 @@ jobs:
       command: test
       # Tool.Tests targets net10.0-windows because the Tool depends on
       # HvDataExchange.Host (WMI). It cannot run on Linux; the Windows job
-      # exercises it.
+      # exercises it. The test/e2e/ tree is the Pester-driven flow that
+      # needs an eryph host — not a CI fit.
       projects: |
         **/test/**/*.csproj
         !**/Eryph.GuestServices.Tool.Tests.csproj
+        !**/test/e2e/**/*.csproj
       arguments: '--configuration $(buildConfiguration) --runtime linux-x64 --collect "Code coverage" --no-build'
 
   - task: DotNetCoreCLI@2

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>12</LangVersion>
+    <LangVersion>13</LangVersion>
     <NoWarn>CS1591</NoWarn>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
   </PropertyGroup>

--- a/src/Eryph.GuestServices.Core/Constants.cs
+++ b/src/Eryph.GuestServices.Core/Constants.cs
@@ -24,4 +24,31 @@ public static class Constants
     public static readonly string VersionKey = "eryph:guest-services:version";
 
     public static readonly string ClientAuthKey = "eryph:guest-services:client-public-key";
+
+    /// <summary>
+    /// The KVP key (External pool) that overrides the shell command spawned
+    /// for an interactive SSH session. When unset, the service falls back to
+    /// the SSH-sent <c>SHELL</c> environment variable, then to the platform
+    /// default (<c>powershell.exe</c> on Windows, <c>$SHELL</c> or
+    /// <c>/bin/bash</c> on Linux).
+    /// </summary>
+    public static readonly string ShellKey = "eryph:guest-services:shell";
+
+    /// <summary>
+    /// The KVP key (External pool) that overrides the arguments passed to the
+    /// shell command. Only consulted when <see cref="ShellKey"/> is also set.
+    /// </summary>
+    public static readonly string ShellArgsKey = "eryph:guest-services:shell-args";
+
+    /// <summary>
+    /// The SSH-sent environment variable name that overrides the shell command
+    /// for one session. Lower priority than <see cref="ShellKey"/>.
+    /// </summary>
+    public static readonly string ShellEnvName = "SHELL";
+
+    /// <summary>
+    /// The SSH-sent environment variable name that overrides the shell
+    /// arguments for one session. Lower priority than <see cref="ShellArgsKey"/>.
+    /// </summary>
+    public static readonly string ShellArgsEnvName = "SHELL_ARGS";
 }

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/DefaultShellSelector.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/DefaultShellSelector.cs
@@ -24,8 +24,12 @@ public sealed class DefaultShellSelector : IShellSelector
     /// </summary>
     public static ShellSelection SelectFromEnvOrDefault(ShellOverride sshOverride)
     {
-        if (!string.IsNullOrWhiteSpace(sshOverride.Command))
-            return new ShellSelection(sshOverride.Command, sshOverride.Arguments ?? string.Empty);
+        // Trim defensively — SSH env values come from a client we authenticate
+        // but don't otherwise constrain. A stray trailing space would silently
+        // fail process-start with a path-not-found-style error.
+        var command = sshOverride.Command?.Trim();
+        if (!string.IsNullOrEmpty(command))
+            return new ShellSelection(command, sshOverride.Arguments?.Trim() ?? string.Empty);
 
         return PlatformDefault();
     }

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/DefaultShellSelector.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/DefaultShellSelector.cs
@@ -1,0 +1,55 @@
+using Eryph.GuestServices.Core;
+
+namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions;
+
+/// <summary>
+/// Selector that does not consult Hyper-V KVP state. Used when the Extensions
+/// library is consumed without the guest service (e.g. tests). Honors SSH-sent
+/// <c>SHELL</c>/<c>SHELL_ARGS</c> env vars and falls back to platform defaults.
+/// </summary>
+public sealed class DefaultShellSelector : IShellSelector
+{
+    public static DefaultShellSelector Instance { get; } = new();
+
+    public Task<ShellSelection> SelectAsync(
+        IReadOnlyDictionary<string, string> sessionEnvironment,
+        CancellationToken cancellation)
+    {
+        return Task.FromResult(SelectFromEnvOrDefault(sessionEnvironment));
+    }
+
+    /// <summary>
+    /// Picks a shell from the SSH-sent environment, falling back to the
+    /// platform default. Exposed so service-side selectors can reuse the
+    /// fallback chain after their own KVP lookup misses.
+    /// </summary>
+    public static ShellSelection SelectFromEnvOrDefault(
+        IReadOnlyDictionary<string, string> sessionEnvironment)
+    {
+        if (sessionEnvironment.TryGetValue(Constants.ShellEnvName, out var sshShell)
+            && !string.IsNullOrWhiteSpace(sshShell))
+        {
+            sessionEnvironment.TryGetValue(Constants.ShellArgsEnvName, out var sshArgs);
+            return new ShellSelection(sshShell, sshArgs ?? string.Empty);
+        }
+
+        return PlatformDefault();
+    }
+
+    /// <summary>
+    /// The hardcoded platform default — last resort when no override is set
+    /// anywhere.
+    /// </summary>
+    public static ShellSelection PlatformDefault()
+    {
+        if (OperatingSystem.IsLinux())
+        {
+            var processShell = Environment.GetEnvironmentVariable("SHELL");
+            return new ShellSelection(
+                string.IsNullOrEmpty(processShell) ? "/bin/bash" : processShell,
+                "-i");
+        }
+
+        return new ShellSelection("powershell.exe", "-WindowStyle Hidden");
+    }
+}

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/DefaultShellSelector.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/DefaultShellSelector.cs
@@ -1,37 +1,31 @@
-using Eryph.GuestServices.Core;
-
 namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions;
 
 /// <summary>
 /// Selector that does not consult Hyper-V KVP state. Used when the Extensions
-/// library is consumed without the guest service (e.g. tests). Honors SSH-sent
-/// <c>SHELL</c>/<c>SHELL_ARGS</c> env vars and falls back to platform defaults.
+/// library is consumed without the guest service (e.g. tests). Honors the
+/// SSH-sent <c>SHELL</c>/<c>SHELL_ARGS</c> env vars and falls back to platform
+/// defaults.
 /// </summary>
 public sealed class DefaultShellSelector : IShellSelector
 {
     public static DefaultShellSelector Instance { get; } = new();
 
     public Task<ShellSelection> SelectAsync(
-        IReadOnlyDictionary<string, string> sessionEnvironment,
+        ShellOverride sshOverride,
         CancellationToken cancellation)
     {
-        return Task.FromResult(SelectFromEnvOrDefault(sessionEnvironment));
+        return Task.FromResult(SelectFromEnvOrDefault(sshOverride));
     }
 
     /// <summary>
-    /// Picks a shell from the SSH-sent environment, falling back to the
-    /// platform default. Exposed so service-side selectors can reuse the
-    /// fallback chain after their own KVP lookup misses.
+    /// Picks a shell from the SSH-sent override, falling back to the platform
+    /// default. Exposed so service-side selectors can reuse the fallback chain
+    /// after their own KVP lookup misses.
     /// </summary>
-    public static ShellSelection SelectFromEnvOrDefault(
-        IReadOnlyDictionary<string, string> sessionEnvironment)
+    public static ShellSelection SelectFromEnvOrDefault(ShellOverride sshOverride)
     {
-        if (sessionEnvironment.TryGetValue(Constants.ShellEnvName, out var sshShell)
-            && !string.IsNullOrWhiteSpace(sshShell))
-        {
-            sessionEnvironment.TryGetValue(Constants.ShellArgsEnvName, out var sshArgs);
-            return new ShellSelection(sshShell, sshArgs ?? string.Empty);
-        }
+        if (!string.IsNullOrWhiteSpace(sshOverride.Command))
+            return new ShellSelection(sshOverride.Command, sshOverride.Arguments ?? string.Empty);
 
         return PlatformDefault();
     }

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Eryph.GuestServices.DevTunnels.Ssh.Extensions.csproj
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Eryph.GuestServices.DevTunnels.Ssh.Extensions.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Eryph.GuestServices.Core\Eryph.GuestServices.Core.csproj" />
     <ProjectReference Include="..\Eryph.GuestServices.Pty\Eryph.GuestServices.Pty.csproj" />
   </ItemGroup>
 

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Eryph.GuestServices.DevTunnels.Ssh.Extensions.csproj
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Eryph.GuestServices.DevTunnels.Ssh.Extensions.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DevTunnels.Ssh" Version="3.12.8" />
+    <PackageReference Include="Microsoft.DevTunnels.Ssh" Version="3.12.29" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
@@ -98,6 +98,9 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
         if (Interlocked.Exchange(ref _disposed, 1) == 1)
             return;
 
+        // Cancel before disposing so both copy pumps observe cancellation and stop
+        // instead of lingering until the underlying pipes happen to close.
+        try { _cts.Cancel(); } catch (ObjectDisposedException) { }
         _cts.Dispose();
         _pty?.Dispose();
     }

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
@@ -63,19 +63,18 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
 
     private async Task RunAsync(SshStream stream, IPty pty)
     {
-        // Give the output pump its own cancellation source so we can stop it
-        // before closing the channel without tearing down the rest of the
-        // forwarder.
+        // Both pumps share a cancellation source so we can stop them together
+        // before closing the channel.
         using var pumpCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
         var outputTask = pty.Output!.CopyToAsync(stream, pumpCts.Token);
-        _ = stream.CopyToAsync(pty.Input!, _cts.Token);
+        var inputTask = stream.CopyToAsync(pty.Input!, pumpCts.Token);
 
         var result = await pty.WaitForExitAsync(_cts.Token);
 
-        // Brief natural-drain window for any final bytes the PTY emitted on
+        // Brief natural-drain window so any final bytes the PTY emitted on
         // shell exit (e.g. ConPTY's terminal-reset escape sequence after
-        // `cmd.exe` exits). The PTY master never returns EOF while we hold
-        // its handle, so this can only time out — the timeout is the budget.
+        // `cmd.exe` exits) reach the wire. The PTY master never returns EOF
+        // while we hold its handle, so this can only time out.
         try
         {
             await outputTask.WaitAsync(TimeSpan.FromMilliseconds(500), _cts.Token);
@@ -83,24 +82,18 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
         catch (TimeoutException) { }
         catch (OperationCanceledException) { }
 
-        // Stop the pump and wait for it to actually finish before closing.
-        // Otherwise an in-flight read could deliver bytes *after* the
-        // channel-close message goes out, and the client would log
-        // "data packet referred to nonexistent channel".
+        // Stop BOTH pumps and wait for them before closing. The output pump
+        // is the obvious one. The input pump matters too: when it reads from
+        // the SshStream, the underlying channel calls AdjustWindow, which
+        // fires off an async-void CHANNEL_WINDOW_ADJUST message. Without
+        // stopping it, that adjust can race past our channel close and the
+        // client logs "data packet referred to nonexistent channel".
         await pumpCts.CancelAsync();
         try
         {
-            await outputTask;
+            await Task.WhenAll(outputTask, inputTask);
         }
         catch (Exception) { /* expected on cancellation / pipe disposal */ }
-
-        // Flush any data still sitting in the SshStream's write queue so the
-        // bytes hit the wire before the channel-close message does.
-        try
-        {
-            await stream.FlushAsync(_cts.Token);
-        }
-        catch (Exception) { /* best-effort drain */ }
 
         await stream.Channel.CloseAsync(unchecked((uint)result), _cts.Token);
     }

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
@@ -1,4 +1,3 @@
-using System.Collections.Frozen;
 using Eryph.GuestServices.Core;
 using Eryph.GuestServices.Pty;
 using Microsoft.DevTunnels.Ssh;
@@ -8,53 +7,66 @@ namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions.Forwarders;
 public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
 {
     private readonly IShellSelector _selector = selector ?? DefaultShellSelector.Instance;
-    private readonly Dictionary<string, string> _sessionEnvironment = new(StringComparer.Ordinal);
-    private readonly Lock _envLock = new();
+    private readonly Lock _stateLock = new();
     private readonly CancellationTokenSource _cts = new();
+
+    private string? _shellOverride;
+    private string? _shellArgsOverride;
+    private bool _isRunning;
 
     private IPty? _pty;
     private int _disposed;
-    private int _isRunning;
 
     private uint _width = 80;
     private uint _height = 25;
 
-    public bool IsRunning => Interlocked.CompareExchange(ref _isRunning, 0, 0) == 1;
+    public bool IsRunning
+    {
+        get { lock (_stateLock) { return _isRunning; } }
+    }
 
     /// <summary>
     /// Records an SSH-sent environment variable that may influence shell
-    /// selection. Only the keys this forwarder actually consults are kept;
-    /// arbitrary names are dropped to avoid unbounded growth from a hostile
-    /// client. Calls after <see cref="StartAsync"/> are ignored — by then the
-    /// selector has already snapshotted the dictionary.
+    /// selection. Returns <see langword="true"/> if the value was accepted
+    /// (recognized name, forwarder not yet started). Unknown names and
+    /// late writes are rejected so the SSH-level response can stay honest.
     /// </summary>
-    public void SetEnvironmentVariable(string name, string value)
+    public bool TrySetEnvironmentVariable(string name, string value)
     {
-        if (IsRunning)
-            return;
-        if (name != Constants.ShellEnvName && name != Constants.ShellArgsEnvName)
-            return;
-
-        lock (_envLock)
+        lock (_stateLock)
         {
-            _sessionEnvironment[name] = value;
+            if (_isRunning)
+                return false;
+
+            if (name == Constants.ShellEnvName)
+            {
+                _shellOverride = value;
+                return true;
+            }
+            if (name == Constants.ShellArgsEnvName)
+            {
+                _shellArgsOverride = value;
+                return true;
+            }
+            return false;
         }
     }
 
     public async Task StartAsync(SshStream stream, CancellationToken cancellation)
     {
-        if (Interlocked.Exchange(ref _isRunning, 1) == 1)
-            throw new InvalidOperationException("Pty instance is already running.");
-
-        // Snapshot the env dict while no further writes can land (IsRunning is
-        // now true, SetEnvironmentVariable early-returns) and hand the
-        // selector an immutable view.
-        FrozenDictionary<string, string> envSnapshot;
-        lock (_envLock)
+        // Atomically flip to running and snapshot the override under one lock
+        // so a concurrent TrySetEnvironmentVariable cannot land between the
+        // flag flip and the snapshot.
+        ShellOverride snapshot;
+        lock (_stateLock)
         {
-            envSnapshot = _sessionEnvironment.ToFrozenDictionary(StringComparer.Ordinal);
+            if (_isRunning)
+                throw new InvalidOperationException("Pty instance is already running.");
+            _isRunning = true;
+            snapshot = new ShellOverride(_shellOverride, _shellArgsOverride);
         }
-        var selection = await _selector.SelectAsync(envSnapshot, cancellation);
+
+        var selection = await _selector.SelectAsync(snapshot, cancellation);
 
         _pty = PtyProvider.CreatePty();
         await _pty.StartAsync(_width, _height, selection.Command, selection.Arguments);

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
@@ -95,6 +95,12 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
         }
         catch (Exception) { /* expected on cancellation / pipe disposal */ }
 
+        // The last input-pump read may have triggered an async-void
+        // TrySendAdjustWindowMessage in SshChannel that we cannot await.
+        // Yield briefly so that fire-and-forget SendMessageAsync grabs the
+        // session's outgoing semaphore before our close does.
+        await Task.Delay(50, _cts.Token);
+
         await stream.Channel.CloseAsync(unchecked((uint)result), _cts.Token);
     }
 

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
@@ -63,10 +63,19 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
 
     private async Task RunAsync(SshStream stream, IPty pty)
     {
-        _ = pty.Output!.CopyToAsync(stream, _cts.Token);
+        // ConPTY emits final reset sequences asynchronously after the child exits.
+        // Drain them before CHANNEL_CLOSE — otherwise they ship as CHANNEL_DATA
+        // after close and strict SSH clients (OpenSSH) disconnect.
+        using var outputDrainCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
+        var outputTask = pty.Output!.CopyToAsync(stream, outputDrainCts.Token);
         _ = stream.CopyToAsync(pty.Input!, _cts.Token);
 
         var result = await pty.WaitForExitAsync(_cts.Token);
+
+        outputDrainCts.CancelAfter(TimeSpan.FromSeconds(1));
+        try { await outputTask; }
+        catch (OperationCanceledException) { }
+
         await stream.Channel.CloseAsync(unchecked((uint)result), _cts.Token);
     }
 

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
@@ -63,23 +63,36 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
 
     private async Task RunAsync(SshStream stream, IPty pty)
     {
-        var outputTask = pty.Output!.CopyToAsync(stream, _cts.Token);
+        // Give the output pump its own cancellation source so we can stop it
+        // before closing the channel without tearing down the rest of the
+        // forwarder.
+        using var pumpCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
+        var outputTask = pty.Output!.CopyToAsync(stream, pumpCts.Token);
         _ = stream.CopyToAsync(pty.Input!, _cts.Token);
 
         var result = await pty.WaitForExitAsync(_cts.Token);
 
-        // Give the output pump a brief window to flush any final bytes the PTY
-        // emitted on shell exit (e.g. ConPTY's terminal-reset escape sequence
-        // after `cmd.exe` exits). Without this, the channel-close message can
-        // overtake those bytes on the wire and the client logs
-        // "data packet referred to nonexistent channel". The PTY master never
-        // returns EOF while we hold its handle, so the drain has to be bounded.
+        // Brief natural-drain window for any final bytes the PTY emitted on
+        // shell exit (e.g. ConPTY's terminal-reset escape sequence after
+        // `cmd.exe` exits). The PTY master never returns EOF while we hold
+        // its handle, so this can only time out — the timeout is the budget.
         try
         {
             await outputTask.WaitAsync(TimeSpan.FromMilliseconds(500), _cts.Token);
         }
-        catch (TimeoutException) { /* bounded drain — proceed to close */ }
-        catch (OperationCanceledException) { /* shutting down */ }
+        catch (TimeoutException) { }
+        catch (OperationCanceledException) { }
+
+        // Stop the pump and wait for it to actually finish before closing.
+        // Otherwise an in-flight read could deliver bytes *after* the
+        // channel-close message goes out, and the client would log
+        // "data packet referred to nonexistent channel".
+        await pumpCts.CancelAsync();
+        try
+        {
+            await outputTask;
+        }
+        catch (Exception) { /* expected on cancellation / pipe disposal */ }
 
         await stream.Channel.CloseAsync(unchecked((uint)result), _cts.Token);
     }

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
@@ -9,7 +9,7 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
 {
     private readonly IShellSelector _selector = selector ?? DefaultShellSelector.Instance;
     private readonly Dictionary<string, string> _sessionEnvironment = new(StringComparer.Ordinal);
-    private readonly object _envLock = new();
+    private readonly Lock _envLock = new();
     private readonly CancellationTokenSource _cts = new();
 
     private IPty? _pty;

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
@@ -63,10 +63,24 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
 
     private async Task RunAsync(SshStream stream, IPty pty)
     {
-        _ = pty.Output!.CopyToAsync(stream, _cts.Token);
+        var outputTask = pty.Output!.CopyToAsync(stream, _cts.Token);
         _ = stream.CopyToAsync(pty.Input!, _cts.Token);
 
         var result = await pty.WaitForExitAsync(_cts.Token);
+
+        // Give the output pump a brief window to flush any final bytes the PTY
+        // emitted on shell exit (e.g. ConPTY's terminal-reset escape sequence
+        // after `cmd.exe` exits). Without this, the channel-close message can
+        // overtake those bytes on the wire and the client logs
+        // "data packet referred to nonexistent channel". The PTY master never
+        // returns EOF while we hold its handle, so the drain has to be bounded.
+        try
+        {
+            await outputTask.WaitAsync(TimeSpan.FromMilliseconds(500), _cts.Token);
+        }
+        catch (TimeoutException) { /* bounded drain — proceed to close */ }
+        catch (OperationCanceledException) { /* shutting down */ }
+
         await stream.Channel.CloseAsync(unchecked((uint)result), _cts.Token);
     }
 

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
@@ -63,44 +63,10 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
 
     private async Task RunAsync(SshStream stream, IPty pty)
     {
-        // Both pumps share a cancellation source so we can stop them together
-        // before closing the channel.
-        using var pumpCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
-        var outputTask = pty.Output!.CopyToAsync(stream, pumpCts.Token);
-        var inputTask = stream.CopyToAsync(pty.Input!, pumpCts.Token);
+        _ = pty.Output!.CopyToAsync(stream, _cts.Token);
+        _ = stream.CopyToAsync(pty.Input!, _cts.Token);
 
         var result = await pty.WaitForExitAsync(_cts.Token);
-
-        // Brief natural-drain window so any final bytes the PTY emitted on
-        // shell exit (e.g. ConPTY's terminal-reset escape sequence after
-        // `cmd.exe` exits) reach the wire. The PTY master never returns EOF
-        // while we hold its handle, so this can only time out.
-        try
-        {
-            await outputTask.WaitAsync(TimeSpan.FromMilliseconds(500), _cts.Token);
-        }
-        catch (TimeoutException) { }
-        catch (OperationCanceledException) { }
-
-        // Stop BOTH pumps and wait for them before closing. The output pump
-        // is the obvious one. The input pump matters too: when it reads from
-        // the SshStream, the underlying channel calls AdjustWindow, which
-        // fires off an async-void CHANNEL_WINDOW_ADJUST message. Without
-        // stopping it, that adjust can race past our channel close and the
-        // client logs "data packet referred to nonexistent channel".
-        await pumpCts.CancelAsync();
-        try
-        {
-            await Task.WhenAll(outputTask, inputTask);
-        }
-        catch (Exception) { /* expected on cancellation / pipe disposal */ }
-
-        // The last input-pump read may have triggered an async-void
-        // TrySendAdjustWindowMessage in SshChannel that we cannot await.
-        // Yield briefly so that fire-and-forget SendMessageAsync grabs the
-        // session's outgoing semaphore before our close does.
-        await Task.Delay(50, _cts.Token);
-
         await stream.Channel.CloseAsync(unchecked((uint)result), _cts.Token);
     }
 

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
@@ -1,13 +1,15 @@
-﻿using Eryph.GuestServices.Pty;
+using Eryph.GuestServices.Pty;
 using Microsoft.DevTunnels.Ssh;
 
 namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions.Forwarders;
 
-public sealed class PtyForwarder : IDisposable
+public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
 {
-    private IPty? _pty;
+    private readonly IShellSelector _selector = selector ?? DefaultShellSelector.Instance;
+    private readonly Dictionary<string, string> _sessionEnvironment = new(StringComparer.Ordinal);
     private readonly CancellationTokenSource _cts = new();
-    
+
+    private IPty? _pty;
     private int _disposed;
     private int _isRunning;
 
@@ -16,28 +18,31 @@ public sealed class PtyForwarder : IDisposable
 
     public bool IsRunning => Interlocked.CompareExchange(ref _isRunning, 0, 0) == 1;
 
+    /// <summary>
+    /// Records an SSH-sent environment variable that may influence shell
+    /// selection. Call before <see cref="StartAsync"/>; values added later are
+    /// ignored.
+    /// </summary>
+    public void SetEnvironmentVariable(string name, string value)
+    {
+        _sessionEnvironment[name] = value;
+    }
+
     public async Task StartAsync(SshStream stream, CancellationToken cancellation)
     {
         if (Interlocked.Exchange(ref _isRunning, 1) == 1)
             throw new InvalidOperationException("Pty instance is already running.");
 
+        var selection = await _selector.SelectAsync(_sessionEnvironment, cancellation);
+
         _pty = PtyProvider.CreatePty();
-        var command = "powershell.exe";
-        var arguments = "-WindowStyle Hidden";
-        if (OperatingSystem.IsLinux())
-        {
-            var shell = Environment.GetEnvironmentVariable("SHELL");
-            command = string.IsNullOrEmpty(shell) ? "/bin/bash" : shell;
-            arguments = "-i";
-        }
-        
-        await _pty.StartAsync(_width, _height, command, arguments);
+        await _pty.StartAsync(_width, _height, selection.Command, selection.Arguments);
         _ = RunAsync(stream, _pty);
     }
 
     private async Task RunAsync(SshStream stream, IPty pty)
     {
-        _ = pty.Output!.CopyToAsync(stream, _cts.Token); 
+        _ = pty.Output!.CopyToAsync(stream, _cts.Token);
         _ = stream.CopyToAsync(pty.Input!, _cts.Token);
 
         var result = await pty.WaitForExitAsync(_cts.Token);
@@ -51,7 +56,7 @@ public sealed class PtyForwarder : IDisposable
     {
         if (Interlocked.CompareExchange(ref _disposed, 0, 0) == 1)
             return;
-        
+
         _width = width;
         _height = height;
         if (_pty is not null)

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
@@ -94,6 +94,14 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
         }
         catch (Exception) { /* expected on cancellation / pipe disposal */ }
 
+        // Flush any data still sitting in the SshStream's write queue so the
+        // bytes hit the wire before the channel-close message does.
+        try
+        {
+            await stream.FlushAsync(_cts.Token);
+        }
+        catch (Exception) { /* best-effort drain */ }
+
         await stream.Channel.CloseAsync(unchecked((uint)result), _cts.Token);
     }
 

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
@@ -1,3 +1,5 @@
+using System.Collections.Frozen;
+using Eryph.GuestServices.Core;
 using Eryph.GuestServices.Pty;
 using Microsoft.DevTunnels.Ssh;
 
@@ -7,6 +9,7 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
 {
     private readonly IShellSelector _selector = selector ?? DefaultShellSelector.Instance;
     private readonly Dictionary<string, string> _sessionEnvironment = new(StringComparer.Ordinal);
+    private readonly object _envLock = new();
     private readonly CancellationTokenSource _cts = new();
 
     private IPty? _pty;
@@ -20,12 +23,22 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
 
     /// <summary>
     /// Records an SSH-sent environment variable that may influence shell
-    /// selection. Call before <see cref="StartAsync"/>; values added later are
-    /// ignored.
+    /// selection. Only the keys this forwarder actually consults are kept;
+    /// arbitrary names are dropped to avoid unbounded growth from a hostile
+    /// client. Calls after <see cref="StartAsync"/> are ignored — by then the
+    /// selector has already snapshotted the dictionary.
     /// </summary>
     public void SetEnvironmentVariable(string name, string value)
     {
-        _sessionEnvironment[name] = value;
+        if (IsRunning)
+            return;
+        if (name != Constants.ShellEnvName && name != Constants.ShellArgsEnvName)
+            return;
+
+        lock (_envLock)
+        {
+            _sessionEnvironment[name] = value;
+        }
     }
 
     public async Task StartAsync(SshStream stream, CancellationToken cancellation)
@@ -33,7 +46,15 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
         if (Interlocked.Exchange(ref _isRunning, 1) == 1)
             throw new InvalidOperationException("Pty instance is already running.");
 
-        var selection = await _selector.SelectAsync(_sessionEnvironment, cancellation);
+        // Snapshot the env dict while no further writes can land (IsRunning is
+        // now true, SetEnvironmentVariable early-returns) and hand the
+        // selector an immutable view.
+        FrozenDictionary<string, string> envSnapshot;
+        lock (_envLock)
+        {
+            envSnapshot = _sessionEnvironment.ToFrozenDictionary(StringComparer.Ordinal);
+        }
+        var selection = await _selector.SelectAsync(envSnapshot, cancellation);
 
         _pty = PtyProvider.CreatePty();
         await _pty.StartAsync(_width, _height, selection.Command, selection.Arguments);

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/IShellSelector.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/IShellSelector.cs
@@ -18,8 +18,9 @@ public interface IShellSelector
 /// <summary>
 /// The command and arguments to spawn as the interactive shell.
 /// </summary>
-/// <param name="Command">Executable name or absolute path. Bare names are
-/// resolved via <c>PATH</c>.</param>
+/// <param name="Command">On Windows, an executable name or an absolute path —
+/// bare names are resolved via <c>PATH</c> by <c>CreateProcess</c>. On Linux,
+/// must be an absolute path; bare names will fail at PTY start.</param>
 /// <param name="Arguments">Argument string passed to the shell, may be empty.</param>
 public sealed record ShellSelection(string Command, string Arguments);
 

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/IShellSelector.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/IShellSelector.cs
@@ -1,0 +1,24 @@
+namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions;
+
+/// <summary>
+/// Resolves the command + arguments to spawn for an interactive SSH session.
+/// </summary>
+public interface IShellSelector
+{
+    /// <summary>
+    /// Selects the shell for one session. The <paramref name="sessionEnvironment"/>
+    /// contains environment variables sent by the SSH client via <c>env</c>
+    /// channel requests on the same channel.
+    /// </summary>
+    Task<ShellSelection> SelectAsync(
+        IReadOnlyDictionary<string, string> sessionEnvironment,
+        CancellationToken cancellation);
+}
+
+/// <summary>
+/// The command and arguments to spawn as the interactive shell.
+/// </summary>
+/// <param name="Command">Executable name or absolute path. Bare names are
+/// resolved via <c>PATH</c>.</param>
+/// <param name="Arguments">Argument string passed to the shell, may be empty.</param>
+public sealed record ShellSelection(string Command, string Arguments);

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/IShellSelector.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/IShellSelector.cs
@@ -6,12 +6,12 @@ namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions;
 public interface IShellSelector
 {
     /// <summary>
-    /// Selects the shell for one session. The <paramref name="sessionEnvironment"/>
-    /// contains environment variables sent by the SSH client via <c>env</c>
-    /// channel requests on the same channel.
+    /// Selects the shell for one session. The <paramref name="sshOverride"/>
+    /// carries any per-session preferences that were sent by the client via
+    /// SSH <c>env</c> channel requests.
     /// </summary>
     Task<ShellSelection> SelectAsync(
-        IReadOnlyDictionary<string, string> sessionEnvironment,
+        ShellOverride sshOverride,
         CancellationToken cancellation);
 }
 
@@ -22,3 +22,14 @@ public interface IShellSelector
 /// resolved via <c>PATH</c>.</param>
 /// <param name="Arguments">Argument string passed to the shell, may be empty.</param>
 public sealed record ShellSelection(string Command, string Arguments);
+
+/// <summary>
+/// Per-session shell preference conveyed by the SSH client via <c>env</c>
+/// channel requests. Either field may be <see langword="null"/> if the client
+/// did not set the corresponding env var. A blank <see cref="Command"/> means
+/// "no preference" and the selector should fall back.
+/// </summary>
+public readonly record struct ShellOverride(string? Command, string? Arguments)
+{
+    public static ShellOverride Empty => default;
+}

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Messages/EnvironmentVariableRequestMessage.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Messages/EnvironmentVariableRequestMessage.cs
@@ -22,14 +22,14 @@ public class EnvironmentVariableRequestMessage : ChannelRequestMessage
     protected override void OnRead(ref SshDataReader reader)
     {
         base.OnRead(ref reader);
-        Name = reader.ReadString(Encoding.ASCII);
+        Name = reader.ReadString(Encoding.UTF8);
         Value = reader.ReadString(Encoding.UTF8);
     }
 
     protected override void OnWrite(ref SshDataWriter writer)
     {
         base.OnWrite(ref writer);
-        writer.Write(Name, Encoding.ASCII);
+        writer.Write(Name, Encoding.UTF8);
         writer.Write(Value, Encoding.UTF8);
     }
 }

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Messages/EnvironmentVariableRequestMessage.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Messages/EnvironmentVariableRequestMessage.cs
@@ -1,0 +1,35 @@
+using System.Text;
+using Microsoft.DevTunnels.Ssh.IO;
+using Microsoft.DevTunnels.Ssh.Messages;
+
+namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions.Messages;
+
+/// <summary>
+/// Channel request that conveys a single environment variable from the
+/// SSH client to the server. See RFC 4254 §6.4.
+/// </summary>
+public class EnvironmentVariableRequestMessage : ChannelRequestMessage
+{
+    public EnvironmentVariableRequestMessage()
+    {
+        RequestType = "env";
+    }
+
+    public string Name { get; set; } = "";
+
+    public string Value { get; set; } = "";
+
+    protected override void OnRead(ref SshDataReader reader)
+    {
+        base.OnRead(ref reader);
+        Name = reader.ReadString(Encoding.ASCII);
+        Value = reader.ReadString(Encoding.UTF8);
+    }
+
+    protected override void OnWrite(ref SshDataWriter writer)
+    {
+        base.OnWrite(ref writer);
+        writer.Write(Name, Encoding.ASCII);
+        writer.Write(Value, Encoding.UTF8);
+    }
+}

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Services/ShellService.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Services/ShellService.cs
@@ -61,11 +61,10 @@ public class ShellService : SshService
         ShellRequestMessage requestMessage,
         CancellationToken cancellation)
     {
-        if (!_instances.TryGetValue(channel.ChannelId, out var pty))
-        {
-            request.ResponseTask = Task.FromResult<SshMessage>(new ChannelFailureMessage());
-            return Task.CompletedTask;
-        }
+        // RFC 4254 §6.5 allows a `shell` request without a prior `pty-req` or
+        // `env`. Lazily create the forwarder so a bare shell request still
+        // works; the PTY backend allocates a default-sized pseudo-console.
+        var pty = GetOrAddForwarder(channel);
 
         if (pty.IsRunning)
         {

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Services/ShellService.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Services/ShellService.cs
@@ -131,18 +131,15 @@ public class ShellService : SshService
         CancellationToken cancellation)
     {
         // The env request can arrive before pty-req, so create the forwarder
-        // lazily on first env. Values set after StartAsync are ignored — the
-        // forwarder snapshots the environment at shell selection time, so we
-        // also fail the request to avoid telling the client we honored it.
+        // lazily on first env. The forwarder reports back whether it actually
+        // stored the value (recognized name + forwarder not yet started); we
+        // mirror that into the SSH channel response so clients don't think an
+        // unhonored env var was applied.
         var pty = GetOrAddForwarder(channel);
-        if (pty.IsRunning)
-        {
-            request.ResponseTask = Task.FromResult<SshMessage>(new ChannelFailureMessage());
-            return Task.CompletedTask;
-        }
+        var accepted = pty.TrySetEnvironmentVariable(requestMessage.Name, requestMessage.Value);
 
-        pty.SetEnvironmentVariable(requestMessage.Name, requestMessage.Value);
-        request.ResponseTask = Task.FromResult<SshMessage>(new ChannelSuccessMessage());
+        request.ResponseTask = Task.FromResult<SshMessage>(
+            accepted ? new ChannelSuccessMessage() : new ChannelFailureMessage());
         return Task.CompletedTask;
     }
 

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Services/ShellService.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Services/ShellService.cs
@@ -16,7 +16,7 @@ namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions.Services;
 public class ShellService : SshService
 {
     private readonly IShellSelector? _shellSelector;
-    private readonly ConcurrentDictionary<uint, PtyForwarder> _instances = new();
+    private readonly ConcurrentDictionary<uint, Lazy<PtyForwarder>> _instances = new();
 
     // Microsoft.DevTunnels.Ssh activation will pick the 2-arg ctor when a
     // config object is present in SshSessionConfiguration.Services.
@@ -108,12 +108,13 @@ public class ShellService : SshService
         WindowChangeRequestMessage requestMessage,
         CancellationToken cancellation)
     {
-        if (!_instances.TryGetValue(channel.ChannelId, out var pty))
+        if (!_instances.TryGetValue(channel.ChannelId, out var lazyPty))
         {
             request.ResponseTask = Task.FromResult<SshMessage>(new ChannelFailureMessage());
             return Task.CompletedTask;
         }
 
+        var pty = lazyPty.Value;
         request.ResponseTask = Task.FromResult<SshMessage>(new ChannelSuccessMessage());
         request.ResponseContinuation = async (_) =>
         {
@@ -131,17 +132,27 @@ public class ShellService : SshService
     {
         // The env request can arrive before pty-req, so create the forwarder
         // lazily on first env. Values set after StartAsync are ignored — the
-        // forwarder snapshots the environment at shell selection time.
+        // forwarder snapshots the environment at shell selection time, so we
+        // also fail the request to avoid telling the client we honored it.
         var pty = GetOrAddForwarder(channel);
-        pty.SetEnvironmentVariable(requestMessage.Name, requestMessage.Value);
+        if (pty.IsRunning)
+        {
+            request.ResponseTask = Task.FromResult<SshMessage>(new ChannelFailureMessage());
+            return Task.CompletedTask;
+        }
 
+        pty.SetEnvironmentVariable(requestMessage.Name, requestMessage.Value);
         request.ResponseTask = Task.FromResult<SshMessage>(new ChannelSuccessMessage());
         return Task.CompletedTask;
     }
 
     private PtyForwarder GetOrAddForwarder(SshChannel channel)
     {
-        return _instances.GetOrAdd(channel.ChannelId, id =>
+        // Lazy<T> with default (ExecutionAndPublication) mode guarantees the
+        // factory runs at most once even if GetOrAdd's outer factory races —
+        // otherwise we could end up with multiple PtyForwarders and duplicate
+        // channel.Closed subscriptions.
+        var lazy = _instances.GetOrAdd(channel.ChannelId, id => new Lazy<PtyForwarder>(() =>
         {
             var forwarder = new PtyForwarder(_shellSelector);
             channel.Closed += (_, _) =>
@@ -150,14 +161,16 @@ public class ShellService : SshService
                 forwarder.Dispose();
             };
             return forwarder;
-        });
+        }));
+        return lazy.Value;
     }
 
     protected override void Dispose(bool disposing)
     {
-        foreach (var instance in _instances.Values.ToArray())
+        foreach (var lazy in _instances.Values.ToArray())
         {
-            instance.Dispose();
+            if (lazy.IsValueCreated)
+                lazy.Value.Dispose();
         }
 
         base.Dispose(disposing);

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Services/ShellService.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Services/ShellService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using Eryph.GuestServices.DevTunnels.Ssh.Extensions.Forwarders;
 using Eryph.GuestServices.DevTunnels.Ssh.Extensions.Messages;
 using Eryph.GuestServices.Pty;
@@ -12,9 +12,20 @@ namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions.Services;
 [ServiceActivation(ChannelRequest = ChannelRequestTypes.Shell)]
 [ServiceActivation(ChannelRequest = ChannelRequestTypes.Terminal)]
 [ServiceActivation(ChannelRequest = "window-change")]
-public class ShellService(SshSession session) : SshService(session)
+[ServiceActivation(ChannelRequest = "env")]
+public class ShellService : SshService
 {
+    private readonly IShellSelector? _shellSelector;
     private readonly ConcurrentDictionary<uint, PtyForwarder> _instances = new();
+
+    // Microsoft.DevTunnels.Ssh activation will pick the 2-arg ctor when a
+    // config object is present in SshSessionConfiguration.Services.
+    public ShellService(SshSession session) : this(session, null) { }
+
+    public ShellService(SshSession session, IShellSelector? shellSelector) : base(session)
+    {
+        _shellSelector = shellSelector;
+    }
 
     protected override Task OnChannelRequestAsync(
         SshChannel channel,
@@ -34,6 +45,10 @@ public class ShellService(SshSession session) : SshService(session)
             case "window-change":
                 var windowChangeMessage = request.Request.ConvertTo<WindowChangeRequestMessage>();
                 return OnWindowChangeRequestAsync(channel, request, windowChangeMessage, cancellation);
+
+            case "env":
+                var envMessage = request.Request.ConvertTo<EnvironmentVariableRequestMessage>();
+                return OnEnvironmentRequestAsync(channel, request, envMessage, cancellation);
         }
 
         request.ResponseTask = Task.FromResult<SshMessage>(new ChannelFailureMessage());
@@ -82,20 +97,8 @@ public class ShellService(SshSession session) : SshService(session)
         TerminalRequestMessage requestMessage,
         CancellationToken cancellation)
     {
-        var pty = new PtyForwarder();
-        if (!_instances.TryAdd(channel.ChannelId, pty))
-        {
-            pty.Dispose();
-            request.ResponseTask = Task.FromResult<SshMessage>(new ChannelFailureMessage());
-            return;
-        }
+        var pty = GetOrAddForwarder(channel);
 
-        channel.Closed += (_, _ ) => 
-        {
-            _instances.TryRemove(channel.ChannelId, out _);
-            pty.Dispose();
-        };
-        
         await pty.ResizeAsync(requestMessage.Columns, requestMessage.Rows, request.Cancellation);
         request.ResponseTask = Task.FromResult<SshMessage>(new ChannelSuccessMessage());
     }
@@ -119,6 +122,36 @@ public class ShellService(SshSession session) : SshService(session)
         };
 
         return Task.CompletedTask;
+    }
+
+    private Task OnEnvironmentRequestAsync(
+        SshChannel channel,
+        SshRequestEventArgs<ChannelRequestMessage> request,
+        EnvironmentVariableRequestMessage requestMessage,
+        CancellationToken cancellation)
+    {
+        // The env request can arrive before pty-req, so create the forwarder
+        // lazily on first env. Values set after StartAsync are ignored — the
+        // forwarder snapshots the environment at shell selection time.
+        var pty = GetOrAddForwarder(channel);
+        pty.SetEnvironmentVariable(requestMessage.Name, requestMessage.Value);
+
+        request.ResponseTask = Task.FromResult<SshMessage>(new ChannelSuccessMessage());
+        return Task.CompletedTask;
+    }
+
+    private PtyForwarder GetOrAddForwarder(SshChannel channel)
+    {
+        return _instances.GetOrAdd(channel.ChannelId, id =>
+        {
+            var forwarder = new PtyForwarder(_shellSelector);
+            channel.Closed += (_, _) =>
+            {
+                _instances.TryRemove(id, out _);
+                forwarder.Dispose();
+            };
+            return forwarder;
+        });
     }
 
     protected override void Dispose(bool disposing)

--- a/src/Eryph.GuestServices.HvDataExchange.Guest/Eryph.GuestServices.HvDataExchange.Guest.csproj
+++ b/src/Eryph.GuestServices.HvDataExchange.Guest/Eryph.GuestServices.HvDataExchange.Guest.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>13</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Eryph.GuestServices.Service/Eryph.GuestServices.Service.csproj
+++ b/src/Eryph.GuestServices.Service/Eryph.GuestServices.Service.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DevTunnels.Ssh.Keys" Version="3.12.8" />
+    <PackageReference Include="Microsoft.DevTunnels.Ssh.Keys" Version="3.12.29" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.7" />

--- a/src/Eryph.GuestServices.Service/Eryph.GuestServices.Service.csproj
+++ b/src/Eryph.GuestServices.Service/Eryph.GuestServices.Service.csproj
@@ -18,10 +18,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DevTunnels.Ssh.Keys" Version="3.12.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Eryph.GuestServices.Service/Eryph.GuestServices.Service.csproj
+++ b/src/Eryph.GuestServices.Service/Eryph.GuestServices.Service.csproj
@@ -31,4 +31,8 @@
     <ProjectReference Include="..\Eryph.GuestServices.Sockets\Eryph.GuestServices.Sockets.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Eryph.GuestServices.Service.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Eryph.GuestServices.Service/Program.cs
+++ b/src/Eryph.GuestServices.Service/Program.cs
@@ -8,6 +8,24 @@ using Microsoft.Extensions.Logging;
 
 Trace.Listeners.Add(new ConsoleTraceListener());
 
+// TEMPORARY: capture every outgoing/incoming SSH message for the cmd.exe
+// post-close-data investigation. Writes to C:\egs-staging\ssh-trace.log.
+var sshTraceFile = OperatingSystem.IsWindows()
+    ? @"C:\egs-staging\ssh-trace.log"
+    : "/tmp/ssh-trace.log";
+try
+{
+    var dir = Path.GetDirectoryName(sshTraceFile);
+    if (dir is not null) Directory.CreateDirectory(dir);
+    var listener = new TextWriterTraceListener(sshTraceFile, "ssh") { TraceOutputOptions = TraceOptions.DateTime };
+    Trace.AutoFlush = true;
+    Trace.Listeners.Add(listener);
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"failed to attach ssh trace listener: {ex.Message}");
+}
+
 var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings()
 {
     ContentRootPath = AppContext.BaseDirectory

--- a/src/Eryph.GuestServices.Service/Program.cs
+++ b/src/Eryph.GuestServices.Service/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using Eryph.GuestServices.DevTunnels.Ssh.Extensions;
 using Eryph.GuestServices.HvDataExchange.Guest;
 using Eryph.GuestServices.Service.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,6 +16,7 @@ builder.Services.AddLogging();
 builder.Services.AddHostedService<SshServerService>();
 builder.Services.AddSingleton<IHostKeyGenerator, HostKeyGenerator>();
 builder.Services.AddSingleton<IClientKeyProvider, ClientKeyProvider>();
+builder.Services.AddSingleton<IShellSelector, KvpShellSelector>();
 
 if (OperatingSystem.IsWindows())
 {

--- a/src/Eryph.GuestServices.Service/Program.cs
+++ b/src/Eryph.GuestServices.Service/Program.cs
@@ -8,24 +8,6 @@ using Microsoft.Extensions.Logging;
 
 Trace.Listeners.Add(new ConsoleTraceListener());
 
-// TEMPORARY: capture every outgoing/incoming SSH message for the cmd.exe
-// post-close-data investigation. Writes to C:\egs-staging\ssh-trace.log.
-var sshTraceFile = OperatingSystem.IsWindows()
-    ? @"C:\egs-staging\ssh-trace.log"
-    : "/tmp/ssh-trace.log";
-try
-{
-    var dir = Path.GetDirectoryName(sshTraceFile);
-    if (dir is not null) Directory.CreateDirectory(dir);
-    var listener = new TextWriterTraceListener(sshTraceFile, "ssh") { TraceOutputOptions = TraceOptions.DateTime };
-    Trace.AutoFlush = true;
-    Trace.Listeners.Add(listener);
-}
-catch (Exception ex)
-{
-    Console.Error.WriteLine($"failed to attach ssh trace listener: {ex.Message}");
-}
-
 var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings()
 {
     ContentRootPath = AppContext.BaseDirectory

--- a/src/Eryph.GuestServices.Service/Services/KvpShellSelector.cs
+++ b/src/Eryph.GuestServices.Service/Services/KvpShellSelector.cs
@@ -13,7 +13,7 @@ internal sealed class KvpShellSelector(
     ILogger<KvpShellSelector> logger) : IShellSelector
 {
     public async Task<ShellSelection> SelectAsync(
-        IReadOnlyDictionary<string, string> sessionEnvironment,
+        ShellOverride sshOverride,
         CancellationToken cancellation)
     {
         try
@@ -34,7 +34,7 @@ internal sealed class KvpShellSelector(
             logger.LogWarning(ex, "Failed to read shell configuration from Hyper-V data exchange.");
         }
 
-        var fallback = DefaultShellSelector.SelectFromEnvOrDefault(sessionEnvironment);
+        var fallback = DefaultShellSelector.SelectFromEnvOrDefault(sshOverride);
         logger.LogDebug("Using shell from env/default: {Command}", fallback.Command);
         return fallback;
     }

--- a/src/Eryph.GuestServices.Service/Services/KvpShellSelector.cs
+++ b/src/Eryph.GuestServices.Service/Services/KvpShellSelector.cs
@@ -1,0 +1,41 @@
+using Eryph.GuestServices.Core;
+using Eryph.GuestServices.DevTunnels.Ssh.Extensions;
+using Eryph.GuestServices.HvDataExchange.Guest;
+using Microsoft.Extensions.Logging;
+
+namespace Eryph.GuestServices.Service.Services;
+
+/// <summary>
+/// Resolves the shell with priority KVP &gt; SSH-sent env &gt; platform default.
+/// </summary>
+internal sealed class KvpShellSelector(
+    IGuestDataExchange dataExchange,
+    ILogger<KvpShellSelector> logger) : IShellSelector
+{
+    public async Task<ShellSelection> SelectAsync(
+        IReadOnlyDictionary<string, string> sessionEnvironment,
+        CancellationToken cancellation)
+    {
+        try
+        {
+            var external = await dataExchange.GetExternalDataAsync();
+            if (external.TryGetValue(Constants.ShellKey, out var kvpShell)
+                && !string.IsNullOrWhiteSpace(kvpShell))
+            {
+                external.TryGetValue(Constants.ShellArgsKey, out var kvpArgs);
+                logger.LogDebug("Using shell from KVP: {Command}", kvpShell);
+                return new ShellSelection(kvpShell, kvpArgs ?? string.Empty);
+            }
+        }
+        catch (Exception ex)
+        {
+            // KVP read failures must not block shell startup. Fall through to
+            // the env/default chain.
+            logger.LogWarning(ex, "Failed to read shell configuration from Hyper-V data exchange.");
+        }
+
+        var fallback = DefaultShellSelector.SelectFromEnvOrDefault(sessionEnvironment);
+        logger.LogDebug("Using shell from env/default: {Command}", fallback.Command);
+        return fallback;
+    }
+}

--- a/src/Eryph.GuestServices.Service/Services/KvpShellSelector.cs
+++ b/src/Eryph.GuestServices.Service/Services/KvpShellSelector.cs
@@ -19,12 +19,17 @@ internal sealed class KvpShellSelector(
         try
         {
             var external = await dataExchange.GetExternalDataAsync();
-            if (external.TryGetValue(Constants.ShellKey, out var kvpShell)
-                && !string.IsNullOrWhiteSpace(kvpShell))
+            if (external.TryGetValue(Constants.ShellKey, out var kvpShell))
             {
-                external.TryGetValue(Constants.ShellArgsKey, out var kvpArgs);
-                logger.LogDebug("Using shell from KVP: {Command}", kvpShell);
-                return new ShellSelection(kvpShell, kvpArgs ?? string.Empty);
+                // Trim — KVP can be written by anything on the host side, not
+                // just egs-tool, so we can't trust the value to be clean.
+                var command = kvpShell?.Trim();
+                if (!string.IsNullOrEmpty(command))
+                {
+                    external.TryGetValue(Constants.ShellArgsKey, out var kvpArgs);
+                    logger.LogDebug("Using shell from KVP: {Command}", command);
+                    return new ShellSelection(command, kvpArgs?.Trim() ?? string.Empty);
+                }
             }
         }
         catch (Exception ex)

--- a/src/Eryph.GuestServices.Service/Services/SshServerService.cs
+++ b/src/Eryph.GuestServices.Service/Services/SshServerService.cs
@@ -50,7 +50,8 @@ internal sealed class SshServerService(
         config.Services.Add(typeof(DownloadFileService), null);
         config.Services.Add(typeof(ListDirectoryService), null);
 
-        _server = new SocketSshServer(config, new TraceSource("SshServer"));
+        var sshTrace = new TraceSource("SshServer", SourceLevels.All);
+        _server = new SocketSshServer(config, sshTrace);
         _server.Credentials = new SshServerCredentials(hostKey);
         _server.SessionAuthenticating += SessionAuthenticating;
         _server.ExceptionRaised += ExceptionRaised;

--- a/src/Eryph.GuestServices.Service/Services/SshServerService.cs
+++ b/src/Eryph.GuestServices.Service/Services/SshServerService.cs
@@ -51,6 +51,23 @@ internal sealed class SshServerService(
         config.Services.Add(typeof(ListDirectoryService), null);
 
         var sshTrace = new TraceSource("SshServer", SourceLevels.All);
+        // TEMPORARY: log every outgoing/incoming SSH message to a file so we
+        // can pin down the post-close-data race observed with cmd.exe.
+        var traceFile = OperatingSystem.IsWindows()
+            ? @"C:\egs-staging\ssh-trace.log"
+            : "/tmp/ssh-trace.log";
+        try
+        {
+            var dir = Path.GetDirectoryName(traceFile);
+            if (dir is not null) Directory.CreateDirectory(dir);
+            var fileListener = new FlushingTraceListener(traceFile);
+            sshTrace.Listeners.Add(fileListener);
+            sshTrace.Switch.Level = SourceLevels.All;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to attach ssh trace listener to {Path}", traceFile);
+        }
         _server = new SocketSshServer(config, sshTrace);
         _server.Credentials = new SshServerCredentials(hostKey);
         _server.SessionAuthenticating += SessionAuthenticating;
@@ -134,5 +151,26 @@ internal sealed class SshServerService(
             [Constants.OperatingSystemKey] = RuntimeInformation.OSDescription,
         };
         await guestDataExchange.SetGuestValuesAsync(values);
+    }
+
+    private sealed class FlushingTraceListener(string fileName) : TextWriterTraceListener(fileName)
+    {
+        public override void TraceEvent(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string? message)
+        {
+            base.TraceEvent(eventCache, source, eventType, id, message);
+            Flush();
+        }
+
+        public override void TraceEvent(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string? format, params object?[]? args)
+        {
+            base.TraceEvent(eventCache, source, eventType, id, format, args);
+            Flush();
+        }
+
+        public override void WriteLine(string? message)
+        {
+            base.WriteLine(message);
+            Flush();
+        }
     }
 }

--- a/src/Eryph.GuestServices.Service/Services/SshServerService.cs
+++ b/src/Eryph.GuestServices.Service/Services/SshServerService.cs
@@ -20,6 +20,7 @@ internal sealed class SshServerService(
     IHostKeyGenerator hostKeyGenerator,
     IGuestDataExchange guestDataExchange,
     IClientKeyProvider clientKeyProvider,
+    IShellSelector shellSelector,
     ILogger<SshServerService> logger) : IHostedService, IAsyncDisposable
 {
     private Socket? _socket;
@@ -42,7 +43,9 @@ internal sealed class SshServerService(
 
         config.Services.Add(typeof(SubsystemService), null);
         config.Services.Add(typeof(CommandService), null);
-        config.Services.Add(typeof(ShellService), null);
+        // The shell selector is passed as the service activation config object.
+        // DevTunnels.Ssh activates the matching 2-arg ctor on ShellService.
+        config.Services.Add(typeof(ShellService), shellSelector);
         config.Services.Add(typeof(UploadFileService), null);
         config.Services.Add(typeof(DownloadFileService), null);
         config.Services.Add(typeof(ListDirectoryService), null);

--- a/src/Eryph.GuestServices.Service/Services/SshServerService.cs
+++ b/src/Eryph.GuestServices.Service/Services/SshServerService.cs
@@ -50,25 +50,7 @@ internal sealed class SshServerService(
         config.Services.Add(typeof(DownloadFileService), null);
         config.Services.Add(typeof(ListDirectoryService), null);
 
-        var sshTrace = new TraceSource("SshServer", SourceLevels.All);
-        // TEMPORARY: log every outgoing/incoming SSH message to a file so we
-        // can pin down the post-close-data race observed with cmd.exe.
-        var traceFile = OperatingSystem.IsWindows()
-            ? @"C:\egs-staging\ssh-trace.log"
-            : "/tmp/ssh-trace.log";
-        try
-        {
-            var dir = Path.GetDirectoryName(traceFile);
-            if (dir is not null) Directory.CreateDirectory(dir);
-            var fileListener = new FlushingTraceListener(traceFile);
-            sshTrace.Listeners.Add(fileListener);
-            sshTrace.Switch.Level = SourceLevels.All;
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Failed to attach ssh trace listener to {Path}", traceFile);
-        }
-        _server = new SocketSshServer(config, sshTrace);
+        _server = new SocketSshServer(config, new TraceSource("SshServer"));
         _server.Credentials = new SshServerCredentials(hostKey);
         _server.SessionAuthenticating += SessionAuthenticating;
         _server.ExceptionRaised += ExceptionRaised;
@@ -151,26 +133,5 @@ internal sealed class SshServerService(
             [Constants.OperatingSystemKey] = RuntimeInformation.OSDescription,
         };
         await guestDataExchange.SetGuestValuesAsync(values);
-    }
-
-    private sealed class FlushingTraceListener(string fileName) : TextWriterTraceListener(fileName)
-    {
-        public override void TraceEvent(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string? message)
-        {
-            base.TraceEvent(eventCache, source, eventType, id, message);
-            Flush();
-        }
-
-        public override void TraceEvent(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string? format, params object?[]? args)
-        {
-            base.TraceEvent(eventCache, source, eventType, id, format, args);
-            Flush();
-        }
-
-        public override void WriteLine(string? message)
-        {
-            base.WriteLine(message);
-            Flush();
-        }
     }
 }

--- a/src/Eryph.GuestServices.Tool/Commands/SetShellCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/SetShellCommand.cs
@@ -25,24 +25,30 @@ public class SetShellCommand : AsyncCommand<SetShellCommand.Settings>
     {
         if (settings.Reset)
         {
-            if (!string.IsNullOrEmpty(settings.Command) || !string.IsNullOrEmpty(settings.Arguments))
+            if (!string.IsNullOrWhiteSpace(settings.Command) || !string.IsNullOrWhiteSpace(settings.Arguments))
             {
                 AnsiConsole.MarkupLineInterpolated(
                     $"[red]--reset cannot be combined with --command or --arguments.[/]");
                 return -1;
             }
         }
-        else if (string.IsNullOrEmpty(settings.Command))
+        else if (string.IsNullOrWhiteSpace(settings.Command))
         {
             AnsiConsole.MarkupLineInterpolated(
                 $"[red]Either --command <CMD> or --reset is required.[/]");
             return -1;
         }
 
+        // Trim so a stray whitespace pad doesn't end up in KVP. The selector
+        // only honors a non-blank shell value anyway; persisting dead data
+        // would be misleading.
+        var command = settings.Command?.Trim();
+        var arguments = settings.Arguments?.Trim();
+
         var values = new Dictionary<string, string?>
         {
-            [Constants.ShellKey] = settings.Reset ? null : settings.Command,
-            [Constants.ShellArgsKey] = settings.Reset ? null : settings.Arguments,
+            [Constants.ShellKey] = settings.Reset ? null : command,
+            [Constants.ShellArgsKey] = settings.Reset ? null : arguments,
         };
 
         var hostDataExchange = new HostDataExchange();
@@ -55,10 +61,10 @@ public class SetShellCommand : AsyncCommand<SetShellCommand.Settings>
         }
         else
         {
-            var argsDisplay = string.IsNullOrEmpty(settings.Arguments) ? "(none)" : settings.Arguments;
+            var argsDisplay = string.IsNullOrEmpty(arguments) ? "(none)" : arguments;
             AnsiConsole.Write(new Rows(
                 new Markup($"[green]Shell override set for VM {settings.VmId}.[/]"),
-                new Text($"  Command:   {settings.Command}"),
+                new Text($"  Command:   {command}"),
                 new Text($"  Arguments: {argsDisplay}"),
                 new Text(""),
                 new Text("Takes effect on the next SSH session.")));

--- a/src/Eryph.GuestServices.Tool/Commands/SetShellCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/SetShellCommand.cs
@@ -39,11 +39,11 @@ public class SetShellCommand : AsyncCommand<SetShellCommand.Settings>
             return -1;
         }
 
-        // Trim so a stray whitespace pad doesn't end up in KVP. The selector
-        // only honors a non-blank shell value anyway; persisting dead data
-        // would be misleading.
-        var command = settings.Command?.Trim();
-        var arguments = settings.Arguments?.Trim();
+        // Collapse blanks to null so a stray whitespace pad (or an explicit
+        // empty value) doesn't end up persisted as dead data in KVP. The
+        // selector only honors a non-blank value anyway.
+        var command = string.IsNullOrWhiteSpace(settings.Command) ? null : settings.Command.Trim();
+        var arguments = string.IsNullOrWhiteSpace(settings.Arguments) ? null : settings.Arguments.Trim();
 
         var values = new Dictionary<string, string?>
         {

--- a/src/Eryph.GuestServices.Tool/Commands/SetShellCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/SetShellCommand.cs
@@ -1,0 +1,69 @@
+using Eryph.GuestServices.Core;
+using Eryph.GuestServices.HvDataExchange.Host;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Eryph.GuestServices.Tool.Commands;
+
+public class SetShellCommand : AsyncCommand<SetShellCommand.Settings>
+{
+    public class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<VmId>")] public Guid VmId { get; set; }
+
+        [CommandOption("-c|--command <CMD>")]
+        public string? Command { get; set; }
+
+        [CommandOption("-a|--arguments <ARGS>")]
+        public string? Arguments { get; set; }
+
+        [CommandOption("--reset")]
+        public bool Reset { get; set; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        if (settings.Reset)
+        {
+            if (!string.IsNullOrEmpty(settings.Command) || !string.IsNullOrEmpty(settings.Arguments))
+            {
+                AnsiConsole.MarkupLineInterpolated(
+                    $"[red]--reset cannot be combined with --command or --arguments.[/]");
+                return -1;
+            }
+        }
+        else if (string.IsNullOrEmpty(settings.Command))
+        {
+            AnsiConsole.MarkupLineInterpolated(
+                $"[red]Either --command <CMD> or --reset is required.[/]");
+            return -1;
+        }
+
+        var values = new Dictionary<string, string?>
+        {
+            [Constants.ShellKey] = settings.Reset ? null : settings.Command,
+            [Constants.ShellArgsKey] = settings.Reset ? null : settings.Arguments,
+        };
+
+        var hostDataExchange = new HostDataExchange();
+        await hostDataExchange.SetExternalValuesAsync(settings.VmId, values);
+
+        if (settings.Reset)
+        {
+            AnsiConsole.MarkupLineInterpolated(
+                $"[green]Cleared the shell override for VM {settings.VmId}.[/]");
+        }
+        else
+        {
+            var argsDisplay = string.IsNullOrEmpty(settings.Arguments) ? "(none)" : settings.Arguments;
+            AnsiConsole.Write(new Rows(
+                new Markup($"[green]Shell override set for VM {settings.VmId}.[/]"),
+                new Text($"  Command:   {settings.Command}"),
+                new Text($"  Arguments: {argsDisplay}"),
+                new Text(""),
+                new Text("Takes effect on the next SSH session.")));
+        }
+
+        return 0;
+    }
+}

--- a/src/Eryph.GuestServices.Tool/Eryph.GuestServices.Tool.csproj
+++ b/src/Eryph.GuestServices.Tool/Eryph.GuestServices.Tool.csproj
@@ -12,6 +12,11 @@
 
   <ItemGroup>
     <PackageReference Include="Eryph.ComputeClient" Version="0.13.0" />
+    <!-- Eryph.ComputeClient (built for older TFMs) compiles against
+         Microsoft.Bcl.AsyncInterfaces 8.0.0. Bumping the explicit ref to the
+         .NET 10 line ensures the type forwarders match the host BCL when the
+         tool is published self-contained. -->
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
     <PackageReference Include="Microsoft.DevTunnels.Ssh.Keys" Version="3.12.8" />
     <PackageReference Include="Spectre.Console" Version="0.51.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.51.1" />

--- a/src/Eryph.GuestServices.Tool/Eryph.GuestServices.Tool.csproj
+++ b/src/Eryph.GuestServices.Tool/Eryph.GuestServices.Tool.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Eryph.ComputeClient" Version="0.13.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.DevTunnels.Ssh.Keys" Version="3.12.8" />
     <PackageReference Include="Spectre.Console" Version="0.51.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.51.1" />

--- a/src/Eryph.GuestServices.Tool/Eryph.GuestServices.Tool.csproj
+++ b/src/Eryph.GuestServices.Tool/Eryph.GuestServices.Tool.csproj
@@ -17,7 +17,7 @@
          .NET 10 line ensures the type forwarders match the host BCL when the
          tool is published self-contained. -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
-    <PackageReference Include="Microsoft.DevTunnels.Ssh.Keys" Version="3.12.8" />
+    <PackageReference Include="Microsoft.DevTunnels.Ssh.Keys" Version="3.12.29" />
     <PackageReference Include="Spectre.Console" Version="0.51.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.51.1" />
   </ItemGroup>

--- a/src/Eryph.GuestServices.Tool/Program.cs
+++ b/src/Eryph.GuestServices.Tool/Program.cs
@@ -57,6 +57,10 @@ app.Configure(config =>
     config.AddCommand<UnregisterCommand>("unregister")
         .WithDescription(
             "Unregisters the eryph guest services from Hyper-V.");
+
+    config.AddCommand<SetShellCommand>("set-shell")
+        .WithDescription(
+            "Configures the shell that interactive SSH sessions spawn in the VM.");
 });
 
 

--- a/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/DefaultShellSelectorTests.cs
+++ b/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/DefaultShellSelectorTests.cs
@@ -1,5 +1,4 @@
 using AwesomeAssertions;
-using Eryph.GuestServices.Core;
 
 namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests;
 
@@ -8,13 +7,9 @@ public class DefaultShellSelectorTests
     [Fact]
     public async Task SelectAsync_WithSshShellEnv_UsesIt()
     {
-        var env = new Dictionary<string, string>
-        {
-            [Constants.ShellEnvName] = "pwsh.exe",
-            [Constants.ShellArgsEnvName] = "-NoLogo",
-        };
+        var sshOverride = new ShellOverride("pwsh.exe", "-NoLogo");
 
-        var selection = await DefaultShellSelector.Instance.SelectAsync(env, CancellationToken.None);
+        var selection = await DefaultShellSelector.Instance.SelectAsync(sshOverride, CancellationToken.None);
 
         selection.Command.Should().Be("pwsh.exe");
         selection.Arguments.Should().Be("-NoLogo");
@@ -23,12 +18,9 @@ public class DefaultShellSelectorTests
     [Fact]
     public async Task SelectAsync_WithShellEnvButNoArgs_UsesEmptyArgs()
     {
-        var env = new Dictionary<string, string>
-        {
-            [Constants.ShellEnvName] = "pwsh.exe",
-        };
+        var sshOverride = new ShellOverride("pwsh.exe", null);
 
-        var selection = await DefaultShellSelector.Instance.SelectAsync(env, CancellationToken.None);
+        var selection = await DefaultShellSelector.Instance.SelectAsync(sshOverride, CancellationToken.None);
 
         selection.Command.Should().Be("pwsh.exe");
         selection.Arguments.Should().BeEmpty();
@@ -37,22 +29,17 @@ public class DefaultShellSelectorTests
     [Fact]
     public async Task SelectAsync_WithBlankShellEnv_FallsBackToPlatformDefault()
     {
-        var env = new Dictionary<string, string>
-        {
-            [Constants.ShellEnvName] = "   ",
-        };
+        var sshOverride = new ShellOverride("   ", null);
 
-        var selection = await DefaultShellSelector.Instance.SelectAsync(env, CancellationToken.None);
+        var selection = await DefaultShellSelector.Instance.SelectAsync(sshOverride, CancellationToken.None);
 
         selection.Should().Be(DefaultShellSelector.PlatformDefault());
     }
 
     [Fact]
-    public async Task SelectAsync_WithEmptyEnv_ReturnsPlatformDefault()
+    public async Task SelectAsync_WithEmptyOverride_ReturnsPlatformDefault()
     {
-        var env = new Dictionary<string, string>();
-
-        var selection = await DefaultShellSelector.Instance.SelectAsync(env, CancellationToken.None);
+        var selection = await DefaultShellSelector.Instance.SelectAsync(ShellOverride.Empty, CancellationToken.None);
 
         selection.Should().Be(DefaultShellSelector.PlatformDefault());
     }

--- a/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/DefaultShellSelectorTests.cs
+++ b/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/DefaultShellSelectorTests.cs
@@ -1,0 +1,87 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.Core;
+
+namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests;
+
+public class DefaultShellSelectorTests
+{
+    [Fact]
+    public async Task SelectAsync_WithSshShellEnv_UsesIt()
+    {
+        var env = new Dictionary<string, string>
+        {
+            [Constants.ShellEnvName] = "pwsh.exe",
+            [Constants.ShellArgsEnvName] = "-NoLogo",
+        };
+
+        var selection = await DefaultShellSelector.Instance.SelectAsync(env, CancellationToken.None);
+
+        selection.Command.Should().Be("pwsh.exe");
+        selection.Arguments.Should().Be("-NoLogo");
+    }
+
+    [Fact]
+    public async Task SelectAsync_WithShellEnvButNoArgs_UsesEmptyArgs()
+    {
+        var env = new Dictionary<string, string>
+        {
+            [Constants.ShellEnvName] = "pwsh.exe",
+        };
+
+        var selection = await DefaultShellSelector.Instance.SelectAsync(env, CancellationToken.None);
+
+        selection.Command.Should().Be("pwsh.exe");
+        selection.Arguments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SelectAsync_WithBlankShellEnv_FallsBackToPlatformDefault()
+    {
+        var env = new Dictionary<string, string>
+        {
+            [Constants.ShellEnvName] = "   ",
+        };
+
+        var selection = await DefaultShellSelector.Instance.SelectAsync(env, CancellationToken.None);
+
+        selection.Should().Be(DefaultShellSelector.PlatformDefault());
+    }
+
+    [Fact]
+    public async Task SelectAsync_WithEmptyEnv_ReturnsPlatformDefault()
+    {
+        var env = new Dictionary<string, string>();
+
+        var selection = await DefaultShellSelector.Instance.SelectAsync(env, CancellationToken.None);
+
+        selection.Should().Be(DefaultShellSelector.PlatformDefault());
+    }
+
+    [Fact]
+    public void PlatformDefault_OnWindows_IsPowerShell()
+    {
+        // The test process always runs net10.0 (Linux job too); however the
+        // selector branches on OperatingSystem.IsLinux/.IsWindows at runtime.
+        // Skip when not on Windows to avoid asserting on the wrong branch.
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var selection = DefaultShellSelector.PlatformDefault();
+
+        selection.Command.Should().Be("powershell.exe");
+        selection.Arguments.Should().Be("-WindowStyle Hidden");
+    }
+
+    [Fact]
+    public void PlatformDefault_OnLinux_UsesShellEnvOrBash()
+    {
+        if (!OperatingSystem.IsLinux())
+            return;
+
+        var selection = DefaultShellSelector.PlatformDefault();
+
+        selection.Arguments.Should().Be("-i");
+        // Either honors $SHELL or falls back to /bin/bash; both are acceptable.
+        selection.Command.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/test/Eryph.GuestServices.Service.Tests/Eryph.GuestServices.Service.Tests.csproj
+++ b/test/Eryph.GuestServices.Service.Tests/Eryph.GuestServices.Service.Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">

--- a/test/Eryph.GuestServices.Service.Tests/Eryph.GuestServices.Service.Tests.csproj
+++ b/test/Eryph.GuestServices.Service.Tests/Eryph.GuestServices.Service.Tests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AwesomeAssertions" Version="9.1.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Eryph.GuestServices.Service\Eryph.GuestServices.Service.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/test/Eryph.GuestServices.Service.Tests/KvpShellSelectorTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/KvpShellSelectorTests.cs
@@ -1,0 +1,150 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.Core;
+using Eryph.GuestServices.DevTunnels.Ssh.Extensions;
+using Eryph.GuestServices.HvDataExchange.Guest;
+using Eryph.GuestServices.Service.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Eryph.GuestServices.Service.Tests;
+
+public class KvpShellSelectorTests
+{
+    [Fact]
+    public async Task SelectAsync_KvpShellAndArgsBothSet_ReturnsThem()
+    {
+        var dataExchange = new StubDataExchange
+        {
+            External =
+            {
+                [Constants.ShellKey] = "pwsh.exe",
+                [Constants.ShellArgsKey] = "-NoLogo -NoProfile",
+            },
+        };
+        var selector = new KvpShellSelector(dataExchange, NullLogger<KvpShellSelector>.Instance);
+
+        var selection = await selector.SelectAsync(EmptyEnv(), CancellationToken.None);
+
+        selection.Should().Be(new ShellSelection("pwsh.exe", "-NoLogo -NoProfile"));
+    }
+
+    [Fact]
+    public async Task SelectAsync_KvpShellOnly_ReturnsShellWithEmptyArgs()
+    {
+        var dataExchange = new StubDataExchange
+        {
+            External = { [Constants.ShellKey] = "pwsh.exe" },
+        };
+        var selector = new KvpShellSelector(dataExchange, NullLogger<KvpShellSelector>.Instance);
+
+        var selection = await selector.SelectAsync(EmptyEnv(), CancellationToken.None);
+
+        selection.Should().Be(new ShellSelection("pwsh.exe", string.Empty));
+    }
+
+    [Fact]
+    public async Task SelectAsync_KvpWinsOverSshEnv()
+    {
+        var dataExchange = new StubDataExchange
+        {
+            External = { [Constants.ShellKey] = "kvp-shell.exe" },
+        };
+        var env = new Dictionary<string, string>
+        {
+            [Constants.ShellEnvName] = "env-shell.exe",
+        };
+        var selector = new KvpShellSelector(dataExchange, NullLogger<KvpShellSelector>.Instance);
+
+        var selection = await selector.SelectAsync(env, CancellationToken.None);
+
+        selection.Command.Should().Be("kvp-shell.exe");
+    }
+
+    [Fact]
+    public async Task SelectAsync_NoKvp_FallsBackToSshEnv()
+    {
+        var dataExchange = new StubDataExchange();
+        var env = new Dictionary<string, string>
+        {
+            [Constants.ShellEnvName] = "env-shell.exe",
+            [Constants.ShellArgsEnvName] = "-i",
+        };
+        var selector = new KvpShellSelector(dataExchange, NullLogger<KvpShellSelector>.Instance);
+
+        var selection = await selector.SelectAsync(env, CancellationToken.None);
+
+        selection.Should().Be(new ShellSelection("env-shell.exe", "-i"));
+    }
+
+    [Fact]
+    public async Task SelectAsync_NeitherKvpNorEnv_ReturnsPlatformDefault()
+    {
+        var dataExchange = new StubDataExchange();
+        var selector = new KvpShellSelector(dataExchange, NullLogger<KvpShellSelector>.Instance);
+
+        var selection = await selector.SelectAsync(EmptyEnv(), CancellationToken.None);
+
+        selection.Should().Be(DefaultShellSelector.PlatformDefault());
+    }
+
+    [Fact]
+    public async Task SelectAsync_KvpReadFails_FallsBackInsteadOfThrowing()
+    {
+        var dataExchange = new ThrowingDataExchange();
+        var env = new Dictionary<string, string>
+        {
+            [Constants.ShellEnvName] = "fallback.exe",
+        };
+        var selector = new KvpShellSelector(dataExchange, NullLogger<KvpShellSelector>.Instance);
+
+        var selection = await selector.SelectAsync(env, CancellationToken.None);
+
+        selection.Command.Should().Be("fallback.exe");
+    }
+
+    [Fact]
+    public async Task SelectAsync_KvpShellIsBlank_FallsThroughToEnv()
+    {
+        var dataExchange = new StubDataExchange
+        {
+            External = { [Constants.ShellKey] = "   " },
+        };
+        var env = new Dictionary<string, string>
+        {
+            [Constants.ShellEnvName] = "env-shell.exe",
+        };
+        var selector = new KvpShellSelector(dataExchange, NullLogger<KvpShellSelector>.Instance);
+
+        var selection = await selector.SelectAsync(env, CancellationToken.None);
+
+        selection.Command.Should().Be("env-shell.exe");
+    }
+
+    private static IReadOnlyDictionary<string, string> EmptyEnv() =>
+        new Dictionary<string, string>();
+
+    private sealed class StubDataExchange : IGuestDataExchange
+    {
+        public Dictionary<string, string> External { get; } = new();
+
+        public Task<IReadOnlyDictionary<string, string>> GetExternalDataAsync()
+            => Task.FromResult<IReadOnlyDictionary<string, string>>(External);
+
+        public Task<IReadOnlyDictionary<string, string>> GetGuestDataAsync()
+            => Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>());
+
+        public Task SetGuestValuesAsync(IReadOnlyDictionary<string, string?> values)
+            => Task.CompletedTask;
+    }
+
+    private sealed class ThrowingDataExchange : IGuestDataExchange
+    {
+        public Task<IReadOnlyDictionary<string, string>> GetExternalDataAsync()
+            => throw new InvalidOperationException("simulated KVP failure");
+
+        public Task<IReadOnlyDictionary<string, string>> GetGuestDataAsync()
+            => Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>());
+
+        public Task SetGuestValuesAsync(IReadOnlyDictionary<string, string?> values)
+            => Task.CompletedTask;
+    }
+}

--- a/test/Eryph.GuestServices.Service.Tests/KvpShellSelectorTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/KvpShellSelectorTests.cs
@@ -22,7 +22,7 @@ public class KvpShellSelectorTests
         };
         var selector = new KvpShellSelector(dataExchange, NullLogger<KvpShellSelector>.Instance);
 
-        var selection = await selector.SelectAsync(EmptyEnv(), CancellationToken.None);
+        var selection = await selector.SelectAsync(ShellOverride.Empty, CancellationToken.None);
 
         selection.Should().Be(new ShellSelection("pwsh.exe", "-NoLogo -NoProfile"));
     }
@@ -36,7 +36,7 @@ public class KvpShellSelectorTests
         };
         var selector = new KvpShellSelector(dataExchange, NullLogger<KvpShellSelector>.Instance);
 
-        var selection = await selector.SelectAsync(EmptyEnv(), CancellationToken.None);
+        var selection = await selector.SelectAsync(ShellOverride.Empty, CancellationToken.None);
 
         selection.Should().Be(new ShellSelection("pwsh.exe", string.Empty));
     }
@@ -48,13 +48,10 @@ public class KvpShellSelectorTests
         {
             External = { [Constants.ShellKey] = "kvp-shell.exe" },
         };
-        var env = new Dictionary<string, string>
-        {
-            [Constants.ShellEnvName] = "env-shell.exe",
-        };
+        var sshOverride = new ShellOverride("env-shell.exe", null);
         var selector = new KvpShellSelector(dataExchange, NullLogger<KvpShellSelector>.Instance);
 
-        var selection = await selector.SelectAsync(env, CancellationToken.None);
+        var selection = await selector.SelectAsync(sshOverride, CancellationToken.None);
 
         selection.Command.Should().Be("kvp-shell.exe");
     }
@@ -63,14 +60,10 @@ public class KvpShellSelectorTests
     public async Task SelectAsync_NoKvp_FallsBackToSshEnv()
     {
         var dataExchange = new StubDataExchange();
-        var env = new Dictionary<string, string>
-        {
-            [Constants.ShellEnvName] = "env-shell.exe",
-            [Constants.ShellArgsEnvName] = "-i",
-        };
+        var sshOverride = new ShellOverride("env-shell.exe", "-i");
         var selector = new KvpShellSelector(dataExchange, NullLogger<KvpShellSelector>.Instance);
 
-        var selection = await selector.SelectAsync(env, CancellationToken.None);
+        var selection = await selector.SelectAsync(sshOverride, CancellationToken.None);
 
         selection.Should().Be(new ShellSelection("env-shell.exe", "-i"));
     }
@@ -81,7 +74,7 @@ public class KvpShellSelectorTests
         var dataExchange = new StubDataExchange();
         var selector = new KvpShellSelector(dataExchange, NullLogger<KvpShellSelector>.Instance);
 
-        var selection = await selector.SelectAsync(EmptyEnv(), CancellationToken.None);
+        var selection = await selector.SelectAsync(ShellOverride.Empty, CancellationToken.None);
 
         selection.Should().Be(DefaultShellSelector.PlatformDefault());
     }
@@ -90,13 +83,10 @@ public class KvpShellSelectorTests
     public async Task SelectAsync_KvpReadFails_FallsBackInsteadOfThrowing()
     {
         var dataExchange = new ThrowingDataExchange();
-        var env = new Dictionary<string, string>
-        {
-            [Constants.ShellEnvName] = "fallback.exe",
-        };
+        var sshOverride = new ShellOverride("fallback.exe", null);
         var selector = new KvpShellSelector(dataExchange, NullLogger<KvpShellSelector>.Instance);
 
-        var selection = await selector.SelectAsync(env, CancellationToken.None);
+        var selection = await selector.SelectAsync(sshOverride, CancellationToken.None);
 
         selection.Command.Should().Be("fallback.exe");
     }
@@ -108,19 +98,13 @@ public class KvpShellSelectorTests
         {
             External = { [Constants.ShellKey] = "   " },
         };
-        var env = new Dictionary<string, string>
-        {
-            [Constants.ShellEnvName] = "env-shell.exe",
-        };
+        var sshOverride = new ShellOverride("env-shell.exe", null);
         var selector = new KvpShellSelector(dataExchange, NullLogger<KvpShellSelector>.Instance);
 
-        var selection = await selector.SelectAsync(env, CancellationToken.None);
+        var selection = await selector.SelectAsync(sshOverride, CancellationToken.None);
 
         selection.Command.Should().Be("env-shell.exe");
     }
-
-    private static IReadOnlyDictionary<string, string> EmptyEnv() =>
-        new Dictionary<string, string>();
 
     private sealed class StubDataExchange : IGuestDataExchange
     {

--- a/test/e2e/EgsShellProbe/EgsShellProbe.csproj
+++ b/test/e2e/EgsShellProbe/EgsShellProbe.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
-    <PackageReference Include="Microsoft.DevTunnels.Ssh.Keys" Version="3.12.8" />
+    <PackageReference Include="Microsoft.DevTunnels.Ssh.Keys" Version="3.12.29" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/e2e/EgsShellProbe/EgsShellProbe.csproj
+++ b/test/e2e/EgsShellProbe/EgsShellProbe.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <AssemblyName>egs-shell-probe</AssemblyName>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
+    <PackageReference Include="Microsoft.DevTunnels.Ssh.Keys" Version="3.12.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Eryph.GuestServices.Core\Eryph.GuestServices.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\Eryph.GuestServices.DevTunnels.Ssh.Extensions\Eryph.GuestServices.DevTunnels.Ssh.Extensions.csproj" />
+    <ProjectReference Include="..\..\..\src\Eryph.GuestServices.Sockets\Eryph.GuestServices.Sockets.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/e2e/EgsShellProbe/Program.cs
+++ b/test/e2e/EgsShellProbe/Program.cs
@@ -30,28 +30,39 @@ string? keyPath = null;
 
 for (var i = 0; i < args.Length; i++)
 {
-    switch (args[i])
+    var flag = args[i];
+    switch (flag)
     {
         case "--vm-id":
-            vmId = Guid.Parse(args[++i]);
+            if (!TryConsumeValue(args, ref i, out var vmIdRaw))
+                return Fail($"{flag} requires a value");
+            vmId = Guid.Parse(vmIdRaw);
             break;
         case "--env":
-            var pair = args[++i].Split('=', 2);
+            if (!TryConsumeValue(args, ref i, out var envRaw))
+                return Fail($"{flag} requires KEY=VAL");
+            var pair = envRaw.Split('=', 2);
             if (pair.Length != 2)
-                return Fail($"--env value must be KEY=VAL, got '{args[i]}'");
+                return Fail($"--env value must be KEY=VAL, got '{envRaw}'");
             envVars.Add((pair[0], pair[1]));
             break;
         case "--input":
-            inputLines.Add(args[++i]);
+            if (!TryConsumeValue(args, ref i, out var inputRaw))
+                return Fail($"{flag} requires a value");
+            inputLines.Add(inputRaw);
             break;
         case "--timeout-ms":
-            timeoutMs = int.Parse(args[++i]);
+            if (!TryConsumeValue(args, ref i, out var timeoutRaw))
+                return Fail($"{flag} requires a value");
+            timeoutMs = int.Parse(timeoutRaw);
             break;
         case "--key-path":
-            keyPath = args[++i];
+            if (!TryConsumeValue(args, ref i, out var keyRaw))
+                return Fail($"{flag} requires a value");
+            keyPath = keyRaw;
             break;
         default:
-            return Fail($"unknown argument: {args[i]}");
+            return Fail($"unknown argument: {flag}");
     }
 }
 
@@ -144,4 +155,15 @@ static int Fail(string message)
 {
     Console.Error.WriteLine($"egs-shell-probe: {message}");
     return 1;
+}
+
+static bool TryConsumeValue(string[] args, ref int index, out string value)
+{
+    if (index + 1 >= args.Length)
+    {
+        value = string.Empty;
+        return false;
+    }
+    value = args[++index];
+    return true;
 }

--- a/test/e2e/EgsShellProbe/Program.cs
+++ b/test/e2e/EgsShellProbe/Program.cs
@@ -103,7 +103,10 @@ var channel = await session.OpenChannelAsync();
 // AdjustWindow plumbing automatically.
 var stream = new SshStream(channel);
 
-// pty-req — required by ShellService to allocate a PtyForwarder.
+// pty-req — gives the server a sized PTY so the shell renders normally.
+// (ShellService also creates the forwarder lazily on the first env or shell
+// request, so pty-req is not strictly required, but providing realistic
+// terminal dimensions matches what an interactive client would send.)
 var ptyOk = await channel.RequestAsync(
     new TerminalRequestMessage
     {

--- a/test/e2e/EgsShellProbe/Program.cs
+++ b/test/e2e/EgsShellProbe/Program.cs
@@ -1,0 +1,147 @@
+// E2E test driver for the SHELL channel of the eryph guest services.
+// ssh.exe -tt cannot be redirected/captured from a script (it writes
+// channel output to the Windows console buffer, not stdout). This probe
+// uses Microsoft.DevTunnels.Ssh — the same library that egs-tool itself
+// uses to talk to the egs SSH server — and drives the protocol directly:
+// pty-req, optional env requests, shell, then pumps channel output to
+// stdout for a fixed window.
+//
+// Usage:
+//   egs-shell-probe --vm-id <guid> [--env KEY=VAL ...] [--input <line> ...]
+//                   [--timeout-ms 3000] [--key-path <path>]
+
+using System.Diagnostics;
+using System.Net.Sockets;
+using System.Security.Claims;
+using System.Text;
+using Eryph.GuestServices.Core;
+using Eryph.GuestServices.DevTunnels.Ssh.Extensions.Messages;
+using Eryph.GuestServices.Sockets;
+using Microsoft.DevTunnels.Ssh;
+using Microsoft.DevTunnels.Ssh.Events;
+using Microsoft.DevTunnels.Ssh.Keys;
+using Microsoft.DevTunnels.Ssh.Messages;
+
+Guid? vmId = null;
+var envVars = new List<(string Name, string Value)>();
+var inputLines = new List<string>();
+var timeoutMs = 3000;
+string? keyPath = null;
+
+for (var i = 0; i < args.Length; i++)
+{
+    switch (args[i])
+    {
+        case "--vm-id":
+            vmId = Guid.Parse(args[++i]);
+            break;
+        case "--env":
+            var pair = args[++i].Split('=', 2);
+            if (pair.Length != 2)
+                return Fail($"--env value must be KEY=VAL, got '{args[i]}'");
+            envVars.Add((pair[0], pair[1]));
+            break;
+        case "--input":
+            inputLines.Add(args[++i]);
+            break;
+        case "--timeout-ms":
+            timeoutMs = int.Parse(args[++i]);
+            break;
+        case "--key-path":
+            keyPath = args[++i];
+            break;
+        default:
+            return Fail($"unknown argument: {args[i]}");
+    }
+}
+
+if (vmId is null)
+    return Fail("--vm-id is required");
+
+keyPath ??= Path.Combine(
+    Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+    "eryph", "guest-services", "private", "id_egs");
+
+if (!File.Exists(keyPath))
+    return Fail($"SSH key not found at {keyPath}");
+
+var keyBytes = await File.ReadAllBytesAsync(keyPath);
+var keyPair = KeyPair.ImportKeyBytes(keyBytes);
+
+using var clientSocket = await SocketFactory.CreateClientSocket(vmId.Value, Constants.ServiceId);
+await using var clientStream = new NetworkStream(clientSocket, ownsSocket: false);
+
+var sshConfig = new SshSessionConfiguration();
+var session = new SshClientSession(sshConfig, new TraceSource("EgsShellProbe"));
+session.Authenticating += (_, e) =>
+{
+    if (e.AuthenticationType == SshAuthenticationType.ServerPublicKey)
+    {
+        // Hyper-V socket isolation is sufficient — same trust model as egs-tool.
+        e.AuthenticationTask = Task.FromResult<ClaimsPrincipal?>(new ClaimsPrincipal());
+    }
+};
+
+await session.ConnectAsync(clientStream);
+if (!await session.AuthenticateAsync(new SshClientCredentials("egs", keyPair)))
+    return Fail("authentication failed");
+
+var channel = await session.OpenChannelAsync();
+
+// SshStream wraps the channel and handles the mandatory DataReceived /
+// AdjustWindow plumbing automatically.
+var stream = new SshStream(channel);
+
+// pty-req — required by ShellService to allocate a PtyForwarder.
+var ptyOk = await channel.RequestAsync(
+    new TerminalRequestMessage
+    {
+        Term = "xterm-256color",
+        Columns = 80,
+        Rows = 25,
+    });
+if (!ptyOk)
+    return Fail("server rejected pty-req");
+
+// env requests — these flow into PtyForwarder.SetEnvironmentVariable on the
+// server. Used to test the SSH-sent SHELL/SHELL_ARGS override path.
+foreach (var (name, value) in envVars)
+{
+    var envOk = await channel.RequestAsync(
+        new EnvironmentVariableRequestMessage { Name = name, Value = value });
+    if (!envOk)
+        return Fail($"server rejected env {name}");
+}
+
+var shellOk = await channel.RequestAsync(new ShellRequestMessage());
+if (!shellOk)
+    return Fail("server rejected shell");
+
+if (inputLines.Count > 0)
+{
+    // Append CR+LF so PowerShell consumes each line as a complete command.
+    var inputBytes = Encoding.UTF8.GetBytes(
+        string.Join("\r\n", inputLines) + "\r\n");
+    await stream.WriteAsync(inputBytes);
+    await stream.FlushAsync();
+}
+
+// Pump channel output for the configured window. The channel will normally
+// stay open until the shell exits; the cancellation cuts the read loop
+// short.
+var captured = new MemoryStream();
+using var cts = new CancellationTokenSource(timeoutMs);
+try
+{
+    await stream.CopyToAsync(captured, cts.Token);
+}
+catch (OperationCanceledException) { /* expected */ }
+
+await Console.OpenStandardOutput().WriteAsync(captured.ToArray());
+return 0;
+
+static int Fail(string message)
+{
+    Console.Error.WriteLine($"egs-shell-probe: {message}");
+    return 1;
+}

--- a/test/e2e/Helpers.ps1
+++ b/test/e2e/Helpers.ps1
@@ -190,74 +190,43 @@ try {
   }
 }
 
-function Invoke-InteractiveShell {
+function Invoke-EgsShellProbe {
   <#
   .SYNOPSIS
-    Opens an interactive SSH shell session and feeds the supplied PowerShell
-    snippets into stdin. Returns the captured output (stdout + stderr).
+    Drives a shell channel against the egs SSH server using the
+    `egs-shell-probe` tool and returns the captured output.
 
   .DESCRIPTION
-    Uses `ssh.exe -tt` to force PTY allocation even with redirected stdio, so
-    the server-side ShellService is exercised (not CommandService). On
-    failure or empty output, the captured stdout+stderr are written to host
-    so the test diagnostics show what happened.
+    `ssh.exe -tt` cannot be redirected/captured from a script — Win32-OpenSSH
+    writes channel output to the Windows console buffer, not stdout. The
+    probe uses Microsoft.DevTunnels.Ssh directly (the same library the
+    egs SSH server itself uses) to send pty-req, optional env requests, and
+    shell, then pumps channel output to stdout. This bypasses the ssh.exe
+    capture quirk while still exercising the full server-side path
+    (ShellService -> PtyForwarder -> IShellSelector).
   #>
   [CmdletBinding()]
   param(
-    [Parameter(Mandatory = $true)] [string] $HostName,
-    [Parameter(Mandatory = $true)] [string[]] $InputLines,
+    [Parameter(Mandatory = $true)] [string] $ProbePath,
+    [Parameter(Mandatory = $true)] [Guid] $VmId,
+    [Parameter()] [string[]] $InputLines = @(),
     [Parameter()] [hashtable] $SetEnv,
-    [Parameter()] [int] $TimeoutSeconds = 60
+    [Parameter()] [int] $TimeoutMs = 3000
   )
 
-  $psi = [System.Diagnostics.ProcessStartInfo]::new()
-  $psi.FileName = 'ssh.exe'
-  $psi.UseShellExecute = $false
-  $psi.RedirectStandardInput = $true
-  $psi.RedirectStandardOutput = $true
-  $psi.RedirectStandardError = $true
-  $psi.CreateNoWindow = $true
-
-  $sshArgs = @('-tt', '-o', 'StrictHostKeyChecking=no')
+  $probeArgs = @('--vm-id', $VmId.ToString(), '--timeout-ms', $TimeoutMs.ToString())
   if ($SetEnv) {
     foreach ($k in $SetEnv.Keys) {
-      $sshArgs += @('-o', "SetEnv=$k=$($SetEnv[$k])")
+      $probeArgs += @('--env', "$k=$($SetEnv[$k])")
     }
   }
-  $sshArgs += $HostName
-
-  foreach ($a in $sshArgs) { $psi.ArgumentList.Add($a) }
-
-  $proc = [System.Diagnostics.Process]::Start($psi)
-
-  # Buffer the stdin payload, then close so the shell sees EOF and exits.
-  # A short pause before 'exit' lets PowerShell flush its prompt + banner +
-  # the marker output before the channel closes.
-  $payload = (($InputLines + @('Start-Sleep -Milliseconds 500', 'exit')) -join "`r`n") + "`r`n"
-  $proc.StandardInput.Write($payload)
-  $proc.StandardInput.Flush()
-  $proc.StandardInput.Close()
-
-  $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
-  $stderrTask = $proc.StandardError.ReadToEndAsync()
-
-  if (-not $proc.WaitForExit($TimeoutSeconds * 1000)) {
-    $proc.Kill($true)
-    Write-Host "ssh -tt timed out after ${TimeoutSeconds}s. Captured so far:"
-    Write-Host "STDOUT: $($stdoutTask.Result)"
-    Write-Host "STDERR: $($stderrTask.Result)"
-    throw "ssh interactive session timed out"
+  foreach ($line in $InputLines) {
+    $probeArgs += @('--input', $line)
   }
 
-  $stdout = $stdoutTask.Result
-  $stderr = $stderrTask.Result
-  $merged = "$stdout$stderr"
-
-  if ([string]::IsNullOrWhiteSpace($merged)) {
-    Write-Host "ssh -tt produced no output. exit=$($proc.ExitCode)"
-    Write-Host "STDOUT bytes: $([Text.Encoding]::UTF8.GetByteCount($stdout))"
-    Write-Host "STDERR bytes: $([Text.Encoding]::UTF8.GetByteCount($stderr))"
-  }
-
-  return $merged
+  $raw = & $ProbePath @probeArgs 2>&1 | Out-String
+  # Strip ANSI escape sequences. The captured stream is ConPTY-encoded
+  # (CSI / OSC), which is unreadable in test diagnostics and also chokes
+  # Pester's NUnit3 XML serializer (ESC = 0x1B is invalid in XML 1.0).
+  return $raw -replace "`e\[[0-?]*[ -/]*[@-~]", '' -replace "`e\][^`a]*`a", ''
 }

--- a/test/e2e/Helpers.ps1
+++ b/test/e2e/Helpers.ps1
@@ -1,0 +1,215 @@
+#Requires -Version 7.4
+
+# Adapted from MaxBack/test/e2e/Helpers.ps1.
+
+function New-TestProject {
+  $projectName = "egs-shell-e2e-$(Get-Date -Format 'yyyyMMddHHmmss')"
+  New-EryphProject -Name $projectName
+}
+
+function New-CatletName {
+  "egs$(Get-Date -Format 'yyMMddHHmmss')"
+}
+
+function Wait-Assert {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [scriptblock] $Assertion,
+
+    [Parameter()]
+    [timespan] $Timeout = (New-TimeSpan -Minutes 1),
+
+    [Parameter()]
+    [timespan] $Interval = (New-TimeSpan -Seconds 5)
+  )
+
+  $cutOff = (Get-Date).Add($Timeout)
+  while ($true) {
+    try {
+      & $Assertion
+      return
+    } catch {
+      if ((Get-Date) -gt $cutOff) { throw }
+      Write-Debug "  not yet, retrying in $($Interval.TotalSeconds)s"
+    }
+    Start-Sleep -Seconds $Interval.TotalSeconds
+  }
+}
+
+function Connect-Catlet {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] [string] $Id,
+    [Parameter()] [timespan] $Timeout = (New-TimeSpan -Minutes 10)
+  )
+
+  $PSNativeCommandUseErrorActionPreference = $true
+  $ErrorActionPreference = 'Stop'
+
+  $catlet = Get-Catlet -Id $Id
+  $cutOff = (Get-Date).Add($Timeout)
+
+  Write-Verbose "Starting catlet $($catlet.Name) (Id: $Id)..."
+  while ($true) {
+    try { Start-Catlet -Id $Id -Force; break }
+    catch {
+      if ((Get-Date) -gt $cutOff) { throw "Failed to start catlet within timeout: $_" }
+      Start-Sleep -Seconds 5
+    }
+  }
+
+  egs-tool update-ssh-config
+
+  $success = $false
+  Write-Verbose "Waiting for catlet to be ready..."
+  while (-not $success) {
+    try {
+      $vmData = egs-tool get-data --json $catlet.VmId | ConvertFrom-Json -AsHashtable
+      if (-not ($vmData.guest.Keys -like 'CLOUDBASE_INIT|0|provisioning|completed|*')) {
+        throw 'cloudbase-init has not completed yet'
+      }
+
+      $egsStatus = egs-tool get-status $catlet.VmId
+      if ($egsStatus -ne 'available') {
+        throw "guest services not available: $egsStatus"
+      }
+
+      egs-tool add-ssh-config $catlet.VmId
+
+      # Quick connectivity probe
+      $sshProcess = Start-Process -FilePath 'ssh.exe' `
+        -ArgumentList "$($catlet.Id).eryph.alt hostname" `
+        -Wait -PassThru -WindowStyle Hidden
+      if ($sshProcess.ExitCode -ne 0) {
+        throw "ssh probe failed: $($sshProcess.ExitCode)"
+      }
+      $success = $true
+    } catch {
+      if ((Get-Date) -gt $cutOff) {
+        throw "Timed out waiting for catlet readiness: $_"
+      }
+      Write-Debug "  not ready: $_"
+      Start-Sleep -Seconds 5
+    }
+  }
+  Write-Verbose "Catlet ready"
+}
+
+function Update-EgsService {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] $Catlet,
+    [Parameter(Mandatory = $true)] [string] $PublishPath
+  )
+
+  $PSNativeCommandUseErrorActionPreference = $true
+  $ErrorActionPreference = 'Stop'
+
+  if (-not (Test-Path $PublishPath)) {
+    throw "Publish path not found: $PublishPath. Run 'dotnet publish' first."
+  }
+
+  Write-Verbose "Uploading service binaries from $PublishPath ..."
+  egs-tool upload-directory $Catlet.VmId $PublishPath 'C:\egs-staging' --overwrite
+
+  # Deploy script: stop service, copy files, start. Runs detached via scheduled
+  # task so the SSH session that triggers it can disconnect cleanly when the
+  # service stops (the service IS our SSH server).
+  $deployScript = @'
+$ErrorActionPreference = 'Stop'
+$logPath = 'C:\egs-staging\deploy.log'
+try {
+  "[$(Get-Date -Format o)] stopping service" | Out-File -Append $logPath
+  Stop-Service -Name eryph-guest-services -Force
+  $sw = [Diagnostics.Stopwatch]::StartNew()
+  while ((Get-Service eryph-guest-services).Status -ne 'Stopped') {
+    if ($sw.Elapsed.TotalSeconds -gt 60) { throw 'service did not stop in 60s' }
+    Start-Sleep -Milliseconds 500
+  }
+  "[$(Get-Date -Format o)] copying files" | Out-File -Append $logPath
+  Get-ChildItem 'C:\egs-staging' -File `
+    | Where-Object { $_.Name -ne 'deploy.ps1' -and $_.Name -ne 'deploy.log' } `
+    | Copy-Item -Destination 'C:\Program Files\eryph\guest-services\bin' -Force
+  "[$(Get-Date -Format o)] starting service" | Out-File -Append $logPath
+  Start-Service -Name eryph-guest-services
+  "[$(Get-Date -Format o)] done" | Out-File -Append $logPath
+} catch {
+  "[$(Get-Date -Format o)] FAILED: $_" | Out-File -Append $logPath
+  throw
+}
+'@
+  $tempScript = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "egs-deploy-$([guid]::NewGuid()).ps1")
+  Set-Content -Path $tempScript -Value $deployScript -Encoding utf8
+  try {
+    egs-tool upload-file $Catlet.VmId $tempScript 'C:\egs-staging\deploy.ps1' --overwrite
+  } finally {
+    Remove-Item -LiteralPath $tempScript -Force
+  }
+
+  Write-Verbose "Triggering detached deploy task ..."
+  $hostName = "$($Catlet.Id).eryph.alt"
+  ssh.exe -o StrictHostKeyChecking=no $hostName `
+    'schtasks.exe /create /tn EgsDeploy /tr "powershell.exe -ExecutionPolicy Bypass -File C:\egs-staging\deploy.ps1" /sc once /st 23:59:59 /ru SYSTEM /f' | Out-Null
+  ssh.exe -o StrictHostKeyChecking=no $hostName 'schtasks.exe /run /tn EgsDeploy' | Out-Null
+
+  Write-Verbose "Waiting for service to come back ..."
+  Start-Sleep -Seconds 5
+  Wait-Assert -Timeout (New-TimeSpan -Minutes 3) {
+    (egs-tool get-status $Catlet.VmId) | Should -Be 'available'
+  }
+  # Confirm the patched binary is the one running by checking version metadata.
+  Wait-Assert -Timeout (New-TimeSpan -Seconds 30) {
+    $sshProcess = Start-Process -FilePath 'ssh.exe' `
+      -ArgumentList "$hostName hostname" -Wait -PassThru -WindowStyle Hidden
+    $sshProcess.ExitCode | Should -Be 0
+  }
+}
+
+function Invoke-InteractiveShell {
+  <#
+  .SYNOPSIS
+    Opens an interactive SSH shell session and feeds the supplied PowerShell
+    snippets into stdin. Returns the captured output (stdout+stderr merged).
+
+  .DESCRIPTION
+    Uses `ssh.exe -tt` to force PTY allocation even with redirected stdio, so
+    the server-side ShellService is exercised (not CommandService).
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] [string] $HostName,
+    [Parameter(Mandatory = $true)] [string[]] $InputLines,
+    [Parameter()] [hashtable] $SetEnv,
+    [Parameter()] [int] $TimeoutSeconds = 60
+  )
+
+  $sshArgs = @('-tt', '-o', 'StrictHostKeyChecking=no')
+  if ($SetEnv) {
+    foreach ($k in $SetEnv.Keys) {
+      $sshArgs += @('-o', "SetEnv=$k=$($SetEnv[$k])")
+    }
+  }
+  $sshArgs += $HostName
+
+  $stdinFile = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "egs-ssh-in-$([guid]::NewGuid()).txt")
+  $stdoutFile = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "egs-ssh-out-$([guid]::NewGuid()).txt")
+  Set-Content -Path $stdinFile -Value (($InputLines + 'exit') -join "`n") -NoNewline -Encoding utf8
+
+  try {
+    $process = Start-Process -FilePath 'ssh.exe' `
+      -ArgumentList $sshArgs `
+      -RedirectStandardInput $stdinFile `
+      -RedirectStandardOutput $stdoutFile `
+      -WindowStyle Hidden `
+      -PassThru
+    if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+      $process | Stop-Process -Force
+      throw "ssh interactive session timed out after ${TimeoutSeconds}s"
+    }
+    return Get-Content -Raw -Path $stdoutFile
+  } finally {
+    Remove-Item -LiteralPath $stdinFile -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $stdoutFile -Force -ErrorAction SilentlyContinue
+  }
+}

--- a/test/e2e/Helpers.ps1
+++ b/test/e2e/Helpers.ps1
@@ -3,7 +3,8 @@
 # Adapted from MaxBack/test/e2e/Helpers.ps1.
 
 function New-TestProject {
-  $projectName = "egs-shell-e2e-$(Get-Date -Format 'yyyyMMddHHmmss')"
+  # Eryph project names are capped at 20 characters.
+  $projectName = "egs-$(Get-Date -Format 'yyyyMMddHHmmss')"
   New-EryphProject -Name $projectName
 }
 

--- a/test/e2e/Helpers.ps1
+++ b/test/e2e/Helpers.ps1
@@ -112,7 +112,7 @@ function Update-EgsService {
   }
 
   Write-Verbose "Uploading service binaries from $PublishPath ..."
-  egs-tool upload-directory $Catlet.VmId $PublishPath 'C:\egs-staging' --overwrite
+  egs-tool upload-directory $Catlet.VmId $PublishPath 'C:\egs-staging' --overwrite --recursive
 
   # Deploy script: stop service, copy files, start. Runs detached via scheduled
   # task so the SSH session that triggers it can disconnect cleanly when the
@@ -120,18 +120,34 @@ function Update-EgsService {
   $deployScript = @'
 $ErrorActionPreference = 'Stop'
 $logPath = 'C:\egs-staging\deploy.log'
+$src = 'C:\egs-staging'
+$dst = 'C:\Program Files\eryph\guest-services\bin'
 try {
   "[$(Get-Date -Format o)] stopping service" | Out-File -Append $logPath
   Stop-Service -Name eryph-guest-services -Force
+  # Status can flip to Stopped while the process is still releasing its DLLs.
+  # Wait until the process is actually gone before touching the bin directory.
   $sw = [Diagnostics.Stopwatch]::StartNew()
-  while ((Get-Service eryph-guest-services).Status -ne 'Stopped') {
-    if ($sw.Elapsed.TotalSeconds -gt 60) { throw 'service did not stop in 60s' }
+  while (
+    (Get-Service eryph-guest-services).Status -ne 'Stopped' `
+    -or (Get-Process -Name egs-service -ErrorAction SilentlyContinue)
+  ) {
+    if ($sw.Elapsed.TotalSeconds -gt 60) { throw 'service did not fully stop in 60s' }
     Start-Sleep -Milliseconds 500
   }
-  "[$(Get-Date -Format o)] copying files" | Out-File -Append $logPath
-  Get-ChildItem 'C:\egs-staging' -File `
-    | Where-Object { $_.Name -ne 'deploy.ps1' -and $_.Name -ne 'deploy.log' } `
-    | Copy-Item -Destination 'C:\Program Files\eryph\guest-services\bin' -Force
+  "[$(Get-Date -Format o)] service process gone after $([int]$sw.Elapsed.TotalSeconds)s" | Out-File -Append $logPath
+  "[$(Get-Date -Format o)] copying files (recursive, mirror $src -> $dst)" | Out-File -Append $logPath
+  Get-ChildItem $src -Recurse -File `
+    | Where-Object { $_.FullName -notlike "$src\deploy.ps1" -and $_.FullName -notlike "$src\deploy.log" } `
+    | ForEach-Object {
+        $relative = $_.FullName.Substring($src.Length).TrimStart('\')
+        $target = Join-Path $dst $relative
+        $targetDir = Split-Path $target -Parent
+        if (-not (Test-Path -LiteralPath $targetDir)) {
+          New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+        }
+        Copy-Item -LiteralPath $_.FullName -Destination $target -Force
+      }
   "[$(Get-Date -Format o)] starting service" | Out-File -Append $logPath
   Start-Service -Name eryph-guest-services
   "[$(Get-Date -Format o)] done" | Out-File -Append $logPath
@@ -156,10 +172,17 @@ try {
 
   Write-Verbose "Waiting for service to come back ..."
   Start-Sleep -Seconds 5
-  Wait-Assert -Timeout (New-TimeSpan -Minutes 3) {
-    (egs-tool get-status $Catlet.VmId) | Should -Be 'available'
+  try {
+    Wait-Assert -Timeout (New-TimeSpan -Minutes 5) {
+      (egs-tool get-status $Catlet.VmId) | Should -Be 'available'
+    }
+  } catch {
+    Write-Host "Service did not come back. VM=$($Catlet.Name) (VmId=$($Catlet.VmId))"
+    Write-Host "Inspect via Hyper-V Manager -> $($Catlet.Name) -> Connect."
+    Write-Host "Deploy log lives at C:\egs-staging\deploy.log inside the VM."
+    throw
   }
-  # Confirm the patched binary is the one running by checking version metadata.
+  # Confirm SSH is responsive.
   Wait-Assert -Timeout (New-TimeSpan -Seconds 30) {
     $sshProcess = Start-Process -FilePath 'ssh.exe' `
       -ArgumentList "$hostName hostname" -Wait -PassThru -WindowStyle Hidden
@@ -171,11 +194,13 @@ function Invoke-InteractiveShell {
   <#
   .SYNOPSIS
     Opens an interactive SSH shell session and feeds the supplied PowerShell
-    snippets into stdin. Returns the captured output (stdout+stderr merged).
+    snippets into stdin. Returns the captured output (stdout + stderr).
 
   .DESCRIPTION
     Uses `ssh.exe -tt` to force PTY allocation even with redirected stdio, so
-    the server-side ShellService is exercised (not CommandService).
+    the server-side ShellService is exercised (not CommandService). On
+    failure or empty output, the captured stdout+stderr are written to host
+    so the test diagnostics show what happened.
   #>
   [CmdletBinding()]
   param(
@@ -185,6 +210,14 @@ function Invoke-InteractiveShell {
     [Parameter()] [int] $TimeoutSeconds = 60
   )
 
+  $psi = [System.Diagnostics.ProcessStartInfo]::new()
+  $psi.FileName = 'ssh.exe'
+  $psi.UseShellExecute = $false
+  $psi.RedirectStandardInput = $true
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+  $psi.CreateNoWindow = $true
+
   $sshArgs = @('-tt', '-o', 'StrictHostKeyChecking=no')
   if ($SetEnv) {
     foreach ($k in $SetEnv.Keys) {
@@ -193,24 +226,38 @@ function Invoke-InteractiveShell {
   }
   $sshArgs += $HostName
 
-  $stdinFile = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "egs-ssh-in-$([guid]::NewGuid()).txt")
-  $stdoutFile = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "egs-ssh-out-$([guid]::NewGuid()).txt")
-  Set-Content -Path $stdinFile -Value (($InputLines + 'exit') -join "`n") -NoNewline -Encoding utf8
+  foreach ($a in $sshArgs) { $psi.ArgumentList.Add($a) }
 
-  try {
-    $process = Start-Process -FilePath 'ssh.exe' `
-      -ArgumentList $sshArgs `
-      -RedirectStandardInput $stdinFile `
-      -RedirectStandardOutput $stdoutFile `
-      -WindowStyle Hidden `
-      -PassThru
-    if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
-      $process | Stop-Process -Force
-      throw "ssh interactive session timed out after ${TimeoutSeconds}s"
-    }
-    return Get-Content -Raw -Path $stdoutFile
-  } finally {
-    Remove-Item -LiteralPath $stdinFile -Force -ErrorAction SilentlyContinue
-    Remove-Item -LiteralPath $stdoutFile -Force -ErrorAction SilentlyContinue
+  $proc = [System.Diagnostics.Process]::Start($psi)
+
+  # Buffer the stdin payload, then close so the shell sees EOF and exits.
+  # A short pause before 'exit' lets PowerShell flush its prompt + banner +
+  # the marker output before the channel closes.
+  $payload = (($InputLines + @('Start-Sleep -Milliseconds 500', 'exit')) -join "`r`n") + "`r`n"
+  $proc.StandardInput.Write($payload)
+  $proc.StandardInput.Flush()
+  $proc.StandardInput.Close()
+
+  $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
+  $stderrTask = $proc.StandardError.ReadToEndAsync()
+
+  if (-not $proc.WaitForExit($TimeoutSeconds * 1000)) {
+    $proc.Kill($true)
+    Write-Host "ssh -tt timed out after ${TimeoutSeconds}s. Captured so far:"
+    Write-Host "STDOUT: $($stdoutTask.Result)"
+    Write-Host "STDERR: $($stderrTask.Result)"
+    throw "ssh interactive session timed out"
   }
+
+  $stdout = $stdoutTask.Result
+  $stderr = $stderrTask.Result
+  $merged = "$stdout$stderr"
+
+  if ([string]::IsNullOrWhiteSpace($merged)) {
+    Write-Host "ssh -tt produced no output. exit=$($proc.ExitCode)"
+    Write-Host "STDOUT bytes: $([Text.Encoding]::UTF8.GetByteCount($stdout))"
+    Write-Host "STDERR bytes: $([Text.Encoding]::UTF8.GetByteCount($stderr))"
+  }
+
+  return $merged
 }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -28,23 +28,27 @@ is already cached.
 
 ## What gets tested
 
-Six tests in two groups:
+Three active tests under `set-shell tool command`:
 
-- `set-shell tool command`
-  - Writes shell + shell-args to the External KVP pool
-  - Writes only shell when no arguments are passed
-  - `--reset` clears both keys
-- `shell selection`
-  - Default: spawns Windows PowerShell (`powershell.exe`)
-  - KVP override: spawns `pwsh.exe`
-  - SSH-sent `SHELL` env var: spawns `pwsh.exe`
-  - KVP wins over SSH env
-  - `--reset` returns to default
+- Writes shell + shell-args to the External KVP pool (use `--arguments=-...`
+  syntax — Spectre.Console.Cli treats space-separated `-`-prefixed values as
+  new flags)
+- Writes only shell when no arguments are passed
+- `--reset` clears both keys
 
-The shell-selection tests use `ssh -tt` with redirected stdin to feed a
-`Get-Process -Id $PID | Select-Object -ExpandProperty ProcessName` snippet
-into the interactive shell and assert on the captured output. `cmd.exe` as an
-override is documented but not e2e-tested (different shell syntax = brittle).
+Five `shell selection` tests are present but **skipped** (`Context ... -Skip`).
+They need to drive an interactive shell session (`pty-req + env + shell` over
+SSH) to verify that the configured executable was actually spawned. Win32-
+OpenSSH's `ssh.exe` with `-tt` and redirected stdin silently refuses to send
+`pty-req` — the channel opens and closes without ever invoking `ShellService`.
+Properly testing this end-to-end requires a custom probe built on
+`Microsoft.DevTunnels.Ssh` (e.g. a small `EgsShellProbe` console app). The
+selector logic itself is covered exhaustively by the unit-test suites:
+
+- `Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/DefaultShellSelectorTests.cs`
+  — env-var honoring + platform default
+- `Eryph.GuestServices.Service.Tests/KvpShellSelectorTests.cs` — full chain
+  (KVP > env > default), KVP-read failure handling, blank-value fall-through
 
 ## How the patch works
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -28,51 +28,17 @@ is already cached.
 
 ## What gets tested
 
-Eight tests in two contexts:
+Eight tests in two groups:
 
-- `set-shell tool command` (3): writes shell+shell-args, writes shell only
-  when no arguments are passed, `--reset` clears both keys. Use
-  `--arguments=-...` (with `=`) — Spectre.Console.Cli treats space-separated
-  `-`-prefixed values as new flags.
-- `shell selection` (5): default → `Windows PowerShell` banner; KVP override
-  → `pwsh` banner; SSH-sent `SHELL` env var → `pwsh`; KVP wins over SSH env;
-  `--reset` returns to default.
+- `set-shell tool command` — writes shell+shell-args, writes shell only,
+  `--reset` clears both keys.
+- `shell selection` — default spawns Windows PowerShell, KVP override
+  spawns `pwsh`, SSH-sent `SHELL` env var spawns `pwsh`, KVP wins over SSH
+  env, `--reset` returns to default.
 
-The shell-selection tests assert on the shell's startup banner
-(`Windows PowerShell` for `powershell.exe`, `PowerShell 7.x` for `pwsh.exe`).
-Banner matching avoids depending on driving input through PSReadLine, which
-is unreliable over a freshly-allocated ConPTY pipe before the shell finishes
-initializing.
+## Troubleshooting
 
-### Why a custom SSH client is required
-
-`ssh.exe -tt` (Win32-OpenSSH) writes channel output to the Windows console
-buffer via `WriteConsole`, not to redirected stdout. Three independent
-capture mechanisms (`Process.Start` redirection, PowerShell pipeline,
-`cmd /c < > 2>&1`) all return empty for an interactive shell session.
-
-`test/e2e/EgsShellProbe/` is a tiny self-contained console app that drives
-`pty-req` + `env` + `shell` directly via `Microsoft.DevTunnels.Ssh` — the
-same client library `egs-tool upload-file` uses — and pumps channel output
-to its stdout, which a script can capture normally. Same server, scriptable
-client.
-
-The selector logic itself is also covered by unit tests
-(`DefaultShellSelectorTests` + `KvpShellSelectorTests`, 13 tests total). The
-e2e suite verifies the wire-level behavior on top.
-
-## How the patch works
-
-`Update-EgsService` (in `Helpers.ps1`):
-
-1. `egs-tool upload-directory` pushes the `publish/` output to `C:\egs-staging`
-   in the VM (works while service is running).
-2. Uploads a `deploy.ps1` script alongside it.
-3. Triggers a one-shot scheduled task that runs the deploy script as `SYSTEM`.
-   The task is detached so the SSH session that triggered it can disconnect
-   when the service stops (the service *is* the SSH server).
-4. `Wait-Assert` polls `egs-tool get-status <vmId>` until `available` returns,
-   then probes `ssh hostname` once to confirm end-to-end.
-
-If a deploy fails, `C:\egs-staging\deploy.log` inside the VM has the timestamps
-of each step.
+- Set `$env:EGS_E2E_KEEP_VM=1` to leave the catlet running after the suite
+  finishes (or fails). Useful for post-mortem inspection via Hyper-V Manager.
+- If the service patch step times out, `C:\egs-staging\deploy.log` inside the
+  VM has timestamps of each deploy step.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,63 @@
+# Configurable-shell e2e tests
+
+End-to-end tests for the `set-shell` feature. They spin up a real Windows VM
+via eryph, replace the gene-installed `egs-service` with the locally-built
+binaries, and exercise the SHELL selection chain (KVP > SSH env > defaults).
+
+## Prerequisites
+
+- Windows host with Hyper-V enabled and eryph installed
+- `egs-tool initialize` has been run (host-side SSH key + integration service
+  registration)
+- PowerShell 7.4+
+- Network access to fetch the eryph genes
+  (`dbosoft/winsrv2022-standard/starter`, `dbosoft/guest-services:win-install`,
+  `dbosoft/powershell/1.2:win-install`) on first run
+
+## Run
+
+```powershell
+pwsh ./Run-E2ETests.ps1                       # winsrv2022
+pwsh ./Run-E2ETests.ps1 -OSVersion winsrv2025
+pwsh ./Run-E2ETests.ps1 -SkipBuild            # reuse existing publish output
+```
+
+The script `dotnet publish`s the service in `Release/win-x64`, then invokes
+Pester. A run takes roughly 8–15 minutes depending on whether the parent gene
+is already cached.
+
+## What gets tested
+
+Six tests in two groups:
+
+- `set-shell tool command`
+  - Writes shell + shell-args to the External KVP pool
+  - Writes only shell when no arguments are passed
+  - `--reset` clears both keys
+- `shell selection`
+  - Default: spawns Windows PowerShell (`powershell.exe`)
+  - KVP override: spawns `pwsh.exe`
+  - SSH-sent `SHELL` env var: spawns `pwsh.exe`
+  - KVP wins over SSH env
+  - `--reset` returns to default
+
+The shell-selection tests use `ssh -tt` with redirected stdin to feed a
+`Get-Process -Id $PID | Select-Object -ExpandProperty ProcessName` snippet
+into the interactive shell and assert on the captured output. `cmd.exe` as an
+override is documented but not e2e-tested (different shell syntax = brittle).
+
+## How the patch works
+
+`Update-EgsService` (in `Helpers.ps1`):
+
+1. `egs-tool upload-directory` pushes the `publish/` output to `C:\egs-staging`
+   in the VM (works while service is running).
+2. Uploads a `deploy.ps1` script alongside it.
+3. Triggers a one-shot scheduled task that runs the deploy script as `SYSTEM`.
+   The task is detached so the SSH session that triggered it can disconnect
+   when the service stops (the service *is* the SSH server).
+4. `Wait-Assert` polls `egs-tool get-status <vmId>` until `available` returns,
+   then probes `ssh hostname` once to confirm end-to-end.
+
+If a deploy fails, `C:\egs-staging\deploy.log` inside the VM has the timestamps
+of each step.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -30,15 +30,54 @@ is already cached.
 
 Eight tests in two groups:
 
-- `set-shell tool command` — writes shell+shell-args, writes shell only,
-  `--reset` clears both keys.
-- `shell selection` — default spawns Windows PowerShell, KVP override
-  spawns `pwsh`, SSH-sent `SHELL` env var spawns `pwsh`, KVP wins over SSH
-  env, `--reset` returns to default.
+- `set-shell tool command` (3): writes shell+shell-args, writes shell only
+  when no arguments are passed, `--reset` clears both keys. Use
+  `--arguments=-...` (with `=`) — Spectre.Console.Cli treats space-separated
+  `-`-prefixed values as new flags.
+- `shell selection` (5): default → `Windows PowerShell` banner; KVP override
+  → `pwsh` banner; SSH-sent `SHELL` env var → `pwsh`; KVP wins over SSH env;
+  `--reset` returns to default.
+
+The shell-selection tests assert on the shell's startup banner
+(`Windows PowerShell` for `powershell.exe`, `PowerShell 7.x` for `pwsh.exe`).
+Banner matching avoids depending on driving input through PSReadLine, which
+is unreliable over a freshly-allocated ConPTY pipe before the shell finishes
+initializing.
+
+### Why a custom SSH client is required
+
+`ssh.exe -tt` (Win32-OpenSSH) writes channel output to the Windows console
+buffer via `WriteConsole`, not to redirected stdout. Three independent
+capture mechanisms (`Process.Start` redirection, PowerShell pipeline,
+`cmd /c < > 2>&1`) all return empty for an interactive shell session.
+
+`test/e2e/EgsShellProbe/` is a tiny self-contained console app that drives
+`pty-req` + `env` + `shell` directly via `Microsoft.DevTunnels.Ssh` — the
+same client library `egs-tool upload-file` uses — and pumps channel output
+to its stdout, which a script can capture normally. Same server, scriptable
+client.
+
+The selector logic itself is also covered by unit tests
+(`DefaultShellSelectorTests` + `KvpShellSelectorTests`, 13 tests total). The
+e2e suite verifies the wire-level behavior on top.
+
+## How the patch works
+
+`Update-EgsService` (in `Helpers.ps1`):
+
+1. `egs-tool upload-directory` pushes the `publish/` output to `C:\egs-staging`
+   in the VM (works while service is running).
+2. Uploads a `deploy.ps1` script alongside it.
+3. Triggers a one-shot scheduled task that runs the deploy script as `SYSTEM`.
+   The task is detached so the SSH session that triggered it can disconnect
+   when the service stops (the service *is* the SSH server).
+4. `Wait-Assert` polls `egs-tool get-status <vmId>` until `available` returns,
+   then probes `ssh hostname` once to confirm end-to-end.
+
+If a deploy fails, `C:\egs-staging\deploy.log` inside the VM has the timestamps
+of each step.
 
 ## Troubleshooting
 
 - Set `$env:EGS_E2E_KEEP_VM=1` to leave the catlet running after the suite
   finishes (or fails). Useful for post-mortem inspection via Hyper-V Manager.
-- If the service patch step times out, `C:\egs-staging\deploy.log` inside the
-  VM has timestamps of each deploy step.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -28,27 +28,38 @@ is already cached.
 
 ## What gets tested
 
-Three active tests under `set-shell tool command`:
+Eight tests in two contexts:
 
-- Writes shell + shell-args to the External KVP pool (use `--arguments=-...`
-  syntax — Spectre.Console.Cli treats space-separated `-`-prefixed values as
-  new flags)
-- Writes only shell when no arguments are passed
-- `--reset` clears both keys
+- `set-shell tool command` (3): writes shell+shell-args, writes shell only
+  when no arguments are passed, `--reset` clears both keys. Use
+  `--arguments=-...` (with `=`) — Spectre.Console.Cli treats space-separated
+  `-`-prefixed values as new flags.
+- `shell selection` (5): default → `Windows PowerShell` banner; KVP override
+  → `pwsh` banner; SSH-sent `SHELL` env var → `pwsh`; KVP wins over SSH env;
+  `--reset` returns to default.
 
-Five `shell selection` tests are present but **skipped** (`Context ... -Skip`).
-They need to drive an interactive shell session (`pty-req + env + shell` over
-SSH) to verify that the configured executable was actually spawned. Win32-
-OpenSSH's `ssh.exe` with `-tt` and redirected stdin silently refuses to send
-`pty-req` — the channel opens and closes without ever invoking `ShellService`.
-Properly testing this end-to-end requires a custom probe built on
-`Microsoft.DevTunnels.Ssh` (e.g. a small `EgsShellProbe` console app). The
-selector logic itself is covered exhaustively by the unit-test suites:
+The shell-selection tests assert on the shell's startup banner
+(`Windows PowerShell` for `powershell.exe`, `PowerShell 7.x` for `pwsh.exe`).
+Banner matching avoids depending on driving input through PSReadLine, which
+is unreliable over a freshly-allocated ConPTY pipe before the shell finishes
+initializing.
 
-- `Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/DefaultShellSelectorTests.cs`
-  — env-var honoring + platform default
-- `Eryph.GuestServices.Service.Tests/KvpShellSelectorTests.cs` — full chain
-  (KVP > env > default), KVP-read failure handling, blank-value fall-through
+### Why a custom SSH client is required
+
+`ssh.exe -tt` (Win32-OpenSSH) writes channel output to the Windows console
+buffer via `WriteConsole`, not to redirected stdout. Three independent
+capture mechanisms (`Process.Start` redirection, PowerShell pipeline,
+`cmd /c < > 2>&1`) all return empty for an interactive shell session.
+
+`test/e2e/EgsShellProbe/` is a tiny self-contained console app that drives
+`pty-req` + `env` + `shell` directly via `Microsoft.DevTunnels.Ssh` — the
+same client library `egs-tool upload-file` uses — and pumps channel output
+to its stdout, which a script can capture normally. Same server, scriptable
+client.
+
+The selector logic itself is also covered by unit tests
+(`DefaultShellSelectorTests` + `KvpShellSelectorTests`, 13 tests total). The
+e2e suite verifies the wire-level behavior on top.
 
 ## How the patch works
 

--- a/test/e2e/Run-E2ETests.ps1
+++ b/test/e2e/Run-E2ETests.ps1
@@ -39,10 +39,15 @@ if (-not $SkipBuild) {
   Write-Host "Publishing egs-tool for win-x64 ..."
   dotnet publish "$PSScriptRoot/../../src/Eryph.GuestServices.Tool/Eryph.GuestServices.Tool.csproj" `
     -c Release -r win-x64 --nologo
+
+  Write-Host "Publishing egs-shell-probe for win-x64 ..."
+  dotnet publish "$PSScriptRoot/EgsShellProbe/EgsShellProbe.csproj" `
+    -c Release -r win-x64 --nologo
 }
 
 $publishPath = Resolve-Path "$PSScriptRoot/../../src/Eryph.GuestServices.Service/bin/Release/net10.0/win-x64/publish"
 $toolPublishPath = Resolve-Path "$PSScriptRoot/../../src/Eryph.GuestServices.Tool/bin/Release/net10.0-windows/win-x64/publish"
+$probePath = Resolve-Path "$PSScriptRoot/EgsShellProbe/bin/Release/net10.0-windows/win-x64/publish/egs-shell-probe.exe"
 
 # Use the locally-built egs-tool for this session — set-shell does not exist
 # in older system installs.
@@ -52,7 +57,11 @@ Write-Host "egs-tool version: $(egs-tool --version)"
 
 Write-Host "Running Pester suite ..."
 $container = New-PesterContainer -Path "$PSScriptRoot/Shell.E2E.Tests.ps1" `
-  -Data @{ OSVersion = $OSVersion; PublishPath = $publishPath.Path }
+  -Data @{
+    OSVersion = $OSVersion
+    PublishPath = $publishPath.Path
+    ProbePath = $probePath.Path
+  }
 
 $config = New-PesterConfiguration
 $config.Output.Verbosity = 'Detailed'

--- a/test/e2e/Run-E2ETests.ps1
+++ b/test/e2e/Run-E2ETests.ps1
@@ -1,0 +1,54 @@
+#Requires -Version 7.4
+<#
+.SYNOPSIS
+  Runs the configurable-shell e2e tests against a fresh eryph catlet.
+
+.DESCRIPTION
+  Builds the egs-service in Release/win-x64, spins up a Windows VM via eryph,
+  patches the gene-installed service with the locally-built binaries, then
+  runs the Pester suite. Tear-down (catlet + project) happens in AfterAll.
+
+  Requires:
+    - PowerShell 7.4+
+    - eryph host with `egs-tool initialize` already run
+    - Pester 5.x, Eryph.ComputeClient module
+    - Hyper-V VM with the `dbosoft/$OSVersion-standard/starter` parent gene
+      cached locally
+#>
+param (
+    [Parameter()]
+    [ValidateSet('winsrv2019', 'winsrv2022', 'winsrv2025')]
+    [string] $OSVersion = 'winsrv2022',
+
+    [Parameter()]
+    [switch] $SkipBuild
+)
+
+$PSNativeCommandUseErrorActionPreference = $true
+$ErrorActionPreference = 'Stop'
+
+Write-Host "Installing required PowerShell modules ..."
+Install-Module -Name Pester -MinimumVersion 5.5 -Force -Scope CurrentUser -SkipPublisherCheck
+Install-Module -Name Eryph.ComputeClient -Force -Scope CurrentUser
+
+if (-not $SkipBuild) {
+  Write-Host "Publishing egs-service for win-x64 ..."
+  dotnet publish "$PSScriptRoot/../../src/Eryph.GuestServices.Service/Eryph.GuestServices.Service.csproj" `
+    -c Release -r win-x64 --nologo
+}
+
+$publishPath = Resolve-Path "$PSScriptRoot/../../src/Eryph.GuestServices.Service/bin/Release/net10.0/win-x64/publish"
+
+Write-Host "Running Pester suite ..."
+$container = New-PesterContainer -Path "$PSScriptRoot/Shell.E2E.Tests.ps1" `
+  -Data @{ OSVersion = $OSVersion; PublishPath = $publishPath.Path }
+
+$config = New-PesterConfiguration
+$config.Output.Verbosity = 'Detailed'
+$config.Run.Container = $container
+$config.Run.Exit = $true
+$config.TestResult.Enabled = $true
+$config.TestResult.OutputFormat = 'NUnit3'
+$config.TestResult.OutputPath = "$PSScriptRoot/TEST-pesterResults.xml"
+
+Invoke-Pester -Configuration $config

--- a/test/e2e/Run-E2ETests.ps1
+++ b/test/e2e/Run-E2ETests.ps1
@@ -35,9 +35,20 @@ if (-not $SkipBuild) {
   Write-Host "Publishing egs-service for win-x64 ..."
   dotnet publish "$PSScriptRoot/../../src/Eryph.GuestServices.Service/Eryph.GuestServices.Service.csproj" `
     -c Release -r win-x64 --nologo
+
+  Write-Host "Publishing egs-tool for win-x64 ..."
+  dotnet publish "$PSScriptRoot/../../src/Eryph.GuestServices.Tool/Eryph.GuestServices.Tool.csproj" `
+    -c Release -r win-x64 --nologo
 }
 
 $publishPath = Resolve-Path "$PSScriptRoot/../../src/Eryph.GuestServices.Service/bin/Release/net10.0/win-x64/publish"
+$toolPublishPath = Resolve-Path "$PSScriptRoot/../../src/Eryph.GuestServices.Tool/bin/Release/net10.0-windows/win-x64/publish"
+
+# Use the locally-built egs-tool for this session — set-shell does not exist
+# in older system installs.
+$env:Path = "$($toolPublishPath.Path);$env:Path"
+Write-Host "Using egs-tool from: $toolPublishPath"
+Write-Host "egs-tool version: $(egs-tool --version)"
 
 Write-Host "Running Pester suite ..."
 $container = New-PesterContainer -Path "$PSScriptRoot/Shell.E2E.Tests.ps1" `

--- a/test/e2e/Shell.E2E.Tests.ps1
+++ b/test/e2e/Shell.E2E.Tests.ps1
@@ -7,7 +7,10 @@ param (
     [string] $OSVersion = 'winsrv2022',
 
     [Parameter()]
-    [string] $PublishPath
+    [string] $PublishPath,
+
+    [Parameter()]
+    [string] $ProbePath
 )
 
 BeforeAll {
@@ -24,6 +27,11 @@ BeforeAll {
     $PublishPath = "$PSScriptRoot/../../src/Eryph.GuestServices.Service/bin/Release/net10.0/win-x64/publish"
   }
   $resolvedPublishPath = (Resolve-Path -LiteralPath $PublishPath).Path
+
+  if (-not $ProbePath) {
+    $ProbePath = "$PSScriptRoot/EgsShellProbe/bin/Release/net10.0-windows/win-x64/publish/egs-shell-probe.exe"
+  }
+  $resolvedProbePath = (Resolve-Path -LiteralPath $ProbePath).Path
 
   $project = New-TestProject
   $catletName = New-CatletName
@@ -89,60 +97,64 @@ Describe 'Configurable shell' {
     }
   }
 
-  # The shell-selection tests below need to drive an interactive shell session
-  # (channel: pty-req + env + shell). Win32-OpenSSH's ssh.exe with `-tt` and
-  # redirected stdin silently refuses to send pty-req — the channel opens and
-  # closes immediately without ever invoking ShellService. Properly testing
-  # this end-to-end requires a custom probe built on Microsoft.DevTunnels.Ssh
-  # (e.g. a small `EgsShellProbe` console app). The selector logic itself is
-  # covered exhaustively by the unit tests in
-  # `Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests` and
-  # `Eryph.GuestServices.Service.Tests`.
-  Context 'shell selection' -Skip {
+  # The shell-selection tests use the EgsShellProbe instead of ssh.exe. ssh
+  # in Win32-OpenSSH writes channel output to the Windows console buffer, not
+  # stdout, so a redirected ssh.exe captures nothing. The probe drives the
+  # SSH protocol directly via Microsoft.DevTunnels.Ssh and pumps channel
+  # output to its stdout, which a script can capture normally.
+  # Shell-selection assertions match against the shell's startup banner:
+  #   - powershell.exe (Windows PowerShell 5.1) prints "Windows PowerShell"
+  #   - pwsh.exe       (PowerShell 7+)          prints "PowerShell 7."
+  # This avoids depending on driving input through PSReadLine over a
+  # freshly-allocated ConPTY pipe, which is unreliable. Patterns are
+  # inlined per test because Pester v5 doesn't propagate variables defined
+  # in a Context body to the run-phase It blocks.
+  Context 'shell selection' {
 
     It 'spawns Windows PowerShell when no override is set' {
-      $output = Invoke-InteractiveShell -HostName $hostName `
-        -InputLines @('"EGS-MARKER-START:" + (Get-Process -Id $PID).ProcessName + ":EGS-MARKER-END"')
+      $output = Invoke-EgsShellProbe -ProbePath $resolvedProbePath -VmId $catlet.VmId `
+        -TimeoutMs 6000
 
-      $output | Should -Match 'EGS-MARKER-START:powershell:EGS-MARKER-END'
+      $output | Should -Match 'Windows PowerShell'
+      $output | Should -Not -Match 'PowerShell 7\.'
     }
 
     It 'spawns pwsh when KVP override is set' {
       egs-tool set-shell $catlet.VmId --command 'pwsh.exe' | Out-Null
 
-      $output = Invoke-InteractiveShell -HostName $hostName `
-        -InputLines @('"EGS-MARKER-START:" + (Get-Process -Id $PID).ProcessName + ":EGS-MARKER-END"')
+      $output = Invoke-EgsShellProbe -ProbePath $resolvedProbePath -VmId $catlet.VmId `
+        -TimeoutMs 6000
 
-      $output | Should -Match 'EGS-MARKER-START:pwsh:EGS-MARKER-END'
+      $output | Should -Match 'PowerShell 7\.'
     }
 
     It 'spawns pwsh when SSH-sent SHELL env var is set (no KVP override)' {
-      $output = Invoke-InteractiveShell -HostName $hostName `
+      $output = Invoke-EgsShellProbe -ProbePath $resolvedProbePath -VmId $catlet.VmId `
         -SetEnv @{ SHELL = 'pwsh.exe' } `
-        -InputLines @('"EGS-MARKER-START:" + (Get-Process -Id $PID).ProcessName + ":EGS-MARKER-END"')
+        -TimeoutMs 6000
 
-      $output | Should -Match 'EGS-MARKER-START:pwsh:EGS-MARKER-END'
+      $output | Should -Match 'PowerShell 7\.'
     }
 
     It 'KVP override wins over SSH-sent SHELL env' {
       egs-tool set-shell $catlet.VmId --command 'pwsh.exe' | Out-Null
 
-      # Try to override with a different shell via env — KVP must win.
-      $output = Invoke-InteractiveShell -HostName $hostName `
+      $output = Invoke-EgsShellProbe -ProbePath $resolvedProbePath -VmId $catlet.VmId `
         -SetEnv @{ SHELL = 'powershell.exe' } `
-        -InputLines @('"EGS-MARKER-START:" + (Get-Process -Id $PID).ProcessName + ":EGS-MARKER-END"')
+        -TimeoutMs 6000
 
-      $output | Should -Match 'EGS-MARKER-START:pwsh:EGS-MARKER-END'
+      $output | Should -Match 'PowerShell 7\.'
     }
 
     It 'returns to default after --reset' {
       egs-tool set-shell $catlet.VmId --command 'pwsh.exe' | Out-Null
       egs-tool set-shell $catlet.VmId --reset | Out-Null
 
-      $output = Invoke-InteractiveShell -HostName $hostName `
-        -InputLines @('"EGS-MARKER-START:" + (Get-Process -Id $PID).ProcessName + ":EGS-MARKER-END"')
+      $output = Invoke-EgsShellProbe -ProbePath $resolvedProbePath -VmId $catlet.VmId `
+        -TimeoutMs 6000
 
-      $output | Should -Match 'EGS-MARKER-START:powershell:EGS-MARKER-END'
+      $output | Should -Match 'Windows PowerShell'
+      $output | Should -Not -Match 'PowerShell 7\.'
     }
   }
 }

--- a/test/e2e/Shell.E2E.Tests.ps1
+++ b/test/e2e/Shell.E2E.Tests.ps1
@@ -38,6 +38,11 @@ BeforeAll {
 }
 
 AfterAll {
+  # Set $env:EGS_E2E_KEEP_VM=1 to keep the catlet for post-mortem inspection.
+  if ($env:EGS_E2E_KEEP_VM) {
+    Write-Host "EGS_E2E_KEEP_VM is set — leaving catlet $($catlet.Name) (project $($project.Name)) for inspection."
+    return
+  }
   if ($catlet) {
     Remove-Catlet -Id $catlet.Id -Force -ErrorAction SilentlyContinue
   }
@@ -56,7 +61,10 @@ Describe 'Configurable shell' {
   Context 'set-shell tool command' {
 
     It 'writes shell and shell-args to the External KVP pool' {
-      egs-tool set-shell $catlet.VmId --command 'pwsh.exe' --arguments '-NoLogo -NoProfile' | Out-Null
+      # Spectre.Console.Cli treats `--arguments -NoLogo` as two flags
+      # (the value '-NoLogo' is interpreted as an option). The `=` form
+      # binds the value unambiguously.
+      egs-tool set-shell $catlet.VmId --command 'pwsh.exe' --arguments='-NoLogo -NoProfile' | Out-Null
 
       $data = egs-tool get-data --json $catlet.VmId | ConvertFrom-Json -AsHashtable
       $data.external.'eryph:guest-services:shell' | Should -Be 'pwsh.exe'
@@ -72,7 +80,7 @@ Describe 'Configurable shell' {
     }
 
     It '--reset clears both keys' {
-      egs-tool set-shell $catlet.VmId --command 'pwsh.exe' --arguments '-x' | Out-Null
+      egs-tool set-shell $catlet.VmId --command 'pwsh.exe' --arguments='-x' | Out-Null
       egs-tool set-shell $catlet.VmId --reset | Out-Null
 
       $data = egs-tool get-data --json $catlet.VmId | ConvertFrom-Json -AsHashtable
@@ -81,7 +89,16 @@ Describe 'Configurable shell' {
     }
   }
 
-  Context 'shell selection' {
+  # The shell-selection tests below need to drive an interactive shell session
+  # (channel: pty-req + env + shell). Win32-OpenSSH's ssh.exe with `-tt` and
+  # redirected stdin silently refuses to send pty-req — the channel opens and
+  # closes immediately without ever invoking ShellService. Properly testing
+  # this end-to-end requires a custom probe built on Microsoft.DevTunnels.Ssh
+  # (e.g. a small `EgsShellProbe` console app). The selector logic itself is
+  # covered exhaustively by the unit tests in
+  # `Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests` and
+  # `Eryph.GuestServices.Service.Tests`.
+  Context 'shell selection' -Skip {
 
     It 'spawns Windows PowerShell when no override is set' {
       $output = Invoke-InteractiveShell -HostName $hostName `

--- a/test/e2e/Shell.E2E.Tests.ps1
+++ b/test/e2e/Shell.E2E.Tests.ps1
@@ -1,0 +1,131 @@
+#Requires -Version 7.4
+#Requires -Module Pester
+#Requires -Module Eryph.ComputeClient
+param (
+    [Parameter()]
+    [ValidateSet('winsrv2019', 'winsrv2022', 'winsrv2025')]
+    [string] $OSVersion = 'winsrv2022',
+
+    [Parameter()]
+    [string] $PublishPath
+)
+
+BeforeAll {
+  $PSNativeCommandUseErrorActionPreference = $true
+  $ErrorActionPreference = 'Stop'
+  . $PSScriptRoot/Helpers.ps1
+
+  $catletConfigTemplate = Get-Content -Raw -Path $PSScriptRoot/catlet.yaml
+  $catletConfig = $catletConfigTemplate `
+    -replace '<<PARENT>>', "dbosoft/$OSVersion-standard/starter" `
+    -replace '<<SSH_PUBLIC_KEY>>', "$(egs-tool get-ssh-key)"
+
+  if (-not $PublishPath) {
+    $PublishPath = "$PSScriptRoot/../../src/Eryph.GuestServices.Service/bin/Release/net10.0/win-x64/publish"
+  }
+  $resolvedPublishPath = (Resolve-Path -LiteralPath $PublishPath).Path
+
+  $project = New-TestProject
+  $catletName = New-CatletName
+  Write-Host "Creating catlet $catletName in project $($project.Name) ..."
+
+  $catlet = New-Catlet -Config $catletConfig -Name $catletName `
+    -ProjectName $project.Name -SkipVariablesPrompt
+  $hostName = "$($catlet.Id).eryph.alt"
+
+  Connect-Catlet -Id $catlet.Id
+  Update-EgsService -Catlet $catlet -PublishPath $resolvedPublishPath
+}
+
+AfterAll {
+  if ($catlet) {
+    Remove-Catlet -Id $catlet.Id -Force -ErrorAction SilentlyContinue
+  }
+  if ($project) {
+    Remove-EryphProject -Id $project.Id -Force -ErrorAction SilentlyContinue
+  }
+}
+
+Describe 'Configurable shell' {
+
+  AfterEach {
+    # Make sure no shell override leaks across tests.
+    egs-tool set-shell $catlet.VmId --reset | Out-Null
+  }
+
+  Context 'set-shell tool command' {
+
+    It 'writes shell and shell-args to the External KVP pool' {
+      egs-tool set-shell $catlet.VmId --command 'pwsh.exe' --arguments '-NoLogo -NoProfile' | Out-Null
+
+      $data = egs-tool get-data --json $catlet.VmId | ConvertFrom-Json -AsHashtable
+      $data.external.'eryph:guest-services:shell' | Should -Be 'pwsh.exe'
+      $data.external.'eryph:guest-services:shell-args' | Should -Be '-NoLogo -NoProfile'
+    }
+
+    It 'writes only shell when no arguments are passed' {
+      egs-tool set-shell $catlet.VmId --command 'pwsh.exe' | Out-Null
+
+      $data = egs-tool get-data --json $catlet.VmId | ConvertFrom-Json -AsHashtable
+      $data.external.'eryph:guest-services:shell' | Should -Be 'pwsh.exe'
+      $data.external.ContainsKey('eryph:guest-services:shell-args') | Should -BeFalse
+    }
+
+    It '--reset clears both keys' {
+      egs-tool set-shell $catlet.VmId --command 'pwsh.exe' --arguments '-x' | Out-Null
+      egs-tool set-shell $catlet.VmId --reset | Out-Null
+
+      $data = egs-tool get-data --json $catlet.VmId | ConvertFrom-Json -AsHashtable
+      $data.external.ContainsKey('eryph:guest-services:shell') | Should -BeFalse
+      $data.external.ContainsKey('eryph:guest-services:shell-args') | Should -BeFalse
+    }
+  }
+
+  Context 'shell selection' {
+
+    It 'spawns Windows PowerShell when no override is set' {
+      $output = Invoke-InteractiveShell -HostName $hostName `
+        -InputLines @('"EGS-MARKER-START:" + (Get-Process -Id $PID).ProcessName + ":EGS-MARKER-END"')
+
+      $output | Should -Match 'EGS-MARKER-START:powershell:EGS-MARKER-END'
+    }
+
+    It 'spawns pwsh when KVP override is set' {
+      egs-tool set-shell $catlet.VmId --command 'pwsh.exe' | Out-Null
+
+      $output = Invoke-InteractiveShell -HostName $hostName `
+        -InputLines @('"EGS-MARKER-START:" + (Get-Process -Id $PID).ProcessName + ":EGS-MARKER-END"')
+
+      $output | Should -Match 'EGS-MARKER-START:pwsh:EGS-MARKER-END'
+    }
+
+    It 'spawns pwsh when SSH-sent SHELL env var is set (no KVP override)' {
+      $output = Invoke-InteractiveShell -HostName $hostName `
+        -SetEnv @{ SHELL = 'pwsh.exe' } `
+        -InputLines @('"EGS-MARKER-START:" + (Get-Process -Id $PID).ProcessName + ":EGS-MARKER-END"')
+
+      $output | Should -Match 'EGS-MARKER-START:pwsh:EGS-MARKER-END'
+    }
+
+    It 'KVP override wins over SSH-sent SHELL env' {
+      egs-tool set-shell $catlet.VmId --command 'pwsh.exe' | Out-Null
+
+      # Try to override with a different shell via env — KVP must win.
+      $output = Invoke-InteractiveShell -HostName $hostName `
+        -SetEnv @{ SHELL = 'powershell.exe' } `
+        -InputLines @('"EGS-MARKER-START:" + (Get-Process -Id $PID).ProcessName + ":EGS-MARKER-END"')
+
+      $output | Should -Match 'EGS-MARKER-START:pwsh:EGS-MARKER-END'
+    }
+
+    It 'returns to default after --reset' {
+      egs-tool set-shell $catlet.VmId --command 'pwsh.exe' | Out-Null
+      egs-tool set-shell $catlet.VmId --reset | Out-Null
+
+      $output = Invoke-InteractiveShell -HostName $hostName `
+        -InputLines @('"EGS-MARKER-START:" + (Get-Process -Id $PID).ProcessName + ":EGS-MARKER-END"')
+
+      $output | Should -Match 'EGS-MARKER-START:powershell:EGS-MARKER-END'
+    }
+  }
+}

--- a/test/e2e/catlet.yaml
+++ b/test/e2e/catlet.yaml
@@ -1,0 +1,13 @@
+name: shell-e2e
+parent: <<PARENT>>
+cpu:
+  count: 2
+memory:
+  startup: 2048
+fodder:
+  - source: gene:dbosoft/guest-services:win-install
+    variables:
+      - name: sshPublicKey
+        value: <<SSH_PUBLIC_KEY>>
+  # PowerShell 7+ is needed for the pwsh.exe override scenario.
+  - source: gene:dbosoft/powershell/1.2:win-install


### PR DESCRIPTION
## Summary

Closes #22.

Adds a per-VM and per-session override for the shell that the egs SSH server spawns for interactive sessions. Supplements the existing hardcoded default (`powershell.exe -WindowStyle Hidden` on Windows, `$SHELL` or `/bin/bash -i` on Linux).

Selection chain (highest priority first):

1. KVP `eryph:guest-services:shell` / `:shell-args` from the External pool — set per-VM via `egs-tool set-shell`
2. SSH-sent env vars `SHELL` / `SHELL_ARGS` — per-session, e.g. `ssh -o "SetEnv=SHELL=pwsh.exe" …`
3. Process env `$SHELL` (Linux only — preserves current behavior)
4. Hardcoded platform defaults

## Tool

```
egs-tool set-shell <VM-ID> --command pwsh.exe [--arguments="-NoLogo -NoProfile"]
egs-tool set-shell <VM-ID> --reset
```

The `=` syntax for `--arguments` is necessary because Spectre.Console.Cli treats space-separated `-`-prefixed values as new flags.

## Code shape

- New `IShellSelector` abstraction in `Eryph.GuestServices.DevTunnels.Ssh.Extensions` with two implementations:
  - `DefaultShellSelector` (env-var honoring + platform default; used standalone)
  - `KvpShellSelector` (full chain via `IGuestDataExchange`; registered in the Service)
- `ShellService` now activates on `env` channel requests too (new `EnvironmentVariableRequestMessage` per RFC 4254 §6.4) and uses Microsoft.DevTunnels.Ssh's documented 2-arg ctor activation to receive the selector via `config.Services.Add(typeof(ShellService), shellSelector)`.
- `PtyForwarder` now consults the selector at shell-start time, snapshotting the per-channel SSH env dict.
- New `egs-tool set-shell` command + Spectre.Console.Cli registration.

## Package bumps (required for .NET 10 self-contained publishes)

PR #24 only ran `dotnet build`; nothing actually `publish`ed self-contained until this branch's e2e flow tried to. The published binaries crashed with `MissingMethodException: IAsyncStateMachine.SetStateMachine` because `Microsoft.Bcl.AsyncInterfaces` 8.0.0 (transitive via `Microsoft.Extensions.Hosting` 8.0.1 / explicit in egs-tool) shadows the .NET 10 BCL type forwarder. Fixed:

- `Microsoft.Bcl.AsyncInterfaces` → 10.0.7 (kept explicit in egs-tool because `Eryph.ComputeClient` 0.13.0 expects it by name)
- `Microsoft.Extensions.Hosting` / `Hosting.Systemd` / `Hosting.WindowsServices` / `Logging` → 10.0.7

These are bug fixes for #24, not feature work, but folded in here because the e2e tests can't run without them.

## Tests

### Unit (16 new, run on every build)
- `DefaultShellSelectorTests` (6) — SSH env honoring, blank fall-through, platform-default sanity per OS
- `KvpShellSelectorTests` (7) — KVP > SSH env > default chain, KVP-read-failure fallback, blank-KVP fall-through

### Pester e2e (8 tests, ~3.5 min, manual via `test/e2e/Run-E2ETests.ps1`)
- `set-shell tool command` (3): KVP write — both keys / shell only / `--reset`
- `shell selection` (5): default → `Windows PowerShell`, KVP → `pwsh`, SSH env → `pwsh`, KVP wins over env, `--reset` → default

The e2e flow spins up a Windows catlet via eryph, patches the gene-installed service with the locally-built binaries via a detached scheduled task (so the SSH session that triggers the patch can disconnect cleanly when the service stops), then exercises both the tool and the wire.

#### EgsShellProbe

Win32-OpenSSH `ssh.exe -tt` is unreliable as a script-driven shell client on Windows: it writes channel output to the console buffer via `WriteConsole`, not to redirected stdout. Three independent capture mechanisms (Process.Start, PowerShell pipeline, `cmd /c < > 2>&1`) all return empty. The verbose log confirms the protocol exchange completes successfully — only the local-side capture fails.

`test/e2e/EgsShellProbe/` is a ~150 LoC self-contained console app that drives `pty-req` + `env` + `shell` via `Microsoft.DevTunnels.Ssh` (the same client library `egs-tool upload-file` uses) and pumps channel output to stdout. Same server, scriptable client. Tests assert on the shell's startup banner (`Windows PowerShell` vs `PowerShell 7.`) — reliable and doesn't depend on driving input through PSReadLine.

## Test plan

- [x] `dotnet build` — 0 errors, 0 IL warnings
- [x] `dotnet test` — 26/26 unit tests pass
- [x] `dotnet publish` for `egs-service` (win-x64 + linux-x64) and `egs-tool` (win-x64) — both run
- [x] `pwsh test/e2e/Run-E2ETests.ps1` — 8/8 pass against a real eryph catlet
- [ ] Manual smoke: `ssh some-catlet.eryph.alt` lands in the configured shell (Windows + Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)