### PR TITLE
Fix SetHostname reboot loop on names Windows normalizes

### DIFF
--- a/src/Eryph.GuestServices.Provisioning/Modules/IModuleContext.cs
+++ b/src/Eryph.GuestServices.Provisioning/Modules/IModuleContext.cs
@@ -21,4 +21,17 @@ public interface IModuleContext
     /// </list>
     /// </summary>
     DataSourceResult DataSource { get; }
+
+    /// <summary>
+    /// True when the StageRunner is re-entering this module after a previous
+    /// run for the same instance returned
+    /// <see cref="ModuleOutcome.RebootRequested"/>. Lets a module make its
+    /// rename/reconfigure work one-shot: do it on the first pass, accept
+    /// whatever post-reboot state the OS settled on, and complete — instead
+    /// of comparing-and-retrying, which can reboot-loop when the OS
+    /// normalizes the value (e.g. NetBIOS-truncates a 17-char hostname so
+    /// the post-reboot <c>Environment.MachineName</c> no longer matches the
+    /// requested name verbatim).
+    /// </summary>
+    bool IsRebootResume { get; }
 }

--- a/src/Eryph.GuestServices.Provisioning/Modules/ModuleContext.cs
+++ b/src/Eryph.GuestServices.Provisioning/Modules/ModuleContext.cs
@@ -3,9 +3,14 @@ using Eryph.GuestServices.Provisioning.Windows;
 
 namespace Eryph.GuestServices.Provisioning.Modules;
 
-internal sealed class ModuleContext(IWindowsOs os, DataSourceResult dataSource) : IModuleContext
+internal sealed class ModuleContext(
+    IWindowsOs os,
+    DataSourceResult dataSource,
+    bool isRebootResume = false) : IModuleContext
 {
     public IWindowsOs Os { get; } = os;
 
     public DataSourceResult DataSource { get; } = dataSource;
+
+    public bool IsRebootResume { get; } = isRebootResume;
 }

--- a/src/Eryph.GuestServices.Provisioning/Modules/SetHostnameModule.cs
+++ b/src/Eryph.GuestServices.Provisioning/Modules/SetHostnameModule.cs
@@ -9,6 +9,14 @@ namespace Eryph.GuestServices.Provisioning.Modules;
 [Stage(Stage.Network, Frequency = ModuleFrequency.PerInstance)]
 internal sealed class SetHostnameModule(ILogger<SetHostnameModule> logger) : IModule
 {
+    // The Windows NetBIOS computer name is capped at 15 characters. A longer
+    // name silently truncates server-side, but Environment.MachineName then
+    // reports the 15-char form — so the "already set" check in the OS layer
+    // would never match a longer desired name, producing an endless
+    // rename-reboot loop. cloudbase-init's set_hostname module truncates here
+    // for the same reason; we mirror that behaviour.
+    private const int NetBiosNameMaxLength = 15;
+
     public async Task<ModuleOutcome> ApplyAsync(
         ResolvedUserData userData,
         IModuleContext context,
@@ -25,6 +33,36 @@ internal sealed class SetHostnameModule(ILogger<SetHostnameModule> logger) : IMo
         if (desired is null)
         {
             logger.LogDebug("No hostname or fqdn specified; nothing to do.");
+            return ModuleOutcome.Ok();
+        }
+
+        if (desired.Length > NetBiosNameMaxLength)
+        {
+            var truncated = desired[..NetBiosNameMaxLength];
+            logger.LogWarning(
+                "Hostname '{Hostname}' exceeds the Windows NetBIOS limit of {Max} characters; truncating to '{Truncated}'.",
+                desired, NetBiosNameMaxLength, truncated);
+            desired = truncated;
+        }
+
+        // One-shot guard: we already requested a rename + reboot for this
+        // instance. Don't compare-and-retry — any post-reboot mismatch
+        // (length truncation, case folding, character drops) would otherwise
+        // trigger another reboot, and so on until the per-module reboot cap
+        // aborts provisioning. Accept whatever the OS settled on.
+        if (context.IsRebootResume)
+        {
+            var actual = await context.Os.GetComputerNameAsync(cancellationToken).ConfigureAwait(false);
+            if (string.Equals(actual, desired, StringComparison.OrdinalIgnoreCase))
+            {
+                logger.LogInformation("Computer name is '{Name}' after reboot.", actual);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "Computer name is '{Actual}' after reboot; requested '{Desired}'. Accepting the OS-normalized value rather than triggering another rename.",
+                    actual, desired);
+            }
             return ModuleOutcome.Ok();
         }
 

--- a/src/Eryph.GuestServices.Provisioning/Stages/StageRunner.cs
+++ b/src/Eryph.GuestServices.Provisioning/Stages/StageRunner.cs
@@ -88,7 +88,6 @@ public sealed class StageRunner(
             new ReportingEvent.ProvisioningStarted(data.InstanceId) { Origin = "stage-runner" },
             cancellationToken).ConfigureAwait(false);
 
-        var context = new ModuleContext(os, data);
         var buckets = BuildStageBuckets(modules, settings, logger);
 
         // userData is resolved lazily at the start of the Network stage so that
@@ -185,10 +184,19 @@ public sealed class StageRunner(
                     new ReportingEvent.ModuleStarted(moduleName) { Origin = $"module:{moduleName}" },
                     cancellationToken).ConfigureAwait(false);
 
+                // Per-module context so the module sees whether StageRunner is
+                // re-entering it after its own previous reboot request — lets
+                // one-shot modules (SetHostname) avoid rename-reboot loops when
+                // the OS normalized the requested value (length, case, chars).
+                var moduleContext = new ModuleContext(
+                    os,
+                    data,
+                    isRebootResume: existingOutcome == OutcomeRebootRequested);
+
                 ModuleOutcome outcome;
                 try
                 {
-                    outcome = await module.ApplyAsync(userDataForStage, context, cancellationToken).ConfigureAwait(false);
+                    outcome = await module.ApplyAsync(userDataForStage, moduleContext, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {

--- a/test/Eryph.GuestServices.Provisioning.Tests/Integration/EndToEndProvisioningTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Integration/EndToEndProvisioningTests.cs
@@ -142,18 +142,21 @@ public sealed class EndToEndProvisioningTests : IDisposable
         await windowsOs.Received(1).SetComputerNameAsync("testhost", Arg.Any<CancellationToken>());
 
         // Second run after the (simulated) reboot — the StageRunner re-enters
-        // SetHostnameModule which sees AlreadySet and returns Completed. That
+        // SetHostnameModule which now treats the resume as one-shot: it reads
+        // the actual machine name, accepts whatever the OS settled on, and
+        // returns Completed without calling SetComputerNameAsync again. That
         // promotes the handler from PendingHandlers to CompletedHandlers.
         windowsOs.ClearReceivedCalls();
-        windowsOs.SetComputerNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(SetComputerNameResult.AlreadySet);
+        windowsOs.GetComputerNameAsync(Arg.Any<CancellationToken>()).Returns("testhost");
 
         var outcome2 = await runner.RunAsync(CancellationToken.None);
         outcome2.Should().BeOfType<StageRunOutcome.Success>();
 
-        // SetHostnameModule is re-entered on resume; the second call confirms
-        // the rename completed during reboot (AlreadySet path).
-        await windowsOs.Received(1).SetComputerNameAsync("testhost", Arg.Any<CancellationToken>());
+        // Resume must NOT call SetComputerNameAsync again — the one-shot
+        // guard reads GetComputerNameAsync and trusts whatever Windows
+        // settled on, preventing rename-reboot loops on OS-normalized names.
+        await windowsOs.DidNotReceive().SetComputerNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await windowsOs.Received().GetComputerNameAsync(Arg.Any<CancellationToken>());
 
         state = await stateStore.LoadAsync(CancellationToken.None);
         state!.PendingHandlers.Should().NotContain(typeof(SetHostnameModule).FullName!);

--- a/test/Eryph.GuestServices.Provisioning.Tests/Modules/SetHostnameModuleTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Modules/SetHostnameModuleTests.cs
@@ -145,6 +145,85 @@ public sealed class SetHostnameModuleTests
         await os.Received().SetComputerNameAsync("a", Arg.Any<CancellationToken>());
     }
 
+    // Regression: a 17-char hostname like "remote-access-e2e" exceeds the 15-char
+    // Windows NetBIOS limit. Without truncation the OS layer compares the long
+    // desired name against the post-rename, already-truncated Environment.MachineName
+    // ("REMOTE-ACCESS-E"), the comparison never matches, and the module
+    // requests a reboot on every run — reboot-looping until the cap kicks in.
+    [Fact]
+    public async Task Truncates_hostname_to_netbios_max_length()
+    {
+        var os = Substitute.For<IWindowsOs>();
+        os.SetComputerNameAsync("remote-access-e", Arg.Any<CancellationToken>())
+            .Returns(SetComputerNameResult.AlreadySet);
+        var module = new SetHostnameModule(NullLogger<SetHostnameModule>.Instance);
+
+        var result = await module.ApplyAsync(
+            ResolvedUserData.Empty(new CloudConfigModel { Hostname = "remote-access-e2e" }),
+            new TestModuleContext(os),
+            CancellationToken.None);
+
+        result.Should().BeOfType<ModuleOutcome.Completed>();
+        await os.Received().SetComputerNameAsync("remote-access-e", Arg.Any<CancellationToken>());
+        await os.DidNotReceive().SetComputerNameAsync("remote-access-e2e", Arg.Any<CancellationToken>());
+    }
+
+    // The same truncation must apply when the name is derived from the
+    // first label of an fqdn — otherwise an fqdn whose first label is > 15
+    // chars would still reboot-loop.
+    [Fact]
+    public async Task Truncates_fqdn_first_label_to_netbios_max_length()
+    {
+        var os = Substitute.For<IWindowsOs>();
+        os.SetComputerNameAsync("remote-access-e", Arg.Any<CancellationToken>())
+            .Returns(SetComputerNameResult.AlreadySet);
+        var module = new SetHostnameModule(NullLogger<SetHostnameModule>.Instance);
+
+        var result = await module.ApplyAsync(
+            ResolvedUserData.Empty(new CloudConfigModel { Fqdn = "remote-access-e2e.example.com" }),
+            new TestModuleContext(os),
+            CancellationToken.None);
+
+        result.Should().BeOfType<ModuleOutcome.Completed>();
+        await os.Received().SetComputerNameAsync("remote-access-e", Arg.Any<CancellationToken>());
+    }
+
+    // One-shot guard: after the StageRunner re-enters us post-reboot the
+    // module accepts whatever the OS settled on and completes. No second
+    // rename attempt — even if Environment.MachineName disagrees with what
+    // we requested for some reason we did not anticipate.
+    [Fact]
+    public async Task Reboot_resume_does_not_rename_again_even_when_machine_name_differs()
+    {
+        var os = Substitute.For<IWindowsOs>();
+        os.GetComputerNameAsync(Arg.Any<CancellationToken>()).Returns("OS-NORMALIZED");
+        var module = new SetHostnameModule(NullLogger<SetHostnameModule>.Instance);
+
+        var result = await module.ApplyAsync(
+            ResolvedUserData.Empty(new CloudConfigModel { Hostname = "some-other-name" }),
+            new TestModuleContext(os, isRebootResume: true),
+            CancellationToken.None);
+
+        result.Should().BeOfType<ModuleOutcome.Completed>();
+        await os.DidNotReceive().SetComputerNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Reboot_resume_completes_quietly_when_machine_name_matches()
+    {
+        var os = Substitute.For<IWindowsOs>();
+        os.GetComputerNameAsync(Arg.Any<CancellationToken>()).Returns("box");
+        var module = new SetHostnameModule(NullLogger<SetHostnameModule>.Instance);
+
+        var result = await module.ApplyAsync(
+            ResolvedUserData.Empty(new CloudConfigModel { Hostname = "box" }),
+            new TestModuleContext(os, isRebootResume: true),
+            CancellationToken.None);
+
+        result.Should().BeOfType<ModuleOutcome.Completed>();
+        await os.DidNotReceive().SetComputerNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
     [Fact]
     public async Task Returns_completed_when_name_is_already_set()
     {

--- a/test/Eryph.GuestServices.Provisioning.Tests/Modules/TestModuleContext.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Modules/TestModuleContext.cs
@@ -6,7 +6,10 @@ namespace Eryph.GuestServices.Provisioning.Tests.Modules;
 
 internal sealed class TestModuleContext : IModuleContext
 {
-    public TestModuleContext(IWindowsOs os, DataSourceResult? dataSource = null)
+    public TestModuleContext(
+        IWindowsOs os,
+        DataSourceResult? dataSource = null,
+        bool isRebootResume = false)
     {
         Os = os;
         DataSource = dataSource ?? new DataSourceResult
@@ -14,9 +17,12 @@ internal sealed class TestModuleContext : IModuleContext
             SourceName = "test",
             InstanceId = "test-instance",
         };
+        IsRebootResume = isRebootResume;
     }
 
     public IWindowsOs Os { get; }
 
     public DataSourceResult DataSource { get; }
+
+    public bool IsRebootResume { get; }
 }

--- a/test/Eryph.GuestServices.Provisioning.Tests/Stages/StageRunnerRebootResumeTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Stages/StageRunnerRebootResumeTests.cs
@@ -167,6 +167,31 @@ public sealed class StageRunnerRebootResumeTests
     }
 
     [Fact]
+    public async Task Context_IsRebootResume_is_false_on_first_run_and_true_after_reboot_request()
+    {
+        // The "one-shot" modules (SetHostname) rely on IModuleContext.IsRebootResume
+        // to know whether they are being re-entered after their own previous
+        // reboot request. Pin the wiring down at the StageRunner layer.
+        var data = MakeData("i-1");
+        var stateStore = new InMemoryStateStore();
+        var semaphoreStore = new InMemorySemaphoreStore();
+        var module = new RebootOnceThenCompleteModule_CapturesResumeFlag("needs-reboot");
+
+        var runner = BuildRunner(
+            locator: LocatorReturning(data),
+            stateStore: stateStore,
+            semaphoreStore: semaphoreStore,
+            modules: [module]);
+
+        var first = await runner.RunAsync(CancellationToken.None);
+        var second = await runner.RunAsync(CancellationToken.None);
+
+        first.Should().BeOfType<StageRunOutcome.RebootRequested>();
+        second.Should().BeOfType<StageRunOutcome.Success>();
+        module.IsRebootResumeObservations.Should().Equal(false, true);
+    }
+
+    [Fact]
     public async Task Per_module_reboot_cap_fails_the_run_instead_of_looping_forever()
     {
         // A misbehaving module returns Reboot forever. Without a cap the
@@ -374,6 +399,20 @@ public sealed class StageRunnerRebootResumeTests
         {
             trace.Add(label);
             return Task.FromResult(ModuleOutcome.Ok());
+        }
+    }
+
+    [Stage(Stage.Final, Order = 0)]
+    private sealed class RebootOnceThenCompleteModule_CapturesResumeFlag(string reason) : IModule
+    {
+        public List<bool> IsRebootResumeObservations { get; } = new();
+
+        public Task<ModuleOutcome> ApplyAsync(ResolvedUserData userData, IModuleContext context, CancellationToken cancellationToken)
+        {
+            IsRebootResumeObservations.Add(context.IsRebootResume);
+            return IsRebootResumeObservations.Count == 1
+                ? Task.FromResult<ModuleOutcome>(ModuleOutcome.Reboot(reason))
+                : Task.FromResult(ModuleOutcome.Ok());
         }
     }
 


### PR DESCRIPTION
The provisioning agent reboot-looped (until the per-module cap aborted the run) when the cloud-config hostname exceeded the 15-char NetBIOS limit, e.g. `remote-access-e2e` (17 chars). Windows truncates server-side but `Environment.MachineName` then reports the 15-char form, so the module's "already set?" check never matched the requested name and asked for another reboot on every resume.

Two-layer fix in `SetHostnameModule`:

- Truncate desired name to 15 chars with a warning (cloudbase-init parity) so the requested and stored names agree.
- Make the module one-shot on reboot-resume via a new `IModuleContext.IsRebootResume` flag wired from `StageRunner`'s existing reboot-requested semaphore. On resume the module reads the current name, logs (warns if it differs from desired), and completes — no second rename, no second reboot, no loop. Robust against any future OS-side name normalization (case, dropped chars, etc.) we didn't anticipate.