### PR TITLE
Fix provisioning crash on transient state-save replace failure

### DIFF
--- a/src/Eryph.GuestServices.Provisioning/Hosting/ProvisioningHostedService.cs
+++ b/src/Eryph.GuestServices.Provisioning/Hosting/ProvisioningHostedService.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using Eryph.GuestServices.Core;
+using Eryph.GuestServices.Provisioning.Reporting;
+using Eryph.GuestServices.Provisioning.Reporting.Events;
 using Eryph.GuestServices.Provisioning.Stages;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -19,6 +21,7 @@ internal sealed class ProvisioningHostedService(
     IStageRunner runner,
     IHostApplicationLifetime lifetime,
     IServiceControlFlags controlFlags,
+    IReportingDispatcher reporter,
     ILogger<ProvisioningHostedService> logger) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -43,6 +46,24 @@ internal sealed class ProvisioningHostedService(
         {
             logger.LogError(ex, "Unhandled exception in provisioning stage runner");
             Environment.ExitCode = 1;
+            // Surface the failure so KVP reports `failed` rather than staying
+            // `running` forever. A swallowed crash here (e.g. a state-save replace
+            // denied by AV) previously left provisioning indistinguishable from a
+            // hung run. Reporting must not itself throw out of the catch — report
+            // on a non-cancellable token and swallow any reporting error.
+            try
+            {
+                await reporter.EmitAsync(
+                    new ReportingEvent.ProvisioningFailed($"Unhandled exception: {ex.Message}", ex)
+                    {
+                        Origin = "provisioning-host",
+                    },
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception reportEx)
+            {
+                logger.LogError(reportEx, "Failed to report provisioning failure state");
+            }
             // Do NOT stop the host: egs-service keeps running its other
             // responsibilities (SSH server, host channel) even when provisioning
             // failed.

--- a/src/Eryph.GuestServices.Provisioning/Modules/FileScriptCheckpointStore.cs
+++ b/src/Eryph.GuestServices.Provisioning/Modules/FileScriptCheckpointStore.cs
@@ -64,7 +64,7 @@ public sealed class FileScriptCheckpointStore : IScriptCheckpointStore
                 cancellationToken).ConfigureAwait(false);
             await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
-        File.Move(tempPath, path, overwrite: true);
+        await State.AtomicFile.ReplaceWithRetryAsync(tempPath, path, _logger, cancellationToken).ConfigureAwait(false);
     }
 
     public Task ResetAsync(string instanceId, CancellationToken cancellationToken)

--- a/src/Eryph.GuestServices.Provisioning/Semaphores/BootSessionDetector.cs
+++ b/src/Eryph.GuestServices.Provisioning/Semaphores/BootSessionDetector.cs
@@ -98,7 +98,7 @@ public sealed class BootSessionDetector : IBootSessionDetector
         var payload = JsonSerializer.Serialize(new BootMarker(current, DateTimeOffset.UtcNow), BootSessionDetectorJsonContext.Default.BootMarker);
         var tempPath = _markerPath + ".tmp";
         await File.WriteAllTextAsync(tempPath, payload, cancellationToken).ConfigureAwait(false);
-        File.Move(tempPath, _markerPath, overwrite: true);
+        await State.AtomicFile.ReplaceWithRetryAsync(tempPath, _markerPath, _logger, cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
             "New boot detected: previous={Previous} current={Current}",

--- a/src/Eryph.GuestServices.Provisioning/Semaphores/FileSemaphoreStore.cs
+++ b/src/Eryph.GuestServices.Provisioning/Semaphores/FileSemaphoreStore.cs
@@ -90,7 +90,7 @@ public sealed class FileSemaphoreStore : ISemaphoreStore
         // file is correctly treated as "not yet completed".
         var tempPath = path + ".tmp";
         await File.WriteAllTextAsync(tempPath, json, cancellationToken).ConfigureAwait(false);
-        File.Move(tempPath, path, overwrite: true);
+        await State.AtomicFile.ReplaceWithRetryAsync(tempPath, path, _logger, cancellationToken).ConfigureAwait(false);
 
         _logger.LogDebug(
             "Wrote semaphore {Path} (module={Module} frequency={Frequency} outcome={Outcome})",

--- a/src/Eryph.GuestServices.Provisioning/State/AtomicFile.cs
+++ b/src/Eryph.GuestServices.Provisioning/State/AtomicFile.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Logging;
+
+namespace Eryph.GuestServices.Provisioning.State;
+
+/// <summary>
+/// Helpers for the write-temp-then-replace pattern the file-backed stores use.
+///
+/// On Windows, replacing an existing file (<c>File.Move(.., overwrite: true)</c> →
+/// <c>MoveFileEx(MOVEFILE_REPLACE_EXISTING)</c>) can transiently fail with
+/// <see cref="UnauthorizedAccessException"/> or <see cref="IOException"/> when
+/// antivirus (Defender real-time scan of the just-written file) or a concurrent
+/// reader briefly holds the destination open without <c>FILE_SHARE_DELETE</c>.
+/// state.json is rewritten after every module, so this race is hit in practice —
+/// it crashed a real Windows Server 2025 provisioning run. Retrying the replace
+/// (and letting readers share delete) makes the stores resilient to it.
+/// </summary>
+internal static class AtomicFile
+{
+    public static async Task ReplaceWithRetryAsync(
+        string source,
+        string destination,
+        ILogger logger,
+        CancellationToken cancellationToken,
+        int maxAttempts = 6)
+    {
+        var delay = TimeSpan.FromMilliseconds(50);
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                File.Move(source, destination, overwrite: true);
+                return;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException && attempt < maxAttempts)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Replacing {Destination} failed (attempt {Attempt}/{Max}); retrying in {Delay}ms",
+                    destination, attempt, maxAttempts, (int)delay.TotalMilliseconds);
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                delay = TimeSpan.FromMilliseconds(Math.Min(delay.TotalMilliseconds * 2, 1000));
+            }
+        }
+    }
+}

--- a/src/Eryph.GuestServices.Provisioning/State/AtomicFile.cs
+++ b/src/Eryph.GuestServices.Provisioning/State/AtomicFile.cs
@@ -9,10 +9,12 @@ namespace Eryph.GuestServices.Provisioning.State;
 /// <c>MoveFileEx(MOVEFILE_REPLACE_EXISTING)</c>) can transiently fail with
 /// <see cref="UnauthorizedAccessException"/> or <see cref="IOException"/> when
 /// antivirus (Defender real-time scan of the just-written file) or a concurrent
-/// reader briefly holds the destination open without <c>FILE_SHARE_DELETE</c>.
-/// state.json is rewritten after every module, so this race is hit in practice —
-/// it crashed a real Windows Server 2025 provisioning run. Retrying the replace
-/// (and letting readers share delete) makes the stores resilient to it.
+/// reader briefly holds the destination open. state.json is rewritten after
+/// every module, so this race is hit in practice — it crashed a real Windows
+/// Server 2025 provisioning run. Retrying the replace makes the stores resilient
+/// to it. (.NET's <c>File.Move</c> cannot replace a destination another handle
+/// has open even with <c>FILE_SHARE_DELETE</c>, so a reader share-mode change
+/// would not help — the retry is the fix.)
 /// </summary>
 internal static class AtomicFile
 {
@@ -31,7 +33,7 @@ internal static class AtomicFile
                 File.Move(source, destination, overwrite: true);
                 return;
             }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException && attempt < maxAttempts)
+            catch (Exception ex) when ((ex is IOException or UnauthorizedAccessException) && attempt < maxAttempts)
             {
                 logger.LogWarning(
                     ex,

--- a/src/Eryph.GuestServices.Provisioning/State/FileStateStore.cs
+++ b/src/Eryph.GuestServices.Provisioning/State/FileStateStore.cs
@@ -47,7 +47,7 @@ public sealed class FileStateStore(ILogger<FileStateStore> logger) : IStateStore
             await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        File.Move(tempPath, _statePath, overwrite: true);
+        await AtomicFile.ReplaceWithRetryAsync(tempPath, _statePath, logger, cancellationToken).ConfigureAwait(false);
     }
 
     public Task ResetAsync(CancellationToken cancellationToken)

--- a/test/Eryph.GuestServices.Provisioning.Tests/Hosting/ProvisioningHostedServiceGateTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Hosting/ProvisioningHostedServiceGateTests.cs
@@ -42,8 +42,10 @@ public class ProvisioningHostedServiceGateTests
         // runner and was swallowed, leaving KVP stuck on `running`. The crash must
         // now surface as a `failed` reporting event so the host reports it.
         var runner = Substitute.For<IStageRunner>();
+        // Return a faulted task (the real async failure mode — exception observed
+        // when awaited), not a synchronous throw at invocation.
         runner.RunAsync(Arg.Any<CancellationToken>())
-            .Returns<Task<StageRunOutcome>>(_ => throw new UnauthorizedAccessException("denied"));
+            .Returns(Task.FromException<StageRunOutcome>(new UnauthorizedAccessException("denied")));
         var reporter = Substitute.For<IReportingDispatcher>();
         var service = CreateService(runner, provisioningEnabled: true, reporter);
 

--- a/test/Eryph.GuestServices.Provisioning.Tests/Hosting/ProvisioningHostedServiceGateTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Hosting/ProvisioningHostedServiceGateTests.cs
@@ -1,5 +1,7 @@
 using Eryph.GuestServices.Core;
 using Eryph.GuestServices.Provisioning.Hosting;
+using Eryph.GuestServices.Provisioning.Reporting;
+using Eryph.GuestServices.Provisioning.Reporting.Events;
 using Eryph.GuestServices.Provisioning.Stages;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -33,12 +35,33 @@ public class ProvisioningHostedServiceGateTests
         await runner.Received(1).RunAsync(Arg.Any<CancellationToken>());
     }
 
-    private static ProvisioningHostedService CreateService(IStageRunner runner, bool provisioningEnabled)
+    [Fact]
+    public async Task ExecuteAsync_StageRunnerThrows_ReportsFailedState()
+    {
+        // Regression: a state-save replace denied by AV threw out of the stage
+        // runner and was swallowed, leaving KVP stuck on `running`. The crash must
+        // now surface as a `failed` reporting event so the host reports it.
+        var runner = Substitute.For<IStageRunner>();
+        runner.RunAsync(Arg.Any<CancellationToken>())
+            .Returns<Task<StageRunOutcome>>(_ => throw new UnauthorizedAccessException("denied"));
+        var reporter = Substitute.For<IReportingDispatcher>();
+        var service = CreateService(runner, provisioningEnabled: true, reporter);
+
+        await RunOnceAsync(service);
+
+        await reporter.Received(1).EmitAsync(
+            Arg.Is<ReportingEvent>(e => e is ReportingEvent.ProvisioningFailed),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static ProvisioningHostedService CreateService(
+        IStageRunner runner, bool provisioningEnabled, IReportingDispatcher? reporter = null)
     {
         var lifetime = Substitute.For<IHostApplicationLifetime>();
         var flags = new FixedFlags(provisioningEnabled);
         return new ProvisioningHostedService(
-            runner, lifetime, flags, NullLogger<ProvisioningHostedService>.Instance);
+            runner, lifetime, flags, reporter ?? Substitute.For<IReportingDispatcher>(),
+            NullLogger<ProvisioningHostedService>.Instance);
     }
 
     // BackgroundService.StartAsync kicks off ExecuteAsync and exposes the task

--- a/test/Eryph.GuestServices.Provisioning.Tests/State/AtomicFileTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/State/AtomicFileTests.cs
@@ -1,0 +1,49 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.Provisioning.State;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Eryph.GuestServices.Provisioning.Tests.State;
+
+/// <summary>
+/// Regression for the WS2025 provisioning crash: replacing state.json threw
+/// UnauthorizedAccessException/IOException when antivirus or a concurrent reader
+/// briefly held the destination. The replace must retry and recover, and our
+/// own readers must not block it.
+/// </summary>
+public sealed class AtomicFileTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "egs-atomic-" + Guid.NewGuid().ToString("N"));
+
+    public AtomicFileTests() => Directory.CreateDirectory(_dir);
+
+    [Fact]
+    public async Task ReplaceWithRetry_recovers_when_destination_is_briefly_locked()
+    {
+        var dest = Path.Combine(_dir, "state.json");
+        File.WriteAllText(dest, "old");
+
+        // Hold the destination with NO sharing (blocks the replace), then release
+        // it shortly after — the retry loop must recover and complete the replace.
+        var blocker = File.Open(dest, FileMode.Open, FileAccess.Read, FileShare.None);
+        var release = Task.Run(async () =>
+        {
+            await Task.Delay(120);
+            blocker.Dispose();
+        });
+
+        var temp = Path.Combine(_dir, "state.json.tmp");
+        File.WriteAllText(temp, "new");
+
+        await AtomicFile.ReplaceWithRetryAsync(temp, dest, NullLogger.Instance, CancellationToken.None);
+        await release;
+
+        File.ReadAllText(dest).Should().Be("new");
+        File.Exists(temp).Should().BeFalse();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+}

--- a/test/Eryph.GuestServices.Provisioning.Tests/State/AtomicFileTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/State/AtomicFileTests.cs
@@ -6,9 +6,8 @@ namespace Eryph.GuestServices.Provisioning.Tests.State;
 
 /// <summary>
 /// Regression for the WS2025 provisioning crash: replacing state.json threw
-/// UnauthorizedAccessException/IOException when antivirus or a concurrent reader
-/// briefly held the destination. The replace must retry and recover, and our
-/// own readers must not block it.
+/// UnauthorizedAccessException/IOException (antivirus / a concurrent reader
+/// briefly holding the destination). The replace must retry and recover.
 /// </summary>
 public sealed class AtomicFileTests : IDisposable
 {
@@ -18,28 +17,45 @@ public sealed class AtomicFileTests : IDisposable
     public AtomicFileTests() => Directory.CreateDirectory(_dir);
 
     [Fact]
-    public async Task ReplaceWithRetry_recovers_when_destination_is_briefly_locked()
+    public async Task ReplaceWithRetry_recovers_after_a_transient_failure()
     {
-        var dest = Path.Combine(_dir, "state.json");
-        File.WriteAllText(dest, "old");
-
-        // Hold the destination with NO sharing (blocks the replace), then release
-        // it shortly after — the retry loop must recover and complete the replace.
-        var blocker = File.Open(dest, FileMode.Open, FileAccess.Read, FileShare.None);
-        var release = Task.Run(async () =>
-        {
-            await Task.Delay(120);
-            blocker.Dispose();
-        });
-
+        // Force File.Move to fail transiently in a cross-platform, deterministic
+        // way: the destination's parent directory is missing at first (File.Move
+        // throws DirectoryNotFoundException, an IOException, on every OS), then a
+        // background task creates it so a later retry succeeds. This exercises the
+        // catch/backoff/recover loop without relying on Windows-specific file
+        // locking semantics.
+        var destDir = Path.Combine(_dir, "subdir");
+        var dest = Path.Combine(destDir, "state.json");
         var temp = Path.Combine(_dir, "state.json.tmp");
         File.WriteAllText(temp, "new");
 
+        var createDir = Task.Run(async () =>
+        {
+            await Task.Delay(120);
+            Directory.CreateDirectory(destDir);
+        });
+
         await AtomicFile.ReplaceWithRetryAsync(temp, dest, NullLogger.Instance, CancellationToken.None);
-        await release;
+        await createDir;
 
         File.ReadAllText(dest).Should().Be("new");
         File.Exists(temp).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ReplaceWithRetry_throws_after_exhausting_attempts()
+    {
+        // A destination directory that never appears must surface the failure
+        // (rather than retrying forever) once the attempt budget is exhausted.
+        var dest = Path.Combine(_dir, "never", "state.json");
+        var temp = Path.Combine(_dir, "state.json.tmp");
+        File.WriteAllText(temp, "new");
+
+        var act = async () => await AtomicFile.ReplaceWithRetryAsync(
+            temp, dest, NullLogger.Instance, CancellationToken.None, maxAttempts: 3);
+
+        await act.Should().ThrowAsync<IOException>();
     }
 
     public void Dispose()


### PR DESCRIPTION
A fresh **Windows Server 2025** run on the released **0.4.0-preview.2** never finished provisioning — KVP stayed `eryph.provisioning.state = running` (stage `Config`) indefinitely.

**Root cause:** `FileStateStore.SaveAsync` does a write-temp-then-`File.Move(overwrite:true)` atomic replace of `state.json`. On the guest that replace threw `UnauthorizedAccessException: Access to the path is denied` while saving state right after `SshModule` — antivirus (Defender) scanning the just-written file, or a concurrent reader, briefly holds the destination and the replace is denied. `state.json` is rewritten after every module, so the race is hit in practice. The exception propagated out of `StageRunner` and was **swallowed** by `ProvisioningHostedService` (logged, exit code set, returned) — so KVP never moved off `running` and the run looked hung.

(Confirmed from the guest EventLog: `UnauthorizedAccessException at FileStateStore.SaveAsync line 50 (File.Move)`, with a leftover `state.json.tmp`. Not the reboot-resume issue — `rebootCount: 0`, no pending handlers.)

**Fix:**
- `AtomicFile.ReplaceWithRetryAsync` — retry the replace on transient `IOException`/`UnauthorizedAccessException` with short exponential backoff. Applied to the state, semaphore, and script-checkpoint stores (all use the same temp+move pattern).
- `ProvisioningHostedService` now emits a `ProvisioningFailed` report when the stage runner throws an otherwise-unhandled exception, so a crash surfaces as KVP `failed` rather than a silent `running`.

Tests: deterministic retry-recovery test (destination locked then released) and an observability test (stage-runner throw → `failed` reported). Full provisioning suite green (659).

Note: `File.Move(overwrite)` cannot replace a destination another handle holds open even with `FILE_SHARE_DELETE`, so the retry — not a share-mode change — is the fix. The original failure is timing-dependent (AV scan window), so it is covered by the deterministic unit test rather than a live repro.