### PR TITLE
Advertise service features and gate set-shell

### DIFF
--- a/src/Eryph.GuestServices.Core/Constants.cs
+++ b/src/Eryph.GuestServices.Core/Constants.cs
@@ -23,6 +23,19 @@ public static class Constants
 
     public static readonly string VersionKey = "eryph:guest-services:version";
 
+    /// <summary>
+    /// The KVP key (Guest pool) where the service advertises supported optional
+    /// features as a space-separated list. Hosts/tools should check this before
+    /// using a feature that may be missing on older services.
+    /// </summary>
+    public static readonly string FeaturesKey = "eryph:guest-services:features";
+
+    /// <summary>
+    /// Feature flag advertised by services that honor the shell override KVP
+    /// keys (<see cref="ShellKey"/>, <see cref="ShellArgsKey"/>).
+    /// </summary>
+    public static readonly string ShellOverrideFeature = "shell-override";
+
     public static readonly string ClientAuthKey = "eryph:guest-services:client-public-key";
 
     /// <summary>

--- a/src/Eryph.GuestServices.Service/Services/SshServerService.cs
+++ b/src/Eryph.GuestServices.Service/Services/SshServerService.cs
@@ -131,7 +131,13 @@ internal sealed class SshServerService(
             [Constants.StatusKey] = status,
             [Constants.VersionKey] = GitVersionInformation.SemVer,
             [Constants.OperatingSystemKey] = RuntimeInformation.OSDescription,
+            [Constants.FeaturesKey] = string.Join(' ', SupportedFeatures),
         };
         await guestDataExchange.SetGuestValuesAsync(values);
     }
+
+    private static readonly string[] SupportedFeatures =
+    [
+        Constants.ShellOverrideFeature,
+    ];
 }

--- a/src/Eryph.GuestServices.Service/Services/SshServerService.cs
+++ b/src/Eryph.GuestServices.Service/Services/SshServerService.cs
@@ -126,12 +126,17 @@ internal sealed class SshServerService(
 
     private async Task SetStatusAsync(string? status)
     {
+        // FeaturesKey is cleared on shutdown so capability discovery stays
+        // honest after a downgrade. A pre-features service does not write
+        // this key, so without explicit removal the previous version's
+        // feature list would remain visible to the host and make tools
+        // think a feature is supported when it isn't.
         var values = new Dictionary<string, string?>
         {
             [Constants.StatusKey] = status,
             [Constants.VersionKey] = GitVersionInformation.SemVer,
             [Constants.OperatingSystemKey] = RuntimeInformation.OSDescription,
-            [Constants.FeaturesKey] = string.Join(' ', SupportedFeatures),
+            [Constants.FeaturesKey] = status is null ? null : string.Join(' ', SupportedFeatures),
         };
         await guestDataExchange.SetGuestValuesAsync(values);
     }

--- a/src/Eryph.GuestServices.Tool/Commands/SetShellCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/SetShellCommand.cs
@@ -47,15 +47,21 @@ public class SetShellCommand : AsyncCommand<SetShellCommand.Settings>
 
         var hostDataExchange = new HostDataExchange();
 
-        var guestData = await hostDataExchange.GetGuestDataAsync(settings.VmId);
-        guestData.TryGetValue(Constants.FeaturesKey, out var features);
-        if (!HasFeature(features, Constants.ShellOverrideFeature))
+        // The feature gate only applies to setting an override. Clearing is
+        // always safe — it may be needed to remove stale keys left over from
+        // a downgrade, when the current service does not advertise the feature.
+        if (!settings.Reset)
         {
-            AnsiConsole.MarkupLineInterpolated(
-                $"[red]The guest service in VM {settings.VmId} does not support the '{Constants.ShellOverrideFeature}' feature.[/]");
-            AnsiConsole.MarkupLine(
-                "[red]Ensure the VM is running and the installed eryph guest services version supports configurable shells.[/]");
-            return -1;
+            var guestData = await hostDataExchange.GetGuestDataAsync(settings.VmId);
+            guestData.TryGetValue(Constants.FeaturesKey, out var features);
+            if (!HasFeature(features, Constants.ShellOverrideFeature))
+            {
+                AnsiConsole.MarkupLineInterpolated(
+                    $"[red]The guest service in VM {settings.VmId} does not support the '{Constants.ShellOverrideFeature}' feature.[/]");
+                AnsiConsole.MarkupLine(
+                    "[red]Ensure the VM is running and the installed eryph guest services version supports configurable shells.[/]");
+                return -1;
+            }
         }
 
         var values = new Dictionary<string, string?>
@@ -85,7 +91,7 @@ public class SetShellCommand : AsyncCommand<SetShellCommand.Settings>
         return 0;
     }
 
-    private static bool HasFeature(string? featureList, string feature)
+    internal static bool HasFeature(string? featureList, string feature)
     {
         if (string.IsNullOrWhiteSpace(featureList))
             return false;

--- a/src/Eryph.GuestServices.Tool/Commands/SetShellCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/SetShellCommand.cs
@@ -45,13 +45,25 @@ public class SetShellCommand : AsyncCommand<SetShellCommand.Settings>
         var command = string.IsNullOrWhiteSpace(settings.Command) ? null : settings.Command.Trim();
         var arguments = string.IsNullOrWhiteSpace(settings.Arguments) ? null : settings.Arguments.Trim();
 
+        var hostDataExchange = new HostDataExchange();
+
+        var guestData = await hostDataExchange.GetGuestDataAsync(settings.VmId);
+        guestData.TryGetValue(Constants.FeaturesKey, out var features);
+        if (!HasFeature(features, Constants.ShellOverrideFeature))
+        {
+            AnsiConsole.MarkupLineInterpolated(
+                $"[red]The guest service in VM {settings.VmId} does not support the '{Constants.ShellOverrideFeature}' feature.[/]");
+            AnsiConsole.MarkupLine(
+                "[red]Ensure the VM is running and the installed eryph guest services version supports configurable shells.[/]");
+            return -1;
+        }
+
         var values = new Dictionary<string, string?>
         {
             [Constants.ShellKey] = settings.Reset ? null : command,
             [Constants.ShellArgsKey] = settings.Reset ? null : arguments,
         };
 
-        var hostDataExchange = new HostDataExchange();
         await hostDataExchange.SetExternalValuesAsync(settings.VmId, values);
 
         if (settings.Reset)
@@ -71,5 +83,18 @@ public class SetShellCommand : AsyncCommand<SetShellCommand.Settings>
         }
 
         return 0;
+    }
+
+    private static bool HasFeature(string? featureList, string feature)
+    {
+        if (string.IsNullOrWhiteSpace(featureList))
+            return false;
+
+        foreach (var entry in featureList.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (string.Equals(entry, feature, StringComparison.Ordinal))
+                return true;
+        }
+        return false;
     }
 }

--- a/test/Eryph.GuestServices.Tool.Tests/SetShellCommandTests.cs
+++ b/test/Eryph.GuestServices.Tool.Tests/SetShellCommandTests.cs
@@ -1,0 +1,23 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.Tool.Commands;
+
+namespace Eryph.GuestServices.Tool.Tests;
+
+public class SetShellCommandTests
+{
+    [Theory]
+    [InlineData("shell-override", "shell-override", true)]
+    [InlineData("other shell-override more", "shell-override", true)]
+    [InlineData("  shell-override   ", "shell-override", true)]
+    [InlineData("a  b  shell-override", "shell-override", true)]
+    [InlineData("other", "shell-override", false)]
+    [InlineData("", "shell-override", false)]
+    [InlineData("   ", "shell-override", false)]
+    [InlineData(null, "shell-override", false)]
+    [InlineData("Shell-Override", "shell-override", false)]
+    [InlineData("shell-override-extra", "shell-override", false)]
+    public void HasFeature_ParsesSpaceSeparatedList(string? featureList, string feature, bool expected)
+    {
+        SetShellCommand.HasFeature(featureList, feature).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
The service now publishes supported optional features via the `eryph:guest-services:features` KVP key (space-separated). Initial entry: `shell-override`.

`set-shell` reads the guest data first and fails with a clear error when the feature isn't advertised, instead of silently writing override keys that an older service ignores.