### PR TITLE
Fix SSH interactive session hang on logout (0.3.x backport)

### DIFF
--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Eryph.GuestServices.DevTunnels.Ssh.Extensions.csproj
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Eryph.GuestServices.DevTunnels.Ssh.Extensions.csproj
@@ -11,6 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Eryph.GuestServices.Core\Eryph.GuestServices.Core.csproj" />
     <ProjectReference Include="..\Eryph.GuestServices.Pty\Eryph.GuestServices.Pty.csproj" />
   </ItemGroup>

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
@@ -75,20 +75,66 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
 
     private async Task RunAsync(SshStream stream, IPty pty)
     {
-        // ConPTY emits final reset sequences asynchronously after the child exits.
-        // Drain them before CHANNEL_CLOSE — otherwise they ship as CHANNEL_DATA
-        // after close and strict SSH clients (OpenSSH) disconnect.
         using var outputDrainCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
         var outputTask = pty.Output!.CopyToAsync(stream, outputDrainCts.Token);
         _ = stream.CopyToAsync(pty.Input!, _cts.Token);
 
         var result = await pty.WaitForExitAsync(_cts.Token);
 
-        outputDrainCts.CancelAfter(TimeSpan.FromSeconds(1));
-        try { await outputTask; }
-        catch (OperationCanceledException) { }
+        await DrainAndCloseAsync(
+            outputTask,
+            outputDrainCts,
+            ct => stream.Channel.CloseAsync(unchecked((uint)result), ct),
+            _cts.Token);
+    }
 
-        await stream.Channel.CloseAsync(unchecked((uint)result), _cts.Token);
+    /// <summary>
+    /// Drains any trailing PTY output, then closes the channel — and closes it
+    /// no matter how the output pump ends, short of a session shutdown.
+    /// </summary>
+    /// <remarks>
+    /// ConPTY emits final reset sequences asynchronously after the child exits,
+    /// so we give them a moment to drain before CHANNEL_CLOSE; otherwise they
+    /// ship as CHANNEL_DATA after close and strict SSH clients (OpenSSH)
+    /// disconnect. But the pump always ends abnormally on teardown — at EOF on
+    /// Windows, with an EIO <see cref="IOException"/> on Linux once the PTY
+    /// slave closes — and an in-flight <see cref="FileStream"/> read can ignore
+    /// cancellation. So the drain must neither block the close indefinitely nor
+    /// let the pump's terminal exception propagate: <see cref="RunAsync"/> is
+    /// fire-and-forget, so a thrown exception here would skip the close and the
+    /// client would never receive CHANNEL_CLOSE — hanging the session on logout.
+    /// </remarks>
+    internal static async Task DrainAndCloseAsync(
+        Task outputTask,
+        CancellationTokenSource outputDrainCts,
+        Func<CancellationToken, Task> closeAsync,
+        CancellationToken cancellation,
+        TimeSpan? drainBudget = null,
+        TimeSpan? drainTimeout = null)
+    {
+        outputDrainCts.CancelAfter(drainBudget ?? TimeSpan.FromSeconds(1));
+        try
+        {
+            await outputTask.WaitAsync(drainTimeout ?? TimeSpan.FromSeconds(2), cancellation);
+        }
+        catch (OperationCanceledException)
+        {
+            // The session/forwarder is shutting down; closing is pointless.
+            return;
+        }
+        catch (TimeoutException)
+        {
+            // The read ignored cancellation; Dispose will tear down the PTY and
+            // unblock it. Observe the eventual fault so it isn't unobserved.
+            _ = outputTask.ContinueWith(static t => _ = t.Exception,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+        }
+        catch
+        {
+            // Pump ended via EOF or EIO — expected, best-effort drain.
+        }
+
+        await closeAsync(cancellation);
     }
 
     public async Task ResizeAsync(

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
@@ -70,22 +70,40 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
 
         _pty = PtyProvider.CreatePty();
         await _pty.StartAsync(_width, _height, selection.Command, selection.Arguments);
-        _ = RunAsync(stream, _pty);
+        ObserveFault(RunAsync(stream, _pty));
     }
+
+    // Keeps a fire-and-forget task from surfacing its fault as an unobserved
+    // task exception. The faults we expect here are teardown races (e.g. the
+    // EIO when the PTY slave closes), not actionable conditions.
+    private static void ObserveFault(Task task) =>
+        _ = task.ContinueWith(static t => _ = t.Exception,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
 
     private async Task RunAsync(SshStream stream, IPty pty)
     {
         using var outputDrainCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
         var outputTask = pty.Output!.CopyToAsync(stream, outputDrainCts.Token);
-        _ = stream.CopyToAsync(pty.Input!, _cts.Token);
+        ObserveFault(stream.CopyToAsync(pty.Input!, _cts.Token));
 
-        var result = await pty.WaitForExitAsync(_cts.Token);
+        try
+        {
+            var result = await pty.WaitForExitAsync(_cts.Token);
 
-        await DrainAndCloseAsync(
-            outputTask,
-            outputDrainCts,
-            ct => stream.Channel.CloseAsync(unchecked((uint)result), ct),
-            _cts.Token);
+            await DrainAndCloseAsync(
+                outputTask,
+                outputDrainCts,
+                ct => stream.Channel.CloseAsync(unchecked((uint)result), ct),
+                _cts.Token);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Consistent with CommandForwarder/PowershellForwarder: an
+            // unexpected failure is surfaced to the client as an exception
+            // signal rather than faulting this fire-and-forget task and
+            // leaving the channel open.
+            await stream.Channel.CloseAsync(EryphSignalTypes.Exception, ex.Message, _cts.Token);
+        }
     }
 
     /// <summary>
@@ -120,14 +138,16 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
         catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
         {
             // The session/forwarder is shutting down; closing is pointless.
+            // Still observe the pump's eventual teardown fault (EIO) so it
+            // isn't left unobserved.
+            ObserveFault(outputTask);
             return;
         }
         catch (TimeoutException)
         {
             // The read ignored cancellation; Dispose will tear down the PTY and
             // unblock it. Observe the eventual fault so it isn't unobserved.
-            _ = outputTask.ContinueWith(static t => _ = t.Exception,
-                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+            ObserveFault(outputTask);
         }
         catch
         {

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/PtyForwarder.cs
@@ -117,7 +117,7 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
         {
             await outputTask.WaitAsync(drainTimeout ?? TimeSpan.FromSeconds(2), cancellation);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
         {
             // The session/forwarder is shutting down; closing is pointless.
             return;
@@ -131,7 +131,8 @@ public sealed class PtyForwarder(IShellSelector? selector = null) : IDisposable
         }
         catch
         {
-            // Pump ended via EOF or EIO — expected, best-effort drain.
+            // Pump ended via EOF, EIO, or the drain-budget cancellation
+            // (outputDrainCts) — all expected; close the channel regardless.
         }
 
         await closeAsync(cancellation);

--- a/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/PtyForwarderDrainTests.cs
+++ b/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/PtyForwarderDrainTests.cs
@@ -11,8 +11,12 @@ namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests;
 /// </summary>
 public class PtyForwarderDrainTests
 {
-    private static readonly TimeSpan FastBudget = TimeSpan.FromMilliseconds(20);
-    private static readonly TimeSpan FastTimeout = TimeSpan.FromMilliseconds(100);
+    // The fault/EOF/cancel/shutdown cases resolve from already-completed tasks
+    // and don't depend on these values; only the stalled-pump case waits out
+    // the drain timeout. Kept comfortably above CI timer resolution so that
+    // test isn't flaky on slow/loaded runners.
+    private static readonly TimeSpan FastBudget = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan FastTimeout = TimeSpan.FromMilliseconds(500);
 
     [Fact]
     public async Task ClosesChannel_WhenOutputPumpFaultsWithIoException_AsOnLinuxPtyEio()

--- a/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/PtyForwarderDrainTests.cs
+++ b/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/PtyForwarderDrainTests.cs
@@ -1,0 +1,95 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.DevTunnels.Ssh.Extensions.Forwarders;
+
+namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests;
+
+/// <summary>
+/// Regression tests for the drain-then-close sequence that runs after the shell
+/// process exits. The channel must always be closed regardless of how the PTY
+/// output pump terminates — otherwise the SSH client never receives
+/// CHANNEL_CLOSE and hangs on logout.
+/// </summary>
+public class PtyForwarderDrainTests
+{
+    private static readonly TimeSpan FastBudget = TimeSpan.FromMilliseconds(20);
+    private static readonly TimeSpan FastTimeout = TimeSpan.FromMilliseconds(100);
+
+    [Fact]
+    public async Task ClosesChannel_WhenOutputPumpFaultsWithIoException_AsOnLinuxPtyEio()
+    {
+        // On Linux the master FD read faults with EIO once the PTY slave closes.
+        // That IOException must not skip the channel close (the original bug).
+        var outputTask = Task.FromException(new IOException("Input/output error"));
+        var closed = false;
+
+        using var drainCts = new CancellationTokenSource();
+        await PtyForwarder.DrainAndCloseAsync(
+            outputTask,
+            drainCts,
+            _ => { closed = true; return Task.CompletedTask; },
+            CancellationToken.None,
+            FastBudget,
+            FastTimeout);
+
+        closed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ClosesChannel_WhenOutputPumpCompletesAtEof()
+    {
+        var closed = false;
+
+        using var drainCts = new CancellationTokenSource();
+        await PtyForwarder.DrainAndCloseAsync(
+            Task.CompletedTask,
+            drainCts,
+            _ => { closed = true; return Task.CompletedTask; },
+            CancellationToken.None,
+            FastBudget,
+            FastTimeout);
+
+        closed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ClosesChannel_WhenOutputPumpStallsBeyondDrainTimeout()
+    {
+        // A read that never returns and ignores cancellation must not wedge the
+        // close: the drain timeout backstops it.
+        var stalled = new TaskCompletionSource();
+        var closed = false;
+
+        using var drainCts = new CancellationTokenSource();
+        await PtyForwarder.DrainAndCloseAsync(
+            stalled.Task,
+            drainCts,
+            _ => { closed = true; return Task.CompletedTask; },
+            CancellationToken.None,
+            FastBudget,
+            FastTimeout);
+
+        closed.Should().BeTrue();
+        stalled.SetResult();
+    }
+
+    [Fact]
+    public async Task DoesNotCloseChannel_WhenSessionIsAlreadyShuttingDown()
+    {
+        // A cancelled session token means teardown is underway; closing the
+        // channel is pointless and would itself throw.
+        var closed = false;
+        using var shutdownCts = new CancellationTokenSource();
+        await shutdownCts.CancelAsync();
+
+        using var drainCts = new CancellationTokenSource();
+        await PtyForwarder.DrainAndCloseAsync(
+            new TaskCompletionSource().Task,
+            drainCts,
+            _ => { closed = true; return Task.CompletedTask; },
+            shutdownCts.Token,
+            FastBudget,
+            FastTimeout);
+
+        closed.Should().BeFalse();
+    }
+}

--- a/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/PtyForwarderDrainTests.cs
+++ b/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/PtyForwarderDrainTests.cs
@@ -52,6 +52,28 @@ public class PtyForwarderDrainTests
     }
 
     [Fact]
+    public async Task ClosesChannel_WhenOutputPumpCanceledByDrainBudget_NotSession()
+    {
+        // The normal drain path cancels the pump via outputDrainCts.CancelAfter,
+        // surfacing as an OperationCanceledException. The session token is NOT
+        // canceled, so the channel must still be closed — otherwise the logout
+        // hang returns on the common (e.g. Windows ConPTY) path.
+        var outputTask = Task.FromCanceled(new CancellationToken(canceled: true));
+        var closed = false;
+
+        using var drainCts = new CancellationTokenSource();
+        await PtyForwarder.DrainAndCloseAsync(
+            outputTask,
+            drainCts,
+            _ => { closed = true; return Task.CompletedTask; },
+            CancellationToken.None,
+            FastBudget,
+            FastTimeout);
+
+        closed.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task ClosesChannel_WhenOutputPumpStallsBeyondDrainTimeout()
     {
         // A read that never returns and ignores cancellation must not wedge the


### PR DESCRIPTION
Backport of #29 to the 0.3.x maintenance line.

Interactive SSH sessions through egs-service hang on logout on Linux guests. The drain added in #25 (shipped in v0.3.0) awaits the PTY output pump before closing the channel but only catches `OperationCanceledException`. On Linux the master-FD read faults with EIO (an `IOException`) once the shell exits and the PTY slave closes, so the await rethrows; since `RunAsync` is fire-and-forget the exception is swallowed and `channel.CloseAsync` never runs, leaving the client waiting for `CHANNEL_CLOSE`.

`RunAsync` now delegates to `DrainAndCloseAsync`, which drains best-effort, swallows any pump-termination exception (EOF on Windows, EIO on Linux), caps the wait with a hard timeout so a cancellation-ignoring read can't wedge the close, and always sends the channel close (skipping only on session shutdown). Added `PtyForwarderDrainTests`.

Clean cherry-pick of the main fix onto v0.3.0; builds and tests pass. Tag `v0.3.1` after merge to cut the patch release.