### PR TITLE
Fix OperationCanceledException on service shutdown

### DIFF
--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/SocketSshServer.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/SocketSshServer.cs
@@ -29,8 +29,17 @@ public sealed class SocketSshServer(SshSessionConfiguration config, TraceSource 
     {
         while (!_disposeCancellationTokenSource.IsCancellationRequested)
         {
-            var socket = await serverSocket.AcceptAsync(_disposeCancellationTokenSource.Token)
-                .ConfigureAwait(false);
+            Socket socket;
+            try
+            {
+                socket = await serverSocket.AcceptAsync(_disposeCancellationTokenSource.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+                when (_disposeCancellationTokenSource.IsCancellationRequested)
+            {
+                return;
+            }
             ConfigureSocketOptionsForSsh(socket);
             var session = new SshServerSession(config, trace);
             

--- a/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/ServerTests.cs
+++ b/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/ServerTests.cs
@@ -57,4 +57,20 @@ public class ServerTests
         var isAuthenticated = await clientSession.AuthenticateAsync(new SshClientCredentials("egs-test", clientKeyPair));
         isAuthenticated.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task AcceptSessionsAsync_CompletesGracefully_WhenServerDisposed()
+    {
+        var serviceId = PortNumberConverter.ToIntegrationId(42425);
+        var config = new SshSessionConfiguration();
+
+        var server = new SocketSshServer(config, new TraceSource("Server"));
+        using var serverSocket = await SocketFactory.CreateServerSocket(ListenMode.Loopback, serviceId, 1);
+        var listenTask = server.AcceptSessionsAsync(serverSocket);
+
+        server.Dispose();
+
+        await listenTask.WaitAsync(TimeSpan.FromSeconds(5));
+        listenTask.IsCompletedSuccessfully.Should().BeTrue();
+    }
 }

--- a/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/ServerTests.cs
+++ b/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/ServerTests.cs
@@ -64,7 +64,7 @@ public class ServerTests
         var serviceId = PortNumberConverter.ToIntegrationId(42425);
         var config = new SshSessionConfiguration();
 
-        var server = new SocketSshServer(config, new TraceSource("Server"));
+        using var server = new SocketSshServer(config, new TraceSource("Server"));
         using var serverSocket = await SocketFactory.CreateServerSocket(ListenMode.Loopback, serviceId, 1);
         var listenTask = server.AcceptSessionsAsync(serverSocket);
 


### PR DESCRIPTION
Fixes #17.

`SocketSshServer.Dispose()` cancels the accept loop's token, which propagated an `OperationCanceledException` out of `_listenTask` during `StopAsync`. Now caught in `AcceptSessionsAsync` so the task completes cleanly.