### PR TITLE
Multi-key client auth + KvpAuthEnabled hardening

### DIFF
--- a/docs/user/reference/cli.md
+++ b/docs/user/reference/cli.md
@@ -101,7 +101,9 @@ Prints the agent name and version.
 
 ## Turning a capability off
 
-To disable first-boot provisioning or the remote-access transport on a guest,
-use the registry flags `ProvisioningEnabled` / `RemoteAccessEnabled` under
-`HKLM\SOFTWARE\eryph\guest-services` — see
-[Service control](settings.md#service-control-registry).
+To disable first-boot provisioning, the remote-access transport, or KVP-
+delivered client keys on a guest, use the operator flags `ProvisioningEnabled`,
+`RemoteAccessEnabled`, and `KvpAuthEnabled`. On Windows they live in the
+registry under `HKLM\SOFTWARE\eryph\guest-services`; on Linux in
+`/etc/opt/eryph/guest-services/service-control.conf`. See
+[Service control](settings.md#service-control).

--- a/docs/user/reference/settings.md
+++ b/docs/user/reference/settings.md
@@ -138,10 +138,13 @@ read at service start, so restart `eryph-guest-services` after changing them.
 ### Windows
 
 Stored in the registry under `HKLM\SOFTWARE\eryph\guest-services` as
-`REG_DWORD` values (`0` = off, anything else = on).
+`REG_DWORD` values (`0` = off, anything else = on). REG_SZ and other value
+types are ignored — only REG_DWORD is the documented control surface.
 
 ```powershell
 New-Item -Path 'HKLM:\SOFTWARE\eryph\guest-services' -Force | Out-Null
+Set-ItemProperty -Path 'HKLM:\SOFTWARE\eryph\guest-services' -Name 'ProvisioningEnabled' -Type DWord -Value 0
+Set-ItemProperty -Path 'HKLM:\SOFTWARE\eryph\guest-services' -Name 'RemoteAccessEnabled' -Type DWord -Value 0
 Set-ItemProperty -Path 'HKLM:\SOFTWARE\eryph\guest-services' -Name 'KvpAuthEnabled' -Type DWord -Value 0
 Restart-Service -Name eryph-guest-services
 ```
@@ -155,9 +158,11 @@ missing file = on). Blank lines and `#` comments are ignored.
 ```bash
 sudo install -d /etc/opt/eryph/guest-services
 sudo tee /etc/opt/eryph/guest-services/service-control.conf <<EOF
+ProvisioningEnabled=0
+RemoteAccessEnabled=0
 KvpAuthEnabled=0
 EOF
 sudo systemctl restart eryph-guest-services
 ```
 
-Set the value back to `1` (or delete the value / file) and restart to re-enable.
+Set values back to `1` (or delete the value / file) and restart to re-enable.

--- a/docs/user/reference/settings.md
+++ b/docs/user/reference/settings.md
@@ -119,27 +119,45 @@ Module names are case-insensitive and accept the `Module` suffix (`SetHostname`
 or `SetHostnameModule`). These lists only add or remove — stage membership and
 order are fixed. An unknown name is logged, not fatal.
 
-## Service control (registry)
+## Service control
 
-Two operator switches turn the top-level capabilities off. They live in the
-registry, not in `egs-provisioning.json`, because they're host controls separate
-from the provisioning tunables above.
-
-Key: `HKLM\SOFTWARE\eryph\guest-services`, values of type `REG_DWORD`.
+Operator switches that turn top-level capabilities off. They live outside
+`egs-provisioning.json` because they're host controls separate from the
+provisioning tunables above.
 
 | Value | Turns off | Default |
 | --- | --- | --- |
 | `ProvisioningEnabled` | The first-boot provisioning agent — no user-data is applied. | on |
 | `RemoteAccessEnabled` | The remote-access transport `egs-tool` connects to. | on |
+| `KvpAuthEnabled` | Honoring of authorized client keys delivered via Hyper-V data exchange. When off, only the locally provisioned key in `id_egs.pub` authorizes — pushes via `egs-tool add-ssh-config` and other KVP writers are ignored. | on |
 
-Both are opt-out: a capability is on unless the value is set to `0`. A missing
-value, a read error, or a non-Windows host all leave it on.
+All three are opt-out: a capability is on unless the value is set to `0`. A
+missing value, a read error, or an unknown OS all leave it on. The flags are
+read at service start, so restart `eryph-guest-services` after changing them.
+
+### Windows
+
+Stored in the registry under `HKLM\SOFTWARE\eryph\guest-services` as
+`REG_DWORD` values (`0` = off, anything else = on).
 
 ```powershell
 New-Item -Path 'HKLM:\SOFTWARE\eryph\guest-services' -Force | Out-Null
-Set-ItemProperty -Path 'HKLM:\SOFTWARE\eryph\guest-services' -Name 'ProvisioningEnabled' -Type DWord -Value 0
-Set-ItemProperty -Path 'HKLM:\SOFTWARE\eryph\guest-services' -Name 'RemoteAccessEnabled' -Type DWord -Value 0
+Set-ItemProperty -Path 'HKLM:\SOFTWARE\eryph\guest-services' -Name 'KvpAuthEnabled' -Type DWord -Value 0
+Restart-Service -Name eryph-guest-services
 ```
 
-Set the value back to `1` or delete it to re-enable. The flags are read at
-service start, so restart the `eryph guest services` service after changing them.
+### Linux
+
+Stored in `/etc/opt/eryph/guest-services/service-control.conf` as `KEY=VALUE`
+lines (`0` / `false` = off, case-insensitive; anything else, missing key, or
+missing file = on). Blank lines and `#` comments are ignored.
+
+```bash
+sudo install -d /etc/opt/eryph/guest-services
+sudo tee /etc/opt/eryph/guest-services/service-control.conf <<EOF
+KvpAuthEnabled=0
+EOF
+sudo systemctl restart eryph-guest-services
+```
+
+Set the value back to `1` (or delete the value / file) and restart to re-enable.

--- a/src/Eryph.GuestServices.Core/Constants.cs
+++ b/src/Eryph.GuestServices.Core/Constants.cs
@@ -39,6 +39,18 @@ public static class Constants
     public static readonly string ClientAuthKey = "eryph:guest-services:client-public-key";
 
     /// <summary>
+    /// Prefix for additional authorized-key slots in the External KVP pool.
+    /// The guest service treats every value whose key matches
+    /// <c>"eryph:guest-services:client-public-key:&lt;id&gt;"</c> as another
+    /// entry in the authorized set, in addition to the legacy single slot at
+    /// <see cref="ClientAuthKey"/>. The slot id is arbitrary (host name,
+    /// machine id, etc.) — only the prefix is meaningful. This sidesteps the
+    /// 2 KiB Hyper-V data exchange per-value limit when more than a handful
+    /// of keys are authorized.
+    /// </summary>
+    public static readonly string ClientAuthKeyPrefix = ClientAuthKey + ":";
+
+    /// <summary>
     /// The KVP key (External pool) that overrides the shell command spawned
     /// for an interactive SSH session. When unset, the service falls back to
     /// the SSH-sent <c>SHELL</c> environment variable, then to the platform

--- a/src/Eryph.GuestServices.Core/ServiceControlFlags.cs
+++ b/src/Eryph.GuestServices.Core/ServiceControlFlags.cs
@@ -4,11 +4,11 @@ using Microsoft.Win32;
 namespace Eryph.GuestServices.Core;
 
 /// <summary>
-/// Operator on/off switches for the two top-level guest-services capabilities.
-/// Both are <b>opt-out</b>: a capability is ON unless an operator has explicitly
-/// turned it off. This is an injectable seam so the gated services
-/// (provisioning agent, remote-access transport) can be unit-tested without
-/// touching the real registry.
+/// Operator on/off switches for the top-level guest-services capabilities.
+/// All flags are <b>opt-out</b>: a capability is ON unless an operator has
+/// explicitly turned it off. This is an injectable seam so the gated services
+/// (provisioning agent, remote-access transport, KVP-auth honoring) can be
+/// unit-tested without touching the real config sources.
 /// </summary>
 public interface IServiceControlFlags
 {
@@ -37,25 +37,31 @@ public interface IServiceControlFlags
 }
 
 /// <summary>
-/// Default <see cref="IServiceControlFlags"/> implementation. Reads the opt-out
-/// flags from <c>HKLM\SOFTWARE\eryph\guest-services</c> on Windows; on every
-/// other platform both capabilities are always ON (the registry is
-/// Windows-only).
+/// Default <see cref="IServiceControlFlags"/> implementation. Reads opt-out
+/// flags from the platform-native config source:
+/// <list type="bullet">
+/// <item><description>Windows: <c>HKLM\SOFTWARE\eryph\guest-services</c>
+/// REG_DWORD values (<c>0</c> = off, anything else = on).</description></item>
+/// <item><description>Linux: <c>/etc/opt/eryph/guest-services/service-control.conf</c>
+/// in <c>KEY=VALUE</c> format (<c>0</c> / <c>false</c> = off, anything
+/// else = on). Blank lines and <c>#</c> comments are ignored.</description></item>
+/// </list>
 /// </summary>
 /// <remarks>
-/// These are <b>fail-open</b> flags: a missing key/value or any registry /
-/// permission error yields <c>true</c>. We never disable a capability because of
-/// a read error — only an explicit <c>REG_DWORD</c> value of <c>0</c> turns a
-/// capability off. The value→bool interpretation lives in the pure
-/// <see cref="InterpretFlag"/> helper so it can be unit-tested without writing
-/// to HKLM (which needs admin and pollutes the machine). The Windows-only
-/// registry access is split behind a <c>[SupportedOSPlatform("windows")]</c>
-/// core plus an <see cref="OperatingSystem.IsWindows"/> gate, mirroring
-/// <c>PlatformProbes</c> / <c>AzureDataSource</c> so CA1416 stays clean.
+/// These are <b>fail-open</b> flags: a missing key/value, missing file, or any
+/// I/O / permission error yields <c>true</c>. We never disable a capability
+/// because of a read error — only an explicit <c>0</c> (or <c>false</c> on
+/// Linux) turns a capability off. The value→bool interpretation lives in the
+/// pure <see cref="InterpretFlag"/> helper so it is unit-testable without
+/// admin rights, registry writes, or filesystem state. Platform-gated reads
+/// are split behind <c>[SupportedOSPlatform]</c> attributes plus an
+/// <see cref="OperatingSystem"/> gate so CA1416 stays clean.
 /// </remarks>
-public sealed class RegistryServiceControlFlags : IServiceControlFlags
+public sealed class PlatformServiceControlFlags : IServiceControlFlags
 {
-    internal const string ServiceControlKey = @"SOFTWARE\eryph\guest-services";
+    internal const string WindowsServiceControlKey = @"SOFTWARE\eryph\guest-services";
+    internal const string LinuxServiceControlConfigPath = "/etc/opt/eryph/guest-services/service-control.conf";
+
     internal const string ProvisioningEnabledValue = "ProvisioningEnabled";
     internal const string RemoteAccessEnabledValue = "RemoteAccessEnabled";
     internal const string KvpAuthEnabledValue = "KvpAuthEnabled";
@@ -67,37 +73,83 @@ public sealed class RegistryServiceControlFlags : IServiceControlFlags
     public bool IsKvpAuthEnabled() => ReadFlag(KvpAuthEnabledValue);
 
     /// <summary>
-    /// Pure value→bool interpretation for an opt-out DWORD flag. A
-    /// <c>REG_DWORD</c> reads back as <see cref="int"/>: <c>0</c> means OFF,
-    /// any non-zero value means ON. A missing value (<c>null</c>) or any other
-    /// value kind means ON. Kept pure (no registry I/O) so the opt-out
-    /// semantics are unit-testable without admin or machine state.
+    /// Pure value→bool interpretation for an opt-out flag. Accepts the value
+    /// shapes both backends can produce. Off iff the value is an integer
+    /// <c>0</c> (Windows REG_DWORD), the string <c>"0"</c>, or the string
+    /// <c>"false"</c> (case-insensitive). Anything else — including
+    /// <see langword="null"/>, unrecognised shapes, or unparseable strings —
+    /// yields <c>true</c> (default ON / fail-open).
     /// </summary>
-    internal static bool InterpretFlag(object? regValue) =>
-        regValue is int i ? i != 0 : true;
+    internal static bool InterpretFlag(object? rawValue) => rawValue switch
+    {
+        null => true,
+        int i => i != 0,
+        string s when int.TryParse(s.Trim(), out var n) => n != 0,
+        string s when bool.TryParse(s.Trim(), out var b) => b,
+        _ => true,
+    };
 
     private static bool ReadFlag(string valueName)
     {
-        if (!OperatingSystem.IsWindows())
-            return true;
-
         try
         {
-            return ReadFlagCore(valueName);
+            if (OperatingSystem.IsWindows())
+                return ReadWindowsFlag(valueName);
+            if (OperatingSystem.IsLinux())
+                return ReadLinuxFlag(valueName);
+            return true;
         }
         catch
         {
-            // Fail-open: a registry / permission error must never disable a
-            // capability. These are opt-out flags; only an explicit 0 turns
-            // them off.
+            // Fail-open: any I/O / permission error must never disable a
+            // capability. These are opt-out flags; only an explicit "0" /
+            // "false" turns them off.
             return true;
         }
     }
 
     [SupportedOSPlatform("windows")]
-    private static bool ReadFlagCore(string valueName)
+    private static bool ReadWindowsFlag(string valueName)
     {
-        using var key = Registry.LocalMachine.OpenSubKey(ServiceControlKey);
+        using var key = Registry.LocalMachine.OpenSubKey(WindowsServiceControlKey);
         return InterpretFlag(key?.GetValue(valueName));
+    }
+
+    [SupportedOSPlatform("linux")]
+    private static bool ReadLinuxFlag(string valueName)
+    {
+        if (!File.Exists(LinuxServiceControlConfigPath))
+            return true;
+
+        foreach (var line in File.ReadAllLines(LinuxServiceControlConfigPath))
+        {
+            var entry = ParseConfigLine(line);
+            if (entry is null)
+                continue;
+            if (!string.Equals(entry.Value.key, valueName, StringComparison.OrdinalIgnoreCase))
+                continue;
+            return InterpretFlag(entry.Value.value);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Pure parser for a single line of the Linux service-control.conf file.
+    /// Returns <see langword="null"/> for blank lines and <c>#</c> comments,
+    /// or a <c>(key, value)</c> tuple for a well-formed <c>KEY=VALUE</c>
+    /// line. Whitespace around the key and value is trimmed.
+    /// </summary>
+    internal static (string key, string value)? ParseConfigLine(string line)
+    {
+        var trimmed = line.Trim();
+        if (trimmed.Length == 0 || trimmed[0] == '#')
+            return null;
+
+        var eq = trimmed.IndexOf('=');
+        if (eq <= 0)
+            return null;
+
+        return (trimmed[..eq].Trim(), trimmed[(eq + 1)..].Trim());
     }
 }

--- a/src/Eryph.GuestServices.Core/ServiceControlFlags.cs
+++ b/src/Eryph.GuestServices.Core/ServiceControlFlags.cs
@@ -51,9 +51,11 @@ public interface IServiceControlFlags
 /// These are <b>fail-open</b> flags: a missing key/value, missing file, or any
 /// I/O / permission error yields <c>true</c>. We never disable a capability
 /// because of a read error — only an explicit <c>0</c> (or <c>false</c> on
-/// Linux) turns a capability off. The value→bool interpretation lives in the
-/// pure <see cref="InterpretFlag"/> helper so it is unit-testable without
-/// admin rights, registry writes, or filesystem state. Platform-gated reads
+/// Linux) turns a capability off. The value→bool interpretation lives in two
+/// pure helpers — <see cref="InterpretWindowsRegistryValue"/> for the
+/// REG_DWORD path and <see cref="InterpretLinuxConfigValue"/> for the
+/// KEY=VALUE path — kept separate so a mistyped REG_SZ on Windows cannot
+/// accidentally exercise the Linux string-parsing rules. Platform-gated reads
 /// are split behind <c>[SupportedOSPlatform]</c> attributes plus an
 /// <see cref="OperatingSystem"/> gate so CA1416 stays clean.
 /// </remarks>

--- a/src/Eryph.GuestServices.Core/ServiceControlFlags.cs
+++ b/src/Eryph.GuestServices.Core/ServiceControlFlags.cs
@@ -73,19 +73,28 @@ public sealed class PlatformServiceControlFlags : IServiceControlFlags
     public bool IsKvpAuthEnabled() => ReadFlag(KvpAuthEnabledValue);
 
     /// <summary>
-    /// Pure value→bool interpretation for an opt-out flag. Accepts the value
-    /// shapes both backends can produce. Off iff the value is an integer
-    /// <c>0</c> (Windows REG_DWORD), the string <c>"0"</c>, or the string
-    /// <c>"false"</c> (case-insensitive). Anything else — including
-    /// <see langword="null"/>, unrecognised shapes, or unparseable strings —
-    /// yields <c>true</c> (default ON / fail-open).
+    /// Pure value→bool interpretation for a Windows REG_DWORD opt-out flag.
+    /// Off iff the registry value is the integer <c>0</c>. Anything else —
+    /// <see langword="null"/>, a REG_SZ string (even <c>"0"</c>), an
+    /// unrecognised kind — yields <c>true</c> (default ON / fail-open).
+    /// The documented Windows control surface is REG_DWORD only; honouring
+    /// strings would silently change long-standing behaviour.
     /// </summary>
-    internal static bool InterpretFlag(object? rawValue) => rawValue switch
+    internal static bool InterpretWindowsRegistryValue(object? regValue) =>
+        regValue is int i ? i != 0 : true;
+
+    /// <summary>
+    /// Pure value→bool interpretation for a Linux config-file opt-out flag.
+    /// Off iff the value is the literal string <c>"0"</c> or <c>"false"</c>
+    /// (case-insensitive, whitespace tolerated). Anything else — including
+    /// <see langword="null"/>, empty, or unparseable strings — yields
+    /// <c>true</c> (default ON / fail-open).
+    /// </summary>
+    internal static bool InterpretLinuxConfigValue(string? rawValue) => rawValue switch
     {
         null => true,
-        int i => i != 0,
-        string s when int.TryParse(s.Trim(), out var n) => n != 0,
-        string s when bool.TryParse(s.Trim(), out var b) => b,
+        var s when int.TryParse(s.Trim(), out var n) => n != 0,
+        var s when bool.TryParse(s.Trim(), out var b) => b,
         _ => true,
     };
 
@@ -112,7 +121,7 @@ public sealed class PlatformServiceControlFlags : IServiceControlFlags
     private static bool ReadWindowsFlag(string valueName)
     {
         using var key = Registry.LocalMachine.OpenSubKey(WindowsServiceControlKey);
-        return InterpretFlag(key?.GetValue(valueName));
+        return InterpretWindowsRegistryValue(key?.GetValue(valueName));
     }
 
     [SupportedOSPlatform("linux")]
@@ -128,7 +137,7 @@ public sealed class PlatformServiceControlFlags : IServiceControlFlags
                 continue;
             if (!string.Equals(entry.Value.key, valueName, StringComparison.OrdinalIgnoreCase))
                 continue;
-            return InterpretFlag(entry.Value.value);
+            return InterpretLinuxConfigValue(entry.Value.value);
         }
 
         return true;

--- a/src/Eryph.GuestServices.Core/ServiceControlFlags.cs
+++ b/src/Eryph.GuestServices.Core/ServiceControlFlags.cs
@@ -24,6 +24,16 @@ public interface IServiceControlFlags
     /// <c>true</c> unless an operator turned it off.
     /// </summary>
     bool IsRemoteAccessEnabled();
+
+    /// <summary>
+    /// Gates whether authorized client keys delivered via Hyper-V data exchange
+    /// (KVP) are honored. When <c>false</c>, only the locally provisioned
+    /// (on-disk) key authorizes — a hardening option for environments that
+    /// want eryph-zero / geneset to be the sole authority over guest access
+    /// and where keys pushed at runtime via <c>egs-tool add-ssh-config</c>
+    /// should be rejected. <c>true</c> unless an operator turned it off.
+    /// </summary>
+    bool IsKvpAuthEnabled();
 }
 
 /// <summary>
@@ -48,10 +58,13 @@ public sealed class RegistryServiceControlFlags : IServiceControlFlags
     internal const string ServiceControlKey = @"SOFTWARE\eryph\guest-services";
     internal const string ProvisioningEnabledValue = "ProvisioningEnabled";
     internal const string RemoteAccessEnabledValue = "RemoteAccessEnabled";
+    internal const string KvpAuthEnabledValue = "KvpAuthEnabled";
 
     public bool IsProvisioningEnabled() => ReadFlag(ProvisioningEnabledValue);
 
     public bool IsRemoteAccessEnabled() => ReadFlag(RemoteAccessEnabledValue);
+
+    public bool IsKvpAuthEnabled() => ReadFlag(KvpAuthEnabledValue);
 
     /// <summary>
     /// Pure value→bool interpretation for an opt-out DWORD flag. A

--- a/src/Eryph.GuestServices.Provisioning/Hosting/ProvisioningContainerBuilder.cs
+++ b/src/Eryph.GuestServices.Provisioning/Hosting/ProvisioningContainerBuilder.cs
@@ -69,10 +69,11 @@ internal static class ProvisioningContainerBuilder
         // they're operator-configurable.
         container.RegisterInstance(options.Settings ?? ProvisioningSettings.LoadOrDefault());
 
-        // Operator on/off flags (HKLM\SOFTWARE\eryph\guest-services). Injected so
-        // ProvisioningHostedService can gate the first-boot run. Opt-out: ON
-        // unless an explicit REG_DWORD 0 turns it off.
-        container.Register<IServiceControlFlags, RegistryServiceControlFlags>(Lifestyle.Singleton);
+        // Operator on/off flags. Windows: HKLM\SOFTWARE\eryph\guest-services
+        // REG_DWORD values; Linux: /etc/opt/eryph/guest-services/service-control.conf
+        // KEY=VALUE lines. Injected so ProvisioningHostedService can gate the
+        // first-boot run. Opt-out: ON unless an explicit 0/false turns it off.
+        container.Register<IServiceControlFlags, PlatformServiceControlFlags>(Lifestyle.Singleton);
 
         // Data sources. The locator orders by IDataSource.Priority, not registration
         // order — Azure(10) -> EC2(20) -> NoCloud(30) -> ConfigDrive(40) ->

--- a/src/Eryph.GuestServices.Service/Program.cs
+++ b/src/Eryph.GuestServices.Service/Program.cs
@@ -93,7 +93,7 @@ internal static class Program
         });
 
         builder.Services.AddLogging();
-        builder.Services.AddSingleton<IServiceControlFlags, RegistryServiceControlFlags>();
+        builder.Services.AddSingleton<IServiceControlFlags, PlatformServiceControlFlags>();
         builder.Services.AddHostedService<SshServerService>();
         builder.Services.AddSingleton<IHostKeyGenerator, HostKeyGenerator>();
         builder.Services.AddSingleton<IClientKeyProvider, ClientKeyProvider>();

--- a/src/Eryph.GuestServices.Service/Services/ClientKeyProvider.cs
+++ b/src/Eryph.GuestServices.Service/Services/ClientKeyProvider.cs
@@ -1,4 +1,4 @@
-﻿using Eryph.GuestServices.Core;
+using Eryph.GuestServices.Core;
 using Eryph.GuestServices.HvDataExchange.Guest;
 using Microsoft.DevTunnels.Ssh;
 using Microsoft.DevTunnels.Ssh.Algorithms;
@@ -6,47 +6,130 @@ using Microsoft.Extensions.Logging;
 
 namespace Eryph.GuestServices.Service.Services;
 
-public class ClientKeyProvider(
-    IKeyStorage keyStorage,
-    IGuestDataExchange dataExchange,
-    ILogger<ClientKeyProvider> logger)
-    : IClientKeyProvider
+public class ClientKeyProvider : IClientKeyProvider
 {
-    public async Task<IKeyPair?> GetClientKey()
+    private readonly IKeyStorage _keyStorage;
+    private readonly IGuestDataExchange _dataExchange;
+    private readonly ILogger<ClientKeyProvider> _logger;
+
+    // Read the KVP-auth flag once at construction and cache it. Matches the
+    // existing IsRemoteAccessEnabled pattern in SshServerService.StartAsync:
+    // operator changes to HKLM\SOFTWARE\eryph\guest-services\KvpAuthEnabled
+    // take effect on the next service restart, not on the next auth attempt.
+    // Hot-reload would surprise operators expecting deterministic policy and
+    // also make audit trails harder ("which value was in force at the time
+    // of this auth?").
+    private readonly bool _kvpAuthEnabled;
+
+    public ClientKeyProvider(
+        IKeyStorage keyStorage,
+        IGuestDataExchange dataExchange,
+        IServiceControlFlags controlFlags,
+        ILogger<ClientKeyProvider> logger)
     {
-        var clientKey = await keyStorage.GetClientKeyAsync();
-        if (clientKey is not null)
-            return clientKey;
-
-        logger.LogInformation("Client key not found. Trying to pull the key from the Hyper-V data exchange.");
-        
-        var guestData = await dataExchange.GetExternalDataAsync();
-        if (!guestData.TryGetValue(Constants.ClientAuthKey, out var clientKeyData))
-            return null;
-
-        if (string.IsNullOrEmpty(clientKeyData))
-            return null;
-
-        var keyPair = ParseKey(clientKeyData);
-        if (keyPair is null)
-            return null;
-
-        logger.LogInformation("Pulled client key from the Hyper-V data exchange. Saving the key.");
-        
-        await keyStorage.SetClientKeyAsync(keyPair);
-
-        return keyPair;
+        _keyStorage = keyStorage;
+        _dataExchange = dataExchange;
+        _logger = logger;
+        _kvpAuthEnabled = controlFlags.IsKvpAuthEnabled();
+        if (!_kvpAuthEnabled)
+        {
+            _logger.LogInformation(
+                "KVP-delivered authorized client keys are disabled via registry (HKLM\\SOFTWARE\\eryph\\guest-services\\KvpAuthEnabled=0); only the locally provisioned key will authorize. Restart the service after changing the flag.");
+        }
     }
 
-    private IKeyPair? ParseKey(string keyData)
+    public async Task<bool> IsAuthorizedAsync(IKeyPair candidate)
     {
+        var candidateBytes = candidate.GetPublicKeyBytes();
+
+        // The locally provisioned key (geneset / cloud-init writes it to disk
+        // during catlet creation) is the catlet's primary authorized identity.
+        // It survives KVP being cleared and is the only source on older
+        // catlets that predate the KVP delivery channel.
+        var provisionedKey = await _keyStorage.GetClientKeyAsync();
+        if (provisionedKey is not null && provisionedKey.GetPublicKeyBytes() == candidateBytes)
+            return true;
+
+        // Hardening switch (cached at startup; see ctor). When KVP-delivered
+        // keys are disabled the provisioned key above is the only source of
+        // trust — nothing pushed at runtime via add-ssh-config (or any future
+        // writer) can authorize against a catlet until the service is restarted
+        // with the flag flipped back.
+        if (!_kvpAuthEnabled)
+            return false;
+
+        // KVP carries additional keys pushed at runtime (egs-tool
+        // add-ssh-config and future multi-host scenarios). Re-read on every
+        // auth attempt so rotation and adds take effect without restarting
+        // the guest or clearing any cache.
+        IReadOnlyDictionary<string, string> guestData;
         try
         {
-            return KeyPair.ImportKey(keyData);
+            guestData = await _dataExchange.GetExternalDataAsync();
         }
         catch (Exception ex)
         {
-            logger.LogInformation(ex, "The provided key could not be parsed.");
+            // KVP reads can fail transiently. Don't lock the user out of the
+            // provisioned key just because the data exchange is unreachable;
+            // the cached/provisioned branch above already returned its verdict.
+            _logger.LogInformation(ex, "Failed to read external KVP data while evaluating authorized client keys.");
+            return false;
+        }
+
+        foreach (var (kvpKey, kvpValue) in guestData)
+        {
+            // Accept the legacy single slot AND any named slot under the
+            // ":<id>" prefix. The per-slot value still parses as
+            // authorized_keys-style 1..N lines so a writer can pack a few
+            // related keys without spinning up more slots.
+            if (kvpKey != Constants.ClientAuthKey
+                && !kvpKey.StartsWith(Constants.ClientAuthKeyPrefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(kvpValue))
+                continue;
+
+            foreach (var line in ParseAuthorizedKeyLines(kvpValue))
+            {
+                var keyPair = TryImport(line);
+                if (keyPair is null)
+                    continue;
+
+                if (keyPair.GetPublicKeyBytes() == candidateBytes)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    // authorized_keys-style: one OpenSSH public key per line, blank lines and
+    // '#' comments ignored. A single-line value (today's add-ssh-config wire
+    // shape) is a degenerate one-entry list — same code path, no special case.
+    private static IEnumerable<string> ParseAuthorizedKeyLines(string raw)
+    {
+        using var reader = new StringReader(raw);
+        while (reader.ReadLine() is { } line)
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length == 0 || trimmed[0] == '#')
+                continue;
+            yield return trimmed;
+        }
+    }
+
+    private IKeyPair? TryImport(string line)
+    {
+        try
+        {
+            return KeyPair.ImportKey(line);
+        }
+        catch (Exception ex)
+        {
+            // One malformed entry must not lock out the rest of the set.
+            _logger.LogInformation(ex, "Skipping unparseable authorized client key entry.");
             return null;
         }
     }

--- a/src/Eryph.GuestServices.Service/Services/ClientKeyProvider.cs
+++ b/src/Eryph.GuestServices.Service/Services/ClientKeyProvider.cs
@@ -14,11 +14,12 @@ public class ClientKeyProvider : IClientKeyProvider
 
     // Read the KVP-auth flag once at construction and cache it. Matches the
     // existing IsRemoteAccessEnabled pattern in SshServerService.StartAsync:
-    // operator changes to HKLM\SOFTWARE\eryph\guest-services\KvpAuthEnabled
-    // take effect on the next service restart, not on the next auth attempt.
-    // Hot-reload would surprise operators expecting deterministic policy and
-    // also make audit trails harder ("which value was in force at the time
-    // of this auth?").
+    // operator changes to the KvpAuthEnabled flag (HKLM\SOFTWARE\eryph\
+    // guest-services on Windows, /etc/opt/eryph/guest-services/
+    // service-control.conf on Linux) take effect on the next service
+    // restart, not on the next auth attempt. Hot-reload would surprise
+    // operators expecting deterministic policy and also make audit trails
+    // harder ("which value was in force at the time of this auth?").
     private readonly bool _kvpAuthEnabled;
 
     public ClientKeyProvider(

--- a/src/Eryph.GuestServices.Service/Services/ClientKeyProvider.cs
+++ b/src/Eryph.GuestServices.Service/Services/ClientKeyProvider.cs
@@ -34,7 +34,7 @@ public class ClientKeyProvider : IClientKeyProvider
         if (!_kvpAuthEnabled)
         {
             _logger.LogInformation(
-                "KVP-delivered authorized client keys are disabled via registry (HKLM\\SOFTWARE\\eryph\\guest-services\\KvpAuthEnabled=0); only the locally provisioned key will authorize. Restart the service after changing the flag.");
+                "KVP-delivered authorized client keys are disabled (KvpAuthEnabled=0); only the locally provisioned key will authorize. Restart the service after changing the flag.");
         }
     }
 

--- a/src/Eryph.GuestServices.Service/Services/IClientKeyProvider.cs
+++ b/src/Eryph.GuestServices.Service/Services/IClientKeyProvider.cs
@@ -8,7 +8,10 @@ public interface IClientKeyProvider
     /// Decides whether <paramref name="candidate"/> is allowed to authenticate
     /// against this guest. The authorized set is the union of the locally
     /// provisioned key (if any) and the keys delivered via Hyper-V data
-    /// exchange. Both sources are consulted on every call.
+    /// exchange. Implementations may short-circuit — typical: return true
+    /// immediately when the provisioned key matches, return false without
+    /// consulting KVP when the operator has disabled the KVP-auth flag
+    /// (see <c>KvpAuthEnabled</c>).
     /// </summary>
     Task<bool> IsAuthorizedAsync(IKeyPair candidate);
 }

--- a/src/Eryph.GuestServices.Service/Services/IClientKeyProvider.cs
+++ b/src/Eryph.GuestServices.Service/Services/IClientKeyProvider.cs
@@ -1,13 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.DevTunnels.Ssh.Algorithms;
 
 namespace Eryph.GuestServices.Service.Services;
 
 public interface IClientKeyProvider
 {
-    Task<IKeyPair?> GetClientKey();
+    /// <summary>
+    /// Decides whether <paramref name="candidate"/> is allowed to authenticate
+    /// against this guest. The authorized set is the union of the locally
+    /// provisioned key (if any) and the keys delivered via Hyper-V data
+    /// exchange. Both sources are consulted on every call.
+    /// </summary>
+    Task<bool> IsAuthorizedAsync(IKeyPair candidate);
 }

--- a/src/Eryph.GuestServices.Service/Services/IKeyStorage.cs
+++ b/src/Eryph.GuestServices.Service/Services/IKeyStorage.cs
@@ -6,8 +6,6 @@ public interface IKeyStorage
 {
     public Task<IKeyPair?> GetClientKeyAsync();
 
-    public Task SetClientKeyAsync(IKeyPair keyPair);
-
     public Task<IKeyPair?> GetHostKeyAsync();
 
     public Task SetHostKeyAsync(IKeyPair keyPair);

--- a/src/Eryph.GuestServices.Service/Services/LinuxKeyStorage.cs
+++ b/src/Eryph.GuestServices.Service/Services/LinuxKeyStorage.cs
@@ -33,17 +33,6 @@ public class LinuxKeyStorage : IKeyStorage
         return KeyPair.ImportKey(content);
     }
 
-    public async Task SetClientKeyAsync(IKeyPair keyPair)
-    {
-        Directory.CreateDirectory(ConfigDirectoryPath);
-
-        if (Path.Exists(ClientKeyPath))
-            throw new InvalidOperationException("Cannot update the client key. It already exists.");
-        
-        var keyBytes = KeyPair.ExportPublicKeyBytes(keyPair);
-        await File.WriteAllBytesAsync(ClientKeyPath, keyBytes);
-    }
-
     public async Task<IKeyPair?> GetHostKeyAsync()
     {
         EnsurePrivateDirectory();

--- a/src/Eryph.GuestServices.Service/Services/SshServerService.cs
+++ b/src/Eryph.GuestServices.Service/Services/SshServerService.cs
@@ -116,22 +116,17 @@ internal sealed class SshServerService(
         e.AuthenticationTask = CheckClientKey(e.PublicKey);
     }
 
-    private async Task<ClaimsPrincipal?> CheckClientKey(IKeyPair clientKey)
+    // internal for composition-root tests in Eryph.GuestServices.Service.Tests
+    internal async Task<ClaimsPrincipal?> CheckClientKey(IKeyPair clientKey)
     {
-        var expectedClientKey = await clientKeyProvider.GetClientKey();
-        if (expectedClientKey is null)
+        if (!await clientKeyProvider.IsAuthorizedAsync(clientKey))
         {
-            logger.LogInformation("Failed to authenticate client. The client public key is missing.");
+            logger.LogInformation(
+                "Failed to authenticate client. The provided public key is not authorized: {FingerPrint}.",
+                clientKey.GetFingerPrint());
             return null;
         }
 
-        if (clientKey.GetPublicKeyBytes() != expectedClientKey.GetPublicKeyBytes())
-        {
-            logger.LogInformation(
-                "Failed to authenticate client. The provided public does not match the expected public key: {FingerPrint}.",
-                expectedClientKey.GetFingerPrint());
-            return null;
-        }
         return new ClaimsPrincipal();
     }
 

--- a/src/Eryph.GuestServices.Service/Services/WindowsKeyStorage.cs
+++ b/src/Eryph.GuestServices.Service/Services/WindowsKeyStorage.cs
@@ -36,17 +36,6 @@ public class WindowsKeyStorage : IKeyStorage
         return KeyPair.ImportKey(content);
     }
 
-    public async Task SetClientKeyAsync(IKeyPair keyPair)
-    {
-        Directory.CreateDirectory(ConfigDirectoryPath);
-
-        if (File.Exists(ClientKeyPath))
-            throw new InvalidOperationException("Cannot update the client key. It already exists.");
-
-        var keyBytes = KeyPair.ExportPublicKeyBytes(keyPair);
-        await File.WriteAllBytesAsync(ClientKeyPath, keyBytes);
-    }
-
     public async Task<IKeyPair?> GetHostKeyAsync()
     {
         EnsurePrivateDirectory();

--- a/src/Eryph.GuestServices.Tool/Commands/AddSshConfigCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/AddSshConfigCommand.cs
@@ -27,11 +27,24 @@ public class AddSshConfigCommand : AsyncCommand<AddSshConfigCommand.Settings>
 
         var publicKey = KeyPair.ExportPublicKey(keyPair, keyFormat: KeyFormat.Ssh);
         var hostDataExchange = new HostDataExchange();
+        // Dual-write for cross-version compatibility:
+        //   - Named slot (new shape): re-running on the same host is
+        //     idempotent; running on a different host adds to the set without
+        //     evicting prior entries. Read by guest services >= this version.
+        //   - Legacy single slot: still consulted by older egs-service guests
+        //     that don't know about the named-slot family. Writing it keeps
+        //     this command working against pre-upgrade catlets. Multi-host
+        //     callers still race for the legacy slot (last-writer-wins) on
+        //     old guests, but that's the pre-existing behaviour, not a
+        //     regression introduced here. The legacy write can be dropped
+        //     once we no longer support upgrading from pre-multi-key guests.
+        var slotKey = Constants.ClientAuthKeyPrefix + Environment.MachineName.ToLowerInvariant();
         await hostDataExchange.SetExternalValuesAsync(
             settings.VmId,
             new Dictionary<string, string?>
             {
                 [Constants.ClientAuthKey] = publicKey,
+                [slotKey] = publicKey,
             });
 
         await SshConfigHelper.EnsureSshConfigAsync();

--- a/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/SshTestHelper.cs
+++ b/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/SshTestHelper.cs
@@ -13,10 +13,17 @@ public sealed class SshTestHelper : IDisposable
     private Stream? _clientStream;
     private Socket? _serverSocket;
 
+    // Per-test unique port. xUnit runs test classes in parallel within an
+    // assembly; on Linux VSOCK two helpers binding the same (cid, port)
+    // race and the second hits EADDRINUSE (Windows' Hyper-V transport
+    // tolerates the collision, which is why this only surfaced on Linux
+    // CI). The previous "use fixed port to avoid flakiness" comment had
+    // it backwards — a fixed port is what *causes* the race.
+    private static int _portCounter = 42425;
+
     public SshTestHelper()
     {
-        // Use fixed port to avoid test flakiness
-        var portNumber = 42425u;
+        var portNumber = (uint)Interlocked.Increment(ref _portCounter);
         ServiceId = PortNumberConverter.ToIntegrationId(portNumber);
     }
 

--- a/test/Eryph.GuestServices.Provisioning.Tests/Hosting/ProvisioningHostedServiceGateTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Hosting/ProvisioningHostedServiceGateTests.cs
@@ -81,5 +81,6 @@ public class ProvisioningHostedServiceGateTests
     {
         public bool IsProvisioningEnabled() => provisioningEnabled;
         public bool IsRemoteAccessEnabled() => true;
+        public bool IsKvpAuthEnabled() => true;
     }
 }

--- a/test/Eryph.GuestServices.Service.Tests/ClientKeyProviderTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/ClientKeyProviderTests.cs
@@ -321,23 +321,23 @@ public class ClientKeyProviderTests
     {
         // Real-world shape: the fixture has the exact bytes a user would
         // get from `cat ~/.ssh/authorized_keys` — extra trailing whitespace,
-        // a stray comment, two different algorithms with a key comment.
+        // a stray comment, two different curves with a key comment.
         // We generate two fresh keys and round-trip through the fixture
         // template to keep the test self-contained.
-        var ed = SshAlgorithms.PublicKey.ECDsaSha2Nistp256.GenerateKeyPair();
-        var rsa = SshAlgorithms.PublicKey.ECDsaSha2Nistp384.GenerateKeyPair();
+        var ecdsaP256 = SshAlgorithms.PublicKey.ECDsaSha2Nistp256.GenerateKeyPair();
+        var ecdsaP384 = SshAlgorithms.PublicKey.ECDsaSha2Nistp384.GenerateKeyPair();
         var fixture =
             "# /home/egs/.ssh/authorized_keys — managed by egs-tool\n"
             + "\n"
-            + KeyPair.ExportPublicKey(ed, keyFormat: KeyFormat.Ssh) + " admin@workstation\n"
+            + KeyPair.ExportPublicKey(ecdsaP256, keyFormat: KeyFormat.Ssh) + " admin@workstation\n"
             + "\n"
             + "# alt host\n"
-            + KeyPair.ExportPublicKey(rsa, keyFormat: KeyFormat.Ssh) + " ci@build-runner\r\n";
+            + KeyPair.ExportPublicKey(ecdsaP384, keyFormat: KeyFormat.Ssh) + " ci@build-runner\r\n";
 
         var provider = NewProvider(kvpValue: fixture);
 
-        (await provider.IsAuthorizedAsync(ed)).Should().BeTrue();
-        (await provider.IsAuthorizedAsync(rsa)).Should().BeTrue();
+        (await provider.IsAuthorizedAsync(ecdsaP256)).Should().BeTrue();
+        (await provider.IsAuthorizedAsync(ecdsaP384)).Should().BeTrue();
     }
 
     private static IKeyPair GenerateKey()

--- a/test/Eryph.GuestServices.Service.Tests/ClientKeyProviderTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/ClientKeyProviderTests.cs
@@ -1,0 +1,407 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.Core;
+using Eryph.GuestServices.HvDataExchange.Guest;
+using Eryph.GuestServices.Service.Services;
+using Microsoft.DevTunnels.Ssh;
+using Microsoft.DevTunnels.Ssh.Algorithms;
+using Microsoft.DevTunnels.Ssh.Keys;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Eryph.GuestServices.Service.Tests;
+
+public class ClientKeyProviderTests
+{
+    [Fact]
+    public async Task IsAuthorizedAsync_ProvisionedKeyMatchesCandidate_ReturnsTrue()
+    {
+        var provisioned = GenerateKey();
+        var provider = NewProvider(provisionedKey: provisioned);
+
+        (await provider.IsAuthorizedAsync(provisioned)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_NoProvisionedKey_KvpSingleKeyMatches_ReturnsTrue()
+    {
+        var kvpKey = GenerateKey();
+        var provider = NewProvider(kvpValue: ExportSsh(kvpKey));
+
+        (await provider.IsAuthorizedAsync(kvpKey)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_ProvisionedAndKvpAreDifferentKeys_BothAuthorize()
+    {
+        // Side-by-side: the provisioned (geneset) key keeps working AND any
+        // extra key added through KVP (add-ssh-config / future multi-host)
+        // also works. The whole point of this PR.
+        var provisioned = GenerateKey();
+        var kvpKey = GenerateKey();
+        var provider = NewProvider(provisionedKey: provisioned, kvpValue: ExportSsh(kvpKey));
+
+        (await provider.IsAuthorizedAsync(provisioned)).Should().BeTrue();
+        (await provider.IsAuthorizedAsync(kvpKey)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_NeitherSourceMatches_ReturnsFalse()
+    {
+        var provisioned = GenerateKey();
+        var kvpKey = GenerateKey();
+        var stranger = GenerateKey();
+        var provider = NewProvider(provisionedKey: provisioned, kvpValue: ExportSsh(kvpKey));
+
+        (await provider.IsAuthorizedAsync(stranger)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_KvpEntryMissing_NoProvisionedKey_ReturnsFalse()
+    {
+        var stranger = GenerateKey();
+        var provider = NewProvider();
+
+        (await provider.IsAuthorizedAsync(stranger)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_KvpValueWhitespaceOnly_TreatedAsEmpty()
+    {
+        var stranger = GenerateKey();
+        var provider = NewProvider(kvpValue: "   \r\n\t  ");
+
+        (await provider.IsAuthorizedAsync(stranger)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_KvpMultiLineValue_AnyEntryAuthorizes()
+    {
+        var a = GenerateKey();
+        var b = GenerateKey();
+        var c = GenerateKey();
+        var kvp = string.Join('\n', ExportSsh(a), ExportSsh(b), ExportSsh(c));
+        var provider = NewProvider(kvpValue: kvp);
+
+        (await provider.IsAuthorizedAsync(a)).Should().BeTrue();
+        (await provider.IsAuthorizedAsync(b)).Should().BeTrue();
+        (await provider.IsAuthorizedAsync(c)).Should().BeTrue();
+        (await provider.IsAuthorizedAsync(GenerateKey())).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_KvpMultiLineCrLf_AnyEntryAuthorizes()
+    {
+        // KVP transport doesn't normalize line endings; whatever the writer
+        // emitted lands here verbatim. Mirror authorized_keys leniency.
+        var a = GenerateKey();
+        var b = GenerateKey();
+        var kvp = ExportSsh(a) + "\r\n" + ExportSsh(b);
+        var provider = NewProvider(kvpValue: kvp);
+
+        (await provider.IsAuthorizedAsync(a)).Should().BeTrue();
+        (await provider.IsAuthorizedAsync(b)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_KvpBlankAndCommentLinesIgnored_GoodKeyStillAuthorizes()
+    {
+        var good = GenerateKey();
+        var kvp = $"""
+
+                   # this is a comment line
+                   {ExportSsh(good)}
+                       # indented comment
+
+                   """;
+        var provider = NewProvider(kvpValue: kvp);
+
+        (await provider.IsAuthorizedAsync(good)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_MalformedEntryAmongValid_StillAuthorizesValidEntries()
+    {
+        // One bad line must not lock out the rest of the set.
+        var good = GenerateKey();
+        var kvp = $"not-a-valid-ssh-key\n{ExportSsh(good)}\nssh-rsa not-base64-garbage";
+        var provider = NewProvider(kvpValue: kvp);
+
+        (await provider.IsAuthorizedAsync(good)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_KvpReadFails_ProvisionedKeyStillAuthorizes()
+    {
+        // Transient KVP failure must not lock out the provisioned identity.
+        var provisioned = GenerateKey();
+        var provider = NewProvider(
+            provisionedKey: provisioned,
+            dataExchange: new ThrowingDataExchange());
+
+        (await provider.IsAuthorizedAsync(provisioned)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_KvpReadFails_NoProvisionedKey_DeniesWithoutThrowing()
+    {
+        var stranger = GenerateKey();
+        var provider = NewProvider(dataExchange: new ThrowingDataExchange());
+
+        (await provider.IsAuthorizedAsync(stranger)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_NamedSlotKey_Authorizes()
+    {
+        // Named slot: eryph:guest-services:client-public-key:laptop-a
+        // Single key per slot — the small-payload path that sidesteps the
+        // 2 KiB Hyper-V data exchange per-value limit.
+        var key = GenerateKey();
+        var dataExchange = new StubDataExchange();
+        dataExchange.External[$"{Constants.ClientAuthKeyPrefix}laptop-a"] = ExportSsh(key);
+        var provider = NewProvider(dataExchange: dataExchange);
+
+        (await provider.IsAuthorizedAsync(key)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_SameKeyInLegacyAndNamedSlot_AuthorizesOnce()
+    {
+        // add-ssh-config dual-writes for cross-version compatibility: the same
+        // key lands in BOTH the legacy slot and the named slot. The reader
+        // must not get confused by the duplicate — any matching entry counts.
+        var key = GenerateKey();
+        var sshKey = ExportSsh(key);
+        var dataExchange = new StubDataExchange();
+        dataExchange.External[Constants.ClientAuthKey] = sshKey;
+        dataExchange.External[$"{Constants.ClientAuthKeyPrefix}laptop-a"] = sshKey;
+        var provider = NewProvider(dataExchange: dataExchange);
+
+        (await provider.IsAuthorizedAsync(key)).Should().BeTrue();
+        (await provider.IsAuthorizedAsync(GenerateKey())).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_LegacySlotAndNamedSlot_BothAuthorizeSideBySide()
+    {
+        // The legacy single-slot writer (today's add-ssh-config) keeps working
+        // even as new named-slot writers add keys without evicting it.
+        var legacyKey = GenerateKey();
+        var namedKey = GenerateKey();
+        var dataExchange = new StubDataExchange();
+        dataExchange.External[Constants.ClientAuthKey] = ExportSsh(legacyKey);
+        dataExchange.External[$"{Constants.ClientAuthKeyPrefix}ci-runner"] = ExportSsh(namedKey);
+        var provider = NewProvider(dataExchange: dataExchange);
+
+        (await provider.IsAuthorizedAsync(legacyKey)).Should().BeTrue();
+        (await provider.IsAuthorizedAsync(namedKey)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_MultipleNamedSlots_EachAuthorizes()
+    {
+        var a = GenerateKey();
+        var b = GenerateKey();
+        var c = GenerateKey();
+        var dataExchange = new StubDataExchange();
+        dataExchange.External[$"{Constants.ClientAuthKeyPrefix}laptop-a"] = ExportSsh(a);
+        dataExchange.External[$"{Constants.ClientAuthKeyPrefix}laptop-b"] = ExportSsh(b);
+        dataExchange.External[$"{Constants.ClientAuthKeyPrefix}ci-runner"] = ExportSsh(c);
+        var provider = NewProvider(dataExchange: dataExchange);
+
+        (await provider.IsAuthorizedAsync(a)).Should().BeTrue();
+        (await provider.IsAuthorizedAsync(b)).Should().BeTrue();
+        (await provider.IsAuthorizedAsync(c)).Should().BeTrue();
+        (await provider.IsAuthorizedAsync(GenerateKey())).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_NamedSlotEmptyOrWhitespace_IgnoredOtherSlotsAuthorize()
+    {
+        var good = GenerateKey();
+        var dataExchange = new StubDataExchange();
+        dataExchange.External[$"{Constants.ClientAuthKeyPrefix}empty"] = "";
+        dataExchange.External[$"{Constants.ClientAuthKeyPrefix}blank"] = "   \r\n  ";
+        dataExchange.External[$"{Constants.ClientAuthKeyPrefix}good"] = ExportSsh(good);
+        var provider = NewProvider(dataExchange: dataExchange);
+
+        (await provider.IsAuthorizedAsync(good)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_MalformedEntryInOneNamedSlot_DoesNotLockOutOtherSlots()
+    {
+        var good = GenerateKey();
+        var dataExchange = new StubDataExchange();
+        dataExchange.External[$"{Constants.ClientAuthKeyPrefix}bad"] = "not-a-valid-ssh-key";
+        dataExchange.External[$"{Constants.ClientAuthKeyPrefix}good"] = ExportSsh(good);
+        var provider = NewProvider(dataExchange: dataExchange);
+
+        (await provider.IsAuthorizedAsync(good)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_UnrelatedExternalKeysIgnored()
+    {
+        // The External pool also holds shell-override, status, etc. The reader
+        // must only consider the client-public-key slot family.
+        var legacy = GenerateKey();
+        var dataExchange = new StubDataExchange();
+        dataExchange.External[Constants.ClientAuthKey] = ExportSsh(legacy);
+        dataExchange.External[Constants.ShellKey] = "ssh-ed25519 NOT-A-CLIENT-KEY-just-a-prankster";
+        dataExchange.External["some.other.pool.entry"] = ExportSsh(GenerateKey());
+        var provider = NewProvider(dataExchange: dataExchange);
+
+        (await provider.IsAuthorizedAsync(legacy)).Should().BeTrue();
+        // An unrelated valid key under a foreign KVP slot must not authorize.
+        var unrelatedKeyBytes = dataExchange.External["some.other.pool.entry"];
+        var unrelatedKey = KeyPair.ImportKey(unrelatedKeyBytes);
+        (await provider.IsAuthorizedAsync(unrelatedKey!)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_KvpAuthDisabled_ProvisionedKeyStillAuthorizes()
+    {
+        // Hardening switch: KVP-delivered keys are rejected, but the on-disk
+        // provisioned key (the eryph-zero / geneset identity) remains the
+        // single trusted source.
+        var provisioned = GenerateKey();
+        var dataExchange = new StubDataExchange();
+        dataExchange.External[Constants.ClientAuthKey] = ExportSsh(GenerateKey());
+        var provider = NewProvider(
+            provisionedKey: provisioned,
+            dataExchange: dataExchange,
+            kvpAuthEnabled: false);
+
+        (await provider.IsAuthorizedAsync(provisioned)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_KvpAuthDisabled_KvpKeysRejected()
+    {
+        // Even an otherwise-valid KVP entry must not authorize when the
+        // operator has disabled KVP-based auth.
+        var kvpKey = GenerateKey();
+        var dataExchange = new StubDataExchange();
+        dataExchange.External[Constants.ClientAuthKey] = ExportSsh(kvpKey);
+        var provider = NewProvider(
+            dataExchange: dataExchange,
+            kvpAuthEnabled: false);
+
+        (await provider.IsAuthorizedAsync(kvpKey)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_KvpAuthDisabled_NamedSlotKeysRejected()
+    {
+        var namedKey = GenerateKey();
+        var dataExchange = new StubDataExchange();
+        dataExchange.External[$"{Constants.ClientAuthKeyPrefix}laptop-a"] = ExportSsh(namedKey);
+        var provider = NewProvider(
+            dataExchange: dataExchange,
+            kvpAuthEnabled: false);
+
+        (await provider.IsAuthorizedAsync(namedKey)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_KvpAuthDisabled_NoProvisionedKey_DeniesEverything()
+    {
+        var dataExchange = new StubDataExchange();
+        dataExchange.External[Constants.ClientAuthKey] = ExportSsh(GenerateKey());
+        dataExchange.External[$"{Constants.ClientAuthKeyPrefix}laptop-a"] = ExportSsh(GenerateKey());
+        var provider = NewProvider(
+            dataExchange: dataExchange,
+            kvpAuthEnabled: false);
+
+        (await provider.IsAuthorizedAsync(GenerateKey())).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsAuthorizedAsync_RealWorldAuthorizedKeysFixture_MembersAuthorize()
+    {
+        // Real-world shape: the fixture has the exact bytes a user would
+        // get from `cat ~/.ssh/authorized_keys` — extra trailing whitespace,
+        // a stray comment, two different algorithms with a key comment.
+        // We generate two fresh keys and round-trip through the fixture
+        // template to keep the test self-contained.
+        var ed = SshAlgorithms.PublicKey.ECDsaSha2Nistp256.GenerateKeyPair();
+        var rsa = SshAlgorithms.PublicKey.ECDsaSha2Nistp384.GenerateKeyPair();
+        var fixture =
+            "# /home/egs/.ssh/authorized_keys — managed by egs-tool\n"
+            + "\n"
+            + KeyPair.ExportPublicKey(ed, keyFormat: KeyFormat.Ssh) + " admin@workstation\n"
+            + "\n"
+            + "# alt host\n"
+            + KeyPair.ExportPublicKey(rsa, keyFormat: KeyFormat.Ssh) + " ci@build-runner\r\n";
+
+        var provider = NewProvider(kvpValue: fixture);
+
+        (await provider.IsAuthorizedAsync(ed)).Should().BeTrue();
+        (await provider.IsAuthorizedAsync(rsa)).Should().BeTrue();
+    }
+
+    private static IKeyPair GenerateKey()
+        => SshAlgorithms.PublicKey.ECDsaSha2Nistp256.GenerateKeyPair();
+
+    private static string ExportSsh(IKeyPair keyPair)
+        => KeyPair.ExportPublicKey(keyPair, keyFormat: KeyFormat.Ssh);
+
+    private static ClientKeyProvider NewProvider(
+        IKeyPair? provisionedKey = null,
+        string? kvpValue = null,
+        IGuestDataExchange? dataExchange = null,
+        bool kvpAuthEnabled = true)
+    {
+        if (dataExchange is null)
+        {
+            var stub = new StubDataExchange();
+            if (kvpValue is not null)
+                stub.External[Constants.ClientAuthKey] = kvpValue;
+            dataExchange = stub;
+        }
+
+        return new ClientKeyProvider(
+            new StubKeyStorage(provisionedKey),
+            dataExchange,
+            new StubFlags(kvpAuthEnabled),
+            NullLogger<ClientKeyProvider>.Instance);
+    }
+
+    private sealed class StubKeyStorage(IKeyPair? clientKey = null) : IKeyStorage
+    {
+        public Task<IKeyPair?> GetClientKeyAsync() => Task.FromResult(clientKey);
+        public Task<IKeyPair?> GetHostKeyAsync() => throw new InvalidOperationException("not relevant here");
+        public Task SetHostKeyAsync(IKeyPair keyPair) => throw new InvalidOperationException("not relevant here");
+    }
+
+    private sealed class StubDataExchange : IGuestDataExchange
+    {
+        public Dictionary<string, string> External { get; } = new();
+
+        public Task<IReadOnlyDictionary<string, string>> GetExternalDataAsync()
+            => Task.FromResult<IReadOnlyDictionary<string, string>>(External);
+
+        public Task<IReadOnlyDictionary<string, string>> GetGuestDataAsync()
+            => Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>());
+
+        public Task SetGuestValuesAsync(IReadOnlyDictionary<string, string?> values) => Task.CompletedTask;
+    }
+
+    private sealed class ThrowingDataExchange : IGuestDataExchange
+    {
+        public Task<IReadOnlyDictionary<string, string>> GetExternalDataAsync()
+            => throw new InvalidOperationException("simulated KVP failure");
+
+        public Task<IReadOnlyDictionary<string, string>> GetGuestDataAsync()
+            => Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>());
+
+        public Task SetGuestValuesAsync(IReadOnlyDictionary<string, string?> values) => Task.CompletedTask;
+    }
+
+    private sealed class StubFlags(bool kvpAuthEnabled = true) : IServiceControlFlags
+    {
+        public bool IsProvisioningEnabled() => true;
+        public bool IsRemoteAccessEnabled() => true;
+        public bool IsKvpAuthEnabled() => kvpAuthEnabled;
+    }
+}

--- a/test/Eryph.GuestServices.Service.Tests/ServiceControlFlagsTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/ServiceControlFlagsTests.cs
@@ -5,48 +5,110 @@ namespace Eryph.GuestServices.Service.Tests;
 
 public class ServiceControlFlagsTests
 {
-    // The pure value->bool interpretation is opt-out: only an explicit
-    // REG_DWORD 0 turns a capability off. Everything else (missing value or any
-    // non-zero) is ON. Tested without touching the real registry.
+    // The pure value->bool interpretation is opt-out: only an explicit 0 /
+    // false turns a capability off. Everything else (missing value, unknown
+    // shape) is ON. Tested without touching the real registry or filesystem.
 
     [Fact]
-    public void InterpretFlag_MissingValue_IsOn()
+    public void InterpretFlag_NullValue_IsOn()
     {
-        RegistryServiceControlFlags.InterpretFlag(null).Should().BeTrue();
+        PlatformServiceControlFlags.InterpretFlag(null).Should().BeTrue();
     }
+
+    // ---- Windows REG_DWORD shape (int) ----
 
     [Fact]
     public void InterpretFlag_DwordZero_IsOff()
     {
-        RegistryServiceControlFlags.InterpretFlag(0).Should().BeFalse();
+        PlatformServiceControlFlags.InterpretFlag(0).Should().BeFalse();
     }
 
     [Fact]
     public void InterpretFlag_DwordOne_IsOn()
     {
-        RegistryServiceControlFlags.InterpretFlag(1).Should().BeTrue();
+        PlatformServiceControlFlags.InterpretFlag(1).Should().BeTrue();
     }
 
     [Fact]
     public void InterpretFlag_NonZeroDword_IsOn()
     {
-        RegistryServiceControlFlags.InterpretFlag(42).Should().BeTrue();
+        PlatformServiceControlFlags.InterpretFlag(42).Should().BeTrue();
+    }
+
+    // ---- Linux config-file shape (string) ----
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("false")]
+    [InlineData("False")]
+    [InlineData("FALSE")]
+    [InlineData("  0  ")]      // whitespace around the value
+    [InlineData("  false ")]
+    public void InterpretFlag_StringFalsyValue_IsOff(string value)
+    {
+        PlatformServiceControlFlags.InterpretFlag(value).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("true")]
+    [InlineData("True")]
+    [InlineData("42")]
+    [InlineData("yes")]        // not parseable as bool/int -> default ON
+    [InlineData("")]            // empty string -> default ON
+    [InlineData("garbage")]
+    public void InterpretFlag_StringTruthyOrUnknown_IsOn(string value)
+    {
+        PlatformServiceControlFlags.InterpretFlag(value).Should().BeTrue();
     }
 
     [Fact]
-    public void InterpretFlag_NonIntValueKind_IsOn()
+    public void InterpretFlag_UnknownKind_IsOn()
     {
-        // A REG_SZ (or any non-DWORD) value is not the opt-out shape we honor,
-        // so it must not disable the capability.
-        RegistryServiceControlFlags.InterpretFlag("0").Should().BeTrue();
+        // A REG_SZ on Windows is not the opt-out shape we honor; tolerate by
+        // defaulting to ON. (REG_SZ is still a string after MZ; this guard is
+        // really about non-string/non-int CIM/registry types.)
+        PlatformServiceControlFlags.InterpretFlag(new object()).Should().BeTrue();
     }
 
-    [Fact]
-    public void NonWindowsOrDefault_AllCapabilities_AreOn()
+    // ---- Linux config-file line parser ----
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("# comment")]
+    [InlineData("  # indented comment")]
+    [InlineData("no-equals-sign")]
+    [InlineData("=value-without-key")]
+    public void ParseConfigLine_NotAnEntry_ReturnsNull(string line)
     {
-        // No flags set on the machine (and the Linux CI leg has no registry at
-        // all): every capability defaults to ON. Fail-open by design.
-        var flags = new RegistryServiceControlFlags();
+        PlatformServiceControlFlags.ParseConfigLine(line).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("KvpAuthEnabled=0", "KvpAuthEnabled", "0")]
+    [InlineData("  KvpAuthEnabled  =  0  ", "KvpAuthEnabled", "0")]
+    [InlineData("RemoteAccessEnabled=false", "RemoteAccessEnabled", "false")]
+    [InlineData("ProvisioningEnabled=1", "ProvisioningEnabled", "1")]
+    [InlineData("Key=value=with=equals", "Key", "value=with=equals")]
+    public void ParseConfigLine_WellFormed_ReturnsKeyValue(string line, string expectedKey, string expectedValue)
+    {
+        var entry = PlatformServiceControlFlags.ParseConfigLine(line);
+        entry.Should().NotBeNull();
+        entry!.Value.key.Should().Be(expectedKey);
+        entry.Value.value.Should().Be(expectedValue);
+    }
+
+    // ---- Platform dispatch (live) ----
+
+    [Fact]
+    public void Default_AllCapabilities_AreOn()
+    {
+        // No flags set on the machine (CI Linux has no /etc/opt/eryph file,
+        // CI Windows has no HKLM keys): every capability defaults to ON.
+        // Fail-open by design — also verifies the platform dispatcher
+        // doesn't throw when the config source is absent.
+        var flags = new PlatformServiceControlFlags();
 
         flags.IsProvisioningEnabled().Should().BeTrue();
         flags.IsRemoteAccessEnabled().Should().BeTrue();

--- a/test/Eryph.GuestServices.Service.Tests/ServiceControlFlagsTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/ServiceControlFlagsTests.cs
@@ -5,37 +5,63 @@ namespace Eryph.GuestServices.Service.Tests;
 
 public class ServiceControlFlagsTests
 {
-    // The pure value->bool interpretation is opt-out: only an explicit 0 /
-    // false turns a capability off. Everything else (missing value, unknown
-    // shape) is ON. Tested without touching the real registry or filesystem.
+    // Each backend has its own value→bool interpreter (kept separate so a
+    // mistyped REG_SZ on Windows cannot accidentally exercise the Linux
+    // string-parsing path). Both are opt-out: a capability is ON unless an
+    // explicit OFF value is present.
+
+    // ---- Windows registry shape (int / REG_DWORD only) ----
 
     [Fact]
-    public void InterpretFlag_NullValue_IsOn()
+    public void InterpretWindowsRegistryValue_NullValue_IsOn()
     {
-        PlatformServiceControlFlags.InterpretFlag(null).Should().BeTrue();
-    }
-
-    // ---- Windows REG_DWORD shape (int) ----
-
-    [Fact]
-    public void InterpretFlag_DwordZero_IsOff()
-    {
-        PlatformServiceControlFlags.InterpretFlag(0).Should().BeFalse();
+        PlatformServiceControlFlags.InterpretWindowsRegistryValue(null).Should().BeTrue();
     }
 
     [Fact]
-    public void InterpretFlag_DwordOne_IsOn()
+    public void InterpretWindowsRegistryValue_DwordZero_IsOff()
     {
-        PlatformServiceControlFlags.InterpretFlag(1).Should().BeTrue();
+        PlatformServiceControlFlags.InterpretWindowsRegistryValue(0).Should().BeFalse();
     }
 
     [Fact]
-    public void InterpretFlag_NonZeroDword_IsOn()
+    public void InterpretWindowsRegistryValue_DwordOne_IsOn()
     {
-        PlatformServiceControlFlags.InterpretFlag(42).Should().BeTrue();
+        PlatformServiceControlFlags.InterpretWindowsRegistryValue(1).Should().BeTrue();
+    }
+
+    [Fact]
+    public void InterpretWindowsRegistryValue_NonZeroDword_IsOn()
+    {
+        PlatformServiceControlFlags.InterpretWindowsRegistryValue(42).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("false")]
+    [InlineData("False")]
+    public void InterpretWindowsRegistryValue_RegSzFalsy_IsStillOn(string regSzValue)
+    {
+        // Regression guard. The documented Windows control surface is
+        // REG_DWORD only. A REG_SZ shouldn't silently disable a flag — a
+        // user typing the wrong type means "I tried to set it but
+        // mistyped", not "disable this capability".
+        PlatformServiceControlFlags.InterpretWindowsRegistryValue(regSzValue).Should().BeTrue();
+    }
+
+    [Fact]
+    public void InterpretWindowsRegistryValue_UnknownKind_IsOn()
+    {
+        PlatformServiceControlFlags.InterpretWindowsRegistryValue(new object()).Should().BeTrue();
     }
 
     // ---- Linux config-file shape (string) ----
+
+    [Fact]
+    public void InterpretLinuxConfigValue_NullValue_IsOn()
+    {
+        PlatformServiceControlFlags.InterpretLinuxConfigValue(null).Should().BeTrue();
+    }
 
     [Theory]
     [InlineData("0")]
@@ -44,9 +70,9 @@ public class ServiceControlFlagsTests
     [InlineData("FALSE")]
     [InlineData("  0  ")]      // whitespace around the value
     [InlineData("  false ")]
-    public void InterpretFlag_StringFalsyValue_IsOff(string value)
+    public void InterpretLinuxConfigValue_FalsyValue_IsOff(string value)
     {
-        PlatformServiceControlFlags.InterpretFlag(value).Should().BeFalse();
+        PlatformServiceControlFlags.InterpretLinuxConfigValue(value).Should().BeFalse();
     }
 
     [Theory]
@@ -57,18 +83,9 @@ public class ServiceControlFlagsTests
     [InlineData("yes")]        // not parseable as bool/int -> default ON
     [InlineData("")]            // empty string -> default ON
     [InlineData("garbage")]
-    public void InterpretFlag_StringTruthyOrUnknown_IsOn(string value)
+    public void InterpretLinuxConfigValue_TruthyOrUnknown_IsOn(string value)
     {
-        PlatformServiceControlFlags.InterpretFlag(value).Should().BeTrue();
-    }
-
-    [Fact]
-    public void InterpretFlag_UnknownKind_IsOn()
-    {
-        // A REG_SZ on Windows is not the opt-out shape we honor; tolerate by
-        // defaulting to ON. (REG_SZ is still a string after MZ; this guard is
-        // really about non-string/non-int CIM/registry types.)
-        PlatformServiceControlFlags.InterpretFlag(new object()).Should().BeTrue();
+        PlatformServiceControlFlags.InterpretLinuxConfigValue(value).Should().BeTrue();
     }
 
     // ---- Linux config-file line parser ----

--- a/test/Eryph.GuestServices.Service.Tests/ServiceControlFlagsTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/ServiceControlFlagsTests.cs
@@ -42,13 +42,14 @@ public class ServiceControlFlagsTests
     }
 
     [Fact]
-    public void NonWindowsOrDefault_BothCapabilities_AreOn()
+    public void NonWindowsOrDefault_AllCapabilities_AreOn()
     {
         // No flags set on the machine (and the Linux CI leg has no registry at
-        // all): both capabilities default to ON. Fail-open by design.
+        // all): every capability defaults to ON. Fail-open by design.
         var flags = new RegistryServiceControlFlags();
 
         flags.IsProvisioningEnabled().Should().BeTrue();
         flags.IsRemoteAccessEnabled().Should().BeTrue();
+        flags.IsKvpAuthEnabled().Should().BeTrue();
     }
 }

--- a/test/Eryph.GuestServices.Service.Tests/SshServerServiceAuthWiringTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/SshServerServiceAuthWiringTests.cs
@@ -1,0 +1,100 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.Core;
+using Eryph.GuestServices.DevTunnels.Ssh.Extensions;
+using Eryph.GuestServices.HvDataExchange.Guest;
+using Eryph.GuestServices.Service.Services;
+using Microsoft.DevTunnels.Ssh;
+using Microsoft.DevTunnels.Ssh.Algorithms;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Eryph.GuestServices.Service.Tests;
+
+/// <summary>
+/// Guards the small but easy-to-break wiring inside
+/// <see cref="SshServerService.CheckClientKey"/>: the candidate must reach the
+/// provider verbatim, and the authorization boolean must not be inverted.
+/// </summary>
+public class SshServerServiceAuthWiringTests
+{
+    [Fact]
+    public async Task CheckClientKey_PlumbsCandidateAndReturnsPrincipalWhenAuthorized()
+    {
+        var candidate = SshAlgorithms.PublicKey.ECDsaSha2Nistp256.GenerateKeyPair();
+        var provider = new RecordingClientKeyProvider(authorize: true);
+        var service = NewService(provider);
+
+        var principal = await service.CheckClientKey(candidate);
+
+        principal.Should().NotBeNull();
+        provider.Calls.Should().ContainSingle().Which.Should().BeSameAs(candidate);
+    }
+
+    [Fact]
+    public async Task CheckClientKey_ReturnsNullWhenProviderDenies()
+    {
+        var candidate = SshAlgorithms.PublicKey.ECDsaSha2Nistp256.GenerateKeyPair();
+        var provider = new RecordingClientKeyProvider(authorize: false);
+        var service = NewService(provider);
+
+        var principal = await service.CheckClientKey(candidate);
+
+        principal.Should().BeNull();
+    }
+
+    private static SshServerService NewService(IClientKeyProvider provider) => new(
+        new NoopKeyStorage(),
+        new NoopHostKeyGenerator(),
+        new NoopDataExchange(),
+        provider,
+        new NoopShellSelector(),
+        new EnabledFlags(),
+        NullLogger<SshServerService>.Instance);
+
+    private sealed class RecordingClientKeyProvider(bool authorize) : IClientKeyProvider
+    {
+        public List<IKeyPair> Calls { get; } = new();
+
+        public Task<bool> IsAuthorizedAsync(IKeyPair candidate)
+        {
+            Calls.Add(candidate);
+            return Task.FromResult(authorize);
+        }
+    }
+
+    private sealed class NoopKeyStorage : IKeyStorage
+    {
+        public Task<IKeyPair?> GetClientKeyAsync() => Task.FromResult<IKeyPair?>(null);
+        public Task<IKeyPair?> GetHostKeyAsync() => Task.FromResult<IKeyPair?>(null);
+        public Task SetHostKeyAsync(IKeyPair keyPair) => Task.CompletedTask;
+    }
+
+    private sealed class NoopHostKeyGenerator : IHostKeyGenerator
+    {
+        public IKeyPair GenerateHostKey()
+            => SshAlgorithms.PublicKey.ECDsaSha2Nistp256.GenerateKeyPair();
+    }
+
+    private sealed class NoopDataExchange : IGuestDataExchange
+    {
+        public Task<IReadOnlyDictionary<string, string>> GetExternalDataAsync()
+            => Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>());
+
+        public Task<IReadOnlyDictionary<string, string>> GetGuestDataAsync()
+            => Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>());
+
+        public Task SetGuestValuesAsync(IReadOnlyDictionary<string, string?> values) => Task.CompletedTask;
+    }
+
+    private sealed class NoopShellSelector : IShellSelector
+    {
+        public Task<ShellSelection> SelectAsync(ShellOverride sshOverride, CancellationToken cancellation)
+            => Task.FromResult(new ShellSelection("/bin/sh", string.Empty));
+    }
+
+    private sealed class EnabledFlags : IServiceControlFlags
+    {
+        public bool IsProvisioningEnabled() => true;
+        public bool IsRemoteAccessEnabled() => true;
+        public bool IsKvpAuthEnabled() => true;
+    }
+}

--- a/test/Eryph.GuestServices.Service.Tests/SshServerServiceRemoteAccessGateTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/SshServerServiceRemoteAccessGateTests.cs
@@ -57,12 +57,12 @@ public class SshServerServiceRemoteAccessGateTests
     {
         public bool IsProvisioningEnabled() => true;
         public bool IsRemoteAccessEnabled() => remoteAccessEnabled;
+        public bool IsKvpAuthEnabled() => true;
     }
 
     private sealed class ThrowingKeyStorage : IKeyStorage
     {
         public Task<IKeyPair?> GetClientKeyAsync() => throw new InvalidOperationException("should not be called");
-        public Task SetClientKeyAsync(IKeyPair keyPair) => throw new InvalidOperationException("should not be called");
         public Task<IKeyPair?> GetHostKeyAsync() => throw new InvalidOperationException("should not be called");
         public Task SetHostKeyAsync(IKeyPair keyPair) => throw new InvalidOperationException("should not be called");
     }
@@ -74,7 +74,7 @@ public class SshServerServiceRemoteAccessGateTests
 
     private sealed class ThrowingClientKeyProvider : IClientKeyProvider
     {
-        public Task<IKeyPair?> GetClientKey() => throw new InvalidOperationException("should not be called");
+        public Task<bool> IsAuthorizedAsync(IKeyPair candidate) => throw new InvalidOperationException("should not be called");
     }
 
     private sealed class ThrowingShellSelector : IShellSelector

--- a/test/e2e/Helpers.ps1
+++ b/test/e2e/Helpers.ps1
@@ -18,6 +18,50 @@ if (-not (Test-Path -LiteralPath $script:WinSshExe)) {
   throw "Windows OpenSSH ssh.exe not found at $($script:WinSshExe); install the 'OpenSSH.Client' optional feature."
 }
 
+function New-ThrowawayPassword {
+  <#
+  .SYNOPSIS
+    Generates a strong random password for a throwaway test account.
+    Never persisted past the catlet's AfterAll teardown. Generated rather
+    than hardcoded so secret scanners (GitGuardian etc.) don't flag the
+    source. Meets the Windows default complexity policy (upper + lower +
+    digit + symbol; >= 12 chars; avoids the obvious account-name overlap
+    traps from the Provisioning.E2E catlet comments).
+  #>
+  [CmdletBinding()]
+  param([int] $Length = 18)
+
+  $upper  = [char[]] 'ABCDEFGHJKLMNPQRSTUVWXYZ'    # excludes I, O
+  $lower  = [char[]] 'abcdefghjkmnpqrstuvwxyz'     # excludes i, l, o
+  $digits = [char[]] '23456789'                    # excludes 0, 1
+  $sym    = [char[]] '!@#$%^*-_=+?'
+
+  $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+  try {
+    function Pick($pool) {
+      $bytes = [byte[]]::new(4)
+      $rng.GetBytes($bytes)
+      $idx = [BitConverter]::ToUInt32($bytes, 0) % [uint32]$pool.Length
+      $pool[$idx]
+    }
+    # Seed one of each category, then fill with the union and shuffle.
+    $chars = @((Pick $upper), (Pick $lower), (Pick $digits), (Pick $sym))
+    $pool = $upper + $lower + $digits + $sym
+    while ($chars.Count -lt $Length) { $chars += Pick $pool }
+    # Fisher-Yates with the same RNG.
+    for ($i = $chars.Count - 1; $i -gt 0; $i--) {
+      $bytes = [byte[]]::new(4)
+      $rng.GetBytes($bytes)
+      $j = [int]([BitConverter]::ToUInt32($bytes, 0) % [uint32]($i + 1))
+      $tmp = $chars[$i]; $chars[$i] = $chars[$j]; $chars[$j] = $tmp
+    }
+    -join $chars
+  }
+  finally {
+    $rng.Dispose()
+  }
+}
+
 function New-TestProject {
   # Eryph project names are capped at 20 characters.
   $projectName = "egs-$(Get-Date -Format 'yyyyMMddHHmmss')"

--- a/test/e2e/Helpers.ps1
+++ b/test/e2e/Helpers.ps1
@@ -14,8 +14,10 @@
 # the docs and ssh_config generation target.
 $script:WinSshExe = Join-Path $env:WINDIR 'System32\OpenSSH\ssh.exe'
 $script:WinScpExe = Join-Path $env:WINDIR 'System32\OpenSSH\scp.exe'
-if (-not (Test-Path -LiteralPath $script:WinSshExe)) {
-  throw "Windows OpenSSH ssh.exe not found at $($script:WinSshExe); install the 'OpenSSH.Client' optional feature."
+foreach ($exe in @($script:WinSshExe, $script:WinScpExe)) {
+  if (-not (Test-Path -LiteralPath $exe)) {
+    throw "Windows OpenSSH binary not found at $exe; install the 'OpenSSH.Client' optional feature."
+  }
 }
 
 function New-ThrowawayPassword {

--- a/test/e2e/Helpers.ps1
+++ b/test/e2e/Helpers.ps1
@@ -13,6 +13,7 @@
 # Pinning to %WINDIR%\System32\OpenSSH\ssh.exe guarantees the same client
 # the docs and ssh_config generation target.
 $script:WinSshExe = Join-Path $env:WINDIR 'System32\OpenSSH\ssh.exe'
+$script:WinScpExe = Join-Path $env:WINDIR 'System32\OpenSSH\scp.exe'
 if (-not (Test-Path -LiteralPath $script:WinSshExe)) {
   throw "Windows OpenSSH ssh.exe not found at $($script:WinSshExe); install the 'OpenSSH.Client' optional feature."
 }
@@ -1184,5 +1185,274 @@ function Set-OfflineProvisioningSettings {
   }
   finally {
     Dismount-CatletVhd -VhdPath $mount.VhdPath
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Linux catlet helpers — direct sshd as the admin channel
+# ---------------------------------------------------------------------------
+#
+# PowerShell Direct does NOT work for Linux guests (Hyper-V VMBus PSDirect is
+# Windows-guest only). On Linux the admin channel is plain OpenSSH on TCP/22
+# as the OS user the linux-starter fodder gene provisioned with our public
+# key — cloud-init enables sshd by default on Ubuntu, so the channel exists
+# from first boot. Same architectural property as PsDirect on Windows: the
+# channel is INDEPENDENT of eryph-guest-services, so we can stop/start that
+# service without losing the session.
+
+function Invoke-CatletAdminSshLinux {
+  <#
+  .SYNOPSIS
+    Runs a shell command on a Linux catlet over its direct sshd, as the
+    cloud-init-provisioned admin user, authenticated by the host's
+    egs-tool private key (whose public half the linux-starter fodder
+    placed in the user's authorized_keys).
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] $Catlet,
+    [Parameter(Mandatory = $true)] [string] $Username,
+    [Parameter(Mandatory = $true)] [string] $Command,
+    [Parameter()] [int] $ConnectTimeoutSeconds = 15
+  )
+
+  $catletIp = (Get-CatletIp -Id $Catlet.Id).IpAddress
+  if (-not $catletIp) {
+    throw "Get-CatletIp returned no IP for $($Catlet.Name); admin channel unreachable."
+  }
+  $idEgs = Join-Path $env:ProgramData 'eryph\guest-services\private\id_egs'
+  # -F NUL to bypass any local ssh_config Host blocks (egs-tool
+  # update-ssh-config writes *.eryph.alt/*.hyper-v.alt patterns, but the
+  # IP target shouldn't match — be defensive).
+  return & $script:WinSshExe `
+    -F NUL `
+    -i $idEgs `
+    -o IdentitiesOnly=yes `
+    -o StrictHostKeyChecking=no `
+    -o "UserKnownHostsFile=$env:TEMP\egs-linux-known_hosts.tmp" `
+    -o BatchMode=yes `
+    -o "ConnectTimeout=$ConnectTimeoutSeconds" `
+    "$Username@$catletIp" $Command
+}
+
+function Wait-LinuxCatletSshReady {
+  <#
+  .SYNOPSIS
+    Polls direct sshd on the catlet's IP as the admin user until a probe
+    command (or `true`) returns 0. Times out with throw.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] $Catlet,
+    [Parameter(Mandatory = $true)] [string] $Username,
+    [Parameter()] [timespan] $Timeout = (New-TimeSpan -Minutes 10),
+    [Parameter()] [timespan] $Interval = (New-TimeSpan -Seconds 5)
+  )
+
+  $savedPref = $PSNativeCommandUseErrorActionPreference
+  $PSNativeCommandUseErrorActionPreference = $false
+  try {
+    $deadline = (Get-Date).Add($Timeout)
+    while ((Get-Date) -lt $deadline) {
+      Invoke-CatletAdminSshLinux -Catlet $Catlet -Username $Username -Command 'true' 2>&1 | Out-Null
+      if ($LASTEXITCODE -eq 0) { return }
+      Start-Sleep -Seconds $Interval.TotalSeconds
+    }
+    throw "Linux catlet $($Catlet.Name) sshd did not become reachable within $($Timeout.TotalSeconds)s."
+  }
+  finally {
+    $PSNativeCommandUseErrorActionPreference = $savedPref
+  }
+}
+
+function Update-EgsServiceLinuxOnline {
+  <#
+  .SYNOPSIS
+    Replaces the egs-service binaries on a running Linux catlet with a
+    locally-built linux-x64 publish, preserving /etc/opt/eryph/guest-services
+    (host key + id_egs.pub live there). Restarts the systemd unit
+    `eryph-guest-services` via direct sshd — never via the egs vsock
+    channel.
+
+  .NOTES
+    Per project memory, a single-DLL hot-swap is unsafe (ABI mismatch
+    between mixed builds → crash-loop). This helper REPLACES the entire
+    bin directory contents.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] $Catlet,
+    [Parameter(Mandatory = $true)] [string] $Username,
+    [Parameter(Mandatory = $true)] [string] $PublishPath
+  )
+
+  if (-not (Test-Path -LiteralPath $PublishPath)) {
+    throw "PublishPath not found: $PublishPath. Run 'dotnet publish -r linux-x64' first."
+  }
+  if (-not (Test-Path -LiteralPath (Join-Path $PublishPath 'egs-service'))) {
+    throw "egs-service binary not present under $PublishPath; check publish target (linux-x64)."
+  }
+
+  $catletIp = (Get-CatletIp -Id $Catlet.Id).IpAddress
+  if (-not $catletIp) { throw "No IP for $($Catlet.Name)" }
+  $idEgs = Join-Path $env:ProgramData 'eryph\guest-services\private\id_egs'
+
+  # Staging dir in the user's home — scp can write there without sudo;
+  # the install step then moves the files with sudo.
+  $stamp = [guid]::NewGuid().ToString('N').Substring(0, 8)
+  $remoteDir = "/tmp/egs-publish-$stamp"
+
+  $savedPref = $PSNativeCommandUseErrorActionPreference
+  $PSNativeCommandUseErrorActionPreference = $false
+  try {
+    Invoke-CatletAdminSshLinux -Catlet $Catlet -Username $Username `
+      -Command "mkdir -p $remoteDir" | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Failed to create staging dir on $($Catlet.Name)." }
+
+    Write-Verbose "Uploading $PublishPath -> $($Catlet.Name):$remoteDir"
+    # scp -r copies directory contents recursively. Bash's brace
+    # expansion isn't portable here — let scp do the recursion.
+    & $script:WinScpExe `
+      -i $idEgs `
+      -o IdentitiesOnly=yes `
+      -o StrictHostKeyChecking=no `
+      -o "UserKnownHostsFile=$env:TEMP\egs-linux-known_hosts.tmp" `
+      -o BatchMode=yes `
+      -r `
+      "$PublishPath/*" `
+      "${Username}@${catletIp}:$remoteDir/" 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "scp upload to $($Catlet.Name) returned $LASTEXITCODE." }
+
+    # All-in-one install: stop service, wipe bin, copy, set executable bit,
+    # restart. Preserve /etc/opt/eryph/guest-services entirely. Single line
+    # with `&&` so it survives the ssh.exe -> remote-shell hop without
+    # newline-handling surprises.
+    $installCmd = 'set -e && ' +
+      'sudo systemctl stop eryph-guest-services && ' +
+      'sudo find /opt/eryph/guest-services/bin -mindepth 1 -delete && ' +
+      "sudo cp -r $remoteDir/. /opt/eryph/guest-services/bin/ && " +
+      'sudo chmod +x /opt/eryph/guest-services/bin/egs-service && ' +
+      'sudo systemctl start eryph-guest-services && ' +
+      "rm -rf $remoteDir"
+    $installOutput = Invoke-CatletAdminSshLinux -Catlet $Catlet -Username $Username `
+      -Command $installCmd 2>&1
+    if ($LASTEXITCODE -ne 0) {
+      $logDir = Join-Path $env:TEMP 'egs-remoteaccess-linux-e2e-logs'
+      New-Item -ItemType Directory -Path $logDir -Force -ErrorAction SilentlyContinue | Out-Null
+      $log = Join-Path $logDir "$($Catlet.VmId)-install-$([DateTime]::UtcNow.Ticks).log"
+      "exit=$LASTEXITCODE`ncmd:`n$installCmd`n----`n" + ($installOutput | Out-String) `
+        | Set-Content -LiteralPath $log -Encoding utf8
+      throw "Binary install on $($Catlet.Name) returned $LASTEXITCODE; log: $log"
+    }
+  }
+  finally {
+    $PSNativeCommandUseErrorActionPreference = $savedPref
+  }
+}
+
+function Write-LinuxEgsClientKey {
+  <#
+  .SYNOPSIS
+    Writes a public key to /etc/opt/eryph/guest-services/id_egs.pub on a
+    running Linux catlet via the direct sshd admin channel. egs-service
+    reads this file on startup as the provisioned authorized identity.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] $Catlet,
+    [Parameter(Mandatory = $true)] [string] $Username,
+    [Parameter(Mandatory = $true)] [string] $PublicKey
+  )
+
+  # base64 the content to avoid quoting/escaping pitfalls through
+  # ssh.exe -> shell. The remote `tee` writes with root privileges via
+  # sudo; the parent dir is created by the egs-service package install.
+  $content = $PublicKey.TrimEnd() + "`n"
+  $b64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($content))
+  $cmd = "echo $b64 | base64 -d | sudo tee /etc/opt/eryph/guest-services/id_egs.pub > /dev/null"
+  Invoke-CatletAdminSshLinux -Catlet $Catlet -Username $Username `
+    -Command $cmd 2>&1 | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    throw "Writing id_egs.pub on $($Catlet.Name) returned $LASTEXITCODE."
+  }
+}
+
+function Set-CatletKvpAuthEnabledLinux {
+  <#
+  .SYNOPSIS
+    Writes / clears the KvpAuthEnabled flag in
+    /etc/opt/eryph/guest-services/service-control.conf on a running
+    Linux catlet, then restarts eryph-guest-services so the new value
+    is in force (PlatformServiceControlFlags caches at startup).
+
+    Channel: direct sshd as the admin user — independent of
+    eryph-guest-services lifecycle.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] $Catlet,
+    [Parameter(Mandatory = $true)] [string] $Username,
+    [Parameter()] [Nullable[int]] $Value
+  )
+
+  $confPath = '/etc/opt/eryph/guest-services/service-control.conf'
+
+  if ($null -eq $Value) {
+    # Clear: just remove the file (no flags = all default ON). Tolerate
+    # "file already absent" — rm -f is idempotent.
+    $writeCmd = "sudo rm -f $confPath"
+  } else {
+    $content = "KvpAuthEnabled=$Value`n"
+    $b64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($content))
+    $writeCmd = "echo $b64 | base64 -d | sudo tee $confPath > /dev/null"
+  }
+
+  $savedPref = $PSNativeCommandUseErrorActionPreference
+  $PSNativeCommandUseErrorActionPreference = $false
+  try {
+    Invoke-CatletAdminSshLinux -Catlet $Catlet -Username $Username `
+      -Command $writeCmd 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+      throw "service-control.conf write on $($Catlet.Name) returned $LASTEXITCODE."
+    }
+
+    # Read back so a hive/path mismatch surfaces immediately.
+    $verifyCmd = "test -f $confPath && cat $confPath || echo MISSING"
+    $readBack = (Invoke-CatletAdminSshLinux -Catlet $Catlet -Username $Username `
+      -Command $verifyCmd) | Out-String
+    if ($null -eq $Value) {
+      if ($readBack -notmatch 'MISSING') {
+        throw "KvpAuthEnabled clear did not take effect on $($Catlet.Name); conf still:`n$readBack"
+      }
+    } else {
+      if ($readBack -notmatch "KvpAuthEnabled\s*=\s*$Value") {
+        throw "KvpAuthEnabled=$Value not visible in conf on $($Catlet.Name). Got:`n$readBack"
+      }
+    }
+
+    # Restart over the admin channel (NOT via egs vsock — that would die
+    # with the service). systemctl restart blocks until the unit is
+    # active or failed; the egs-status poll below catches a failed unit.
+    Invoke-CatletAdminSshLinux -Catlet $Catlet -Username $Username `
+      -Command 'sudo systemctl restart eryph-guest-services' 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+      throw "systemctl restart on $($Catlet.Name) returned $LASTEXITCODE."
+    }
+
+    # Poll egs-status via host-side KVP until the new instance reports
+    # 'available' again.
+    $deadline = (Get-Date).AddMinutes(2)
+    $status = ''
+    while ((Get-Date) -lt $deadline) {
+      Start-Sleep -Seconds 2
+      try { $status = & egs-tool get-status $Catlet.VmId 2>&1 } catch { $status = $_.Exception.Message }
+      if ($status -eq 'available') { break }
+    }
+    if ($status -ne 'available') {
+      throw "egs-service did not return to 'available' within 2 minutes after restart on $($Catlet.Name) (status=$status)"
+    }
+  }
+  finally {
+    $PSNativeCommandUseErrorActionPreference = $savedPref
   }
 }

--- a/test/e2e/Helpers.ps1
+++ b/test/e2e/Helpers.ps1
@@ -2,6 +2,21 @@
 
 # Adapted from MaxBack/test/e2e/Helpers.ps1.
 
+# egs ssh ALWAYS has to use the Windows OpenSSH client. A bare `ssh.exe`
+# can resolve to Git-Bash's portable OpenSSH (in C:\Program Files\Git\usr\bin
+# on most dev boxes), which:
+#   - reads ~/.ssh/config as a Unix path and corrupts Windows-style Include
+#     directives ("/c/Users/<u>/.ssh/<C:\Users\...>") — so the catlet alias
+#     blocks are never applied and the hostname falls through to DNS;
+#   - uses MSYS2-bundled libcrypto which fails to load private keys whose
+#     ACL only grants BUILTIN\Administrators (the egs id_egs files).
+# Pinning to %WINDIR%\System32\OpenSSH\ssh.exe guarantees the same client
+# the docs and ssh_config generation target.
+$script:WinSshExe = Join-Path $env:WINDIR 'System32\OpenSSH\ssh.exe'
+if (-not (Test-Path -LiteralPath $script:WinSshExe)) {
+  throw "Windows OpenSSH ssh.exe not found at $($script:WinSshExe); install the 'OpenSSH.Client' optional feature."
+}
+
 function New-TestProject {
   # Eryph project names are capped at 20 characters.
   $projectName = "egs-$(Get-Date -Format 'yyyyMMddHHmmss')"
@@ -368,6 +383,54 @@ function Update-EgsServiceBinariesOffline {
     }
 
     Disable-CloudbaseInitUnattend -VolumeRoot $mount.VolumeRoot
+  }
+  finally {
+    Dismount-CatletVhd -VhdPath $mount.VhdPath
+  }
+}
+
+function Write-OfflineEgsClientKey {
+  <#
+  .SYNOPSIS
+    Writes a public key into the offline catlet's egs-service client-key
+    cache path (C:\ProgramData\eryph\guest-services\id_egs.pub), mimicking
+    what gene:dbosoft/guest-services:win-install would have done. Used in
+    the offline-injection path where cloudbase-init (and the win-install
+    gene that depends on it) are disabled.
+
+  .DESCRIPTION
+    The catlet must be Stopped. Mounts the VHD, creates the directory
+    chain if missing, writes the supplied public-key string (single
+    OpenSSH line), then dismounts. egs-service reads this file via
+    WindowsKeyStorage.GetClientKeyAsync on first auth and treats it as
+    the catlet's primary authorized identity.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] [Guid] $VmId,
+    [Parameter(Mandatory = $true)] [string] $PublicKey
+  )
+
+  $status = (Get-VM -Id $VmId).State
+  if ($status -eq 'Running' -or $status -eq 'Saved') {
+    throw "Catlet must be Stopped (current: $status) before mounting its VHD."
+  }
+
+  $mount = Mount-CatletVhd -VmId $VmId
+  try {
+    $configDir = Join-Path $mount.VolumeRoot 'ProgramData\eryph\guest-services'
+    if (-not (Test-Path -LiteralPath $configDir)) {
+      New-Item -ItemType Directory -Path $configDir -Force | Out-Null
+    }
+    $keyFile = Join-Path $configDir 'id_egs.pub'
+    # WindowsKeyStorage.GetClientKeyAsync reads with File.ReadAllText and
+    # then KeyPair.ImportKey, so trailing newlines are tolerated. Match the
+    # OpenSSH single-line convention with one trailing LF. UTF-8 *without*
+    # BOM — File.ReadAllText auto-strips BOM, but the OpenSSH writer
+    # convention is BOM-less and a few key parsers in the wild trip on it.
+    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+    [System.IO.File]::WriteAllText($keyFile, $PublicKey.TrimEnd() + "`n", $utf8NoBom)
+    Write-Verbose "Wrote provisioned client key to $keyFile"
   }
   finally {
     Dismount-CatletVhd -VhdPath $mount.VhdPath
@@ -779,6 +842,252 @@ function Save-GuestDiagnostics {
     $PSNativeCommandUseErrorActionPreference = $savedPref
   }
   Write-Host "Guest diagnostics saved to $OutputDir"
+}
+
+function Push-CatletExternalKvp {
+  <#
+  .SYNOPSIS
+    Writes a single key/value into the External KVP pool of a (running)
+    Hyper-V VM, bypassing egs-tool. Used by the multi-key e2e to push
+    arbitrary authorized client keys into named slots without mutating the
+    host's local egs-tool key files.
+
+  .DESCRIPTION
+    Mirrors what HostDataExchange.SetExternalValuesAsync does in C#: build
+    a Msvm_KvpExchangeDataItem (Source = HostExternal = 0), serialize to a
+    WMI-DTD embedded instance, and invoke AddKvpItems on the host's
+    Msvm_VirtualSystemManagementService. Falls back to ModifyKvpItems when
+    the slot already exists. Returns when the operation completes (poll-
+    short-sleep for the async-job code path).
+
+    Requires administrator + Hyper-V.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] [Guid] $VmId,
+    [Parameter(Mandatory = $true)] [string] $Key,
+    [Parameter(Mandatory = $true)] [string] $Value
+  )
+
+  $ns = 'root\virtualization\v2'
+  $vm = Get-CimInstance -Namespace $ns -ClassName Msvm_ComputerSystem `
+    -Filter "Name = '$VmId'"
+  if (-not $vm) { throw "Hyper-V VM $VmId not found in $ns" }
+
+  $vmms = Get-CimInstance -Namespace $ns -ClassName Msvm_VirtualSystemManagementService
+
+  $itemClass = Get-CimClass -Namespace $ns -ClassName Msvm_KvpExchangeDataItem
+  $item = New-CimInstance -CimClass $itemClass -Property @{
+    Name = $Key
+    Data = $Value
+    Source = [UInt16]0   # HostExternal
+  } -ClientOnly
+
+  $serializer = [Microsoft.Management.Infrastructure.Serialization.CimSerializer]::Create()
+  $bytes = $serializer.Serialize($item, `
+    [Microsoft.Management.Infrastructure.Serialization.InstanceSerializationOptions]::None)
+  $embedded = [System.Text.Encoding]::Unicode.GetString($bytes)
+
+  # Try Add first; on any non-success/non-async return, fall through to Modify.
+  $result = Invoke-CimMethod -InputObject $vmms -MethodName 'AddKvpItems' `
+    -Arguments @{ TargetSystem = $vm; DataItems = @($embedded) }
+  if ($result.ReturnValue -ne 0 -and $result.ReturnValue -ne 4096) {
+    $result = Invoke-CimMethod -InputObject $vmms -MethodName 'ModifyKvpItems' `
+      -Arguments @{ TargetSystem = $vm; DataItems = @($embedded) }
+  }
+  if ($result.ReturnValue -ne 0 -and $result.ReturnValue -ne 4096) {
+    throw "Add/ModifyKvpItems for '$Key' failed: ReturnValue=$($result.ReturnValue)"
+  }
+
+  # 4096 == async job; sleep briefly. KVP writes are sub-second so this is
+  # ample without us having to thread a Msvm_ConcreteJob poller.
+  if ($result.ReturnValue -eq 4096) {
+    Start-Sleep -Seconds 2
+  }
+}
+
+function Test-CatletSshWithKey {
+  <#
+  .SYNOPSIS
+    Returns the exit code of `ssh hostname` against a catlet using the
+    supplied identity file. Zero = auth succeeded; non-zero = auth failed
+    (or the proxy/network broke). Suppresses prompts so a failed auth is
+    a fast, deterministic non-zero exit.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] [Guid] $VmId,
+    [Parameter(Mandatory = $true)] [string] $IdentityFile,
+    [Parameter()] [int] $TimeoutSeconds = 10
+  )
+
+  $savedPref = $PSNativeCommandUseErrorActionPreference
+  $PSNativeCommandUseErrorActionPreference = $false
+  try {
+    $proxy = "egs-tool.exe proxy $VmId"
+    # Capture stderr so a failure here yields an actionable log instead of
+    # an opaque exit-255. Pester redirection / variable-scope differences
+    # have bitten us before; the log file makes both rerunnable and easy
+    # to diff against an interactive ssh probe.
+    # `-F NUL` ignores ~/.ssh/config entirely. Without it, the catlet's
+    # Host block (written by egs-tool update-ssh-config) matches the
+    # *.hyper-v.alt target and silently adds `IdentityFile
+    # C:\ProgramData\eryph\guest-services\private\id_egs` to the list of
+    # keys ssh.exe offers — even with IdentitiesOnly=yes, because that
+    # flag merely restricts to "keys explicitly listed in config or -i",
+    # and the Host-block IdentityFile counts as explicit. The fallback
+    # makes a "this key should be REJECTED" test pass spuriously, because
+    # the provisioned id_egs key still authorizes after the ephemeral
+    # bounces off the gate. ProxyCommand is supplied via -o so we don't
+    # need the Host block for routing either.
+    $output = & $script:WinSshExe `
+      -F NUL `
+      -i $IdentityFile `
+      -o "IdentitiesOnly=yes" `
+      -o "StrictHostKeyChecking=no" `
+      -o "UserKnownHostsFile=$env:TEMP\egs-remoteaccess-known_hosts.tmp" `
+      -o "BatchMode=yes" `
+      -o "PasswordAuthentication=no" `
+      -o "KbdInteractiveAuthentication=no" `
+      -o "ConnectTimeout=$TimeoutSeconds" `
+      -o "ProxyCommand=$proxy" `
+      -v `
+      "egs@$($VmId).hyper-v.alt" hostname 2>&1
+    $exit = $LASTEXITCODE
+    if ($exit -ne 0) {
+      $logDir = Join-Path $env:TEMP "egs-remoteaccess-e2e-ssh-logs"
+      New-Item -ItemType Directory -Path $logDir -Force -ErrorAction SilentlyContinue | Out-Null
+      $log = Join-Path $logDir "$VmId-$([DateTime]::UtcNow.Ticks).log"
+      "exit=$exit`nargs: -i $IdentityFile / egs@$VmId.hyper-v.alt hostname / ProxyCommand=$proxy`n----`n" + ($output | Out-String) `
+        | Set-Content -LiteralPath $log -Encoding utf8
+      Write-Host "ssh probe failed (exit=$exit); log: $log"
+    }
+    return $exit
+  }
+  finally {
+    $PSNativeCommandUseErrorActionPreference = $savedPref
+    Remove-Item -LiteralPath "$env:TEMP\egs-remoteaccess-known_hosts.tmp" -Force -ErrorAction SilentlyContinue
+  }
+}
+
+function Set-CatletKvpAuthEnabled {
+  <#
+  .SYNOPSIS
+    Writes (or clears) the HKLM\SOFTWARE\eryph\guest-services\KvpAuthEnabled
+    DWORD inside a running catlet AND restarts eryph-guest-services so the
+    new flag value is in force. The service caches the flag at startup
+    (matches IsRemoteAccessEnabled semantics), so a registry change alone
+    is invisible to the running service until restart.
+
+    Uses PowerShell Direct (Hyper-V VMBus) for BOTH the registry write and
+    the service restart — no networking, no SSH, no firewall. The caller
+    supplies a Credential for an admin user on the catlet. This channel is
+    independent of eryph-guest-services lifecycle, so stopping it does NOT
+    kill the admin session.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] $Catlet,
+    [Parameter()] [Nullable[int]] $Value,  # null = delete, otherwise REG_DWORD
+    [Parameter(Mandatory = $true)] [pscredential] $Credential
+  )
+
+  # All registry I/O + the restart go through PowerShell Direct. Same
+  # channel for write, verify, and restart — survives the service stop.
+  Invoke-Command -VMId $Catlet.VmId -Credential $Credential -ScriptBlock {
+    param([Nullable[int]] $TargetValue)
+    $key = 'HKLM:\SOFTWARE\eryph\guest-services'
+    if ($null -eq $TargetValue) {
+      if (Test-Path -LiteralPath $key) {
+        Remove-ItemProperty -LiteralPath $key -Name 'KvpAuthEnabled' -ErrorAction SilentlyContinue
+      }
+    } else {
+      if (-not (Test-Path -LiteralPath $key)) {
+        New-Item -Path $key -Force | Out-Null
+      }
+      Set-ItemProperty -LiteralPath $key -Name 'KvpAuthEnabled' -Type DWord -Value $TargetValue
+    }
+    # Read back so the caller can fail fast if the write didn't land
+    # where egs-service reads from.
+    $kvp = Get-ItemProperty -LiteralPath $key -Name 'KvpAuthEnabled' -ErrorAction SilentlyContinue
+    if ($null -ne $kvp) { $kvp.KvpAuthEnabled } else { $null }
+  } -ArgumentList $Value -OutVariable readBack | Out-Null
+
+  if ($null -eq $Value) {
+    if ($null -ne $readBack[0]) {
+      throw "KvpAuthEnabled clear did not take effect on $($Catlet.Name); still reads $($readBack[0])."
+    }
+  } else {
+    if ($readBack[0] -ne $Value) {
+      throw "KvpAuthEnabled=$Value not visible on $($Catlet.Name) (read back $($readBack[0]))."
+    }
+  }
+
+  # Restart eryph-guest-services so the new (cached-at-startup) flag is
+  # in force. PowerShell Direct is independent of the service, so this
+  # works cleanly even though we're stopping the SSH listener that other
+  # tests rely on.
+  Invoke-Command -VMId $Catlet.VmId -Credential $Credential -ScriptBlock {
+    Restart-Service -Name eryph-guest-services -Force
+  } | Out-Null
+
+  # Poll until the SSH listener is back via the egs channel.
+  $deadline = (Get-Date).AddMinutes(2)
+  $status = ''
+  while ((Get-Date) -lt $deadline) {
+    Start-Sleep -Seconds 2
+    try { $status = & egs-tool get-status $Catlet.VmId 2>&1 } catch { $status = $_.Exception.Message }
+    if ($status -eq 'available') { break }
+  }
+  if ($status -ne 'available') {
+    throw "egs-service did not return to 'available' within 2 minutes after restart (status=$status)"
+  }
+}
+
+function New-EphemeralSshKey {
+  <#
+  .SYNOPSIS
+    Generates an ephemeral ecdsa-sha2-nistp256 keypair into a temp
+    directory and returns a record with the private-key path and
+    public-key OpenSSH string. The caller owns cleanup.
+
+  .NOTES
+    Algorithm is ecdsa-sha2-nistp256 because the egs-service's SSH
+    library (Microsoft.DevTunnels.Ssh) advertises only rsa-sha2-* and
+    ecdsa-sha2-nistp{256,384}. An ed25519 ephemeral key parses and is
+    accepted into the authorized set on the guest, but the handshake
+    fails with "PublicKeyAlgorithm not supported: ssh-ed25519" — the
+    library can't VERIFY ed25519 signatures.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter()] [string] $Comment = 'multikey-e2e-ephemeral'
+  )
+
+  $dir = Join-Path $env:TEMP "egs-multikey-$([guid]::NewGuid().ToString('N'))"
+  New-Item -ItemType Directory -Path $dir -Force | Out-Null
+  $key = Join-Path $dir 'id'
+
+  # Pin to the Windows OpenSSH ssh-keygen so the produced key file is
+  # readable by the Windows OpenSSH ssh.exe we use to authenticate. The
+  # Git-Bash variant writes files OK but the ACL pattern can trip an
+  # IdentityFile permissions check on Windows.
+  #
+  # -N '' creates a passphraseless key. Do NOT use -N '""' — PowerShell
+  # passes those two double-quote characters through verbatim and
+  # ssh-keygen encrypts the key with a literal two-char passphrase, which
+  # ssh.exe in BatchMode then silently fails to decrypt (server accepts
+  # the public key offer, client can't sign, ssh exits 255).
+  $sshKeygen = Join-Path $env:WINDIR 'System32\OpenSSH\ssh-keygen.exe'
+  & $sshKeygen -t ecdsa -b 256 -N '' -f $key -C $Comment | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    throw "ssh-keygen failed: $LASTEXITCODE"
+  }
+  return [pscustomobject]@{
+    PrivateKeyPath = $key
+    PublicKey = (Get-Content -Raw -LiteralPath "$key.pub").Trim()
+    TempDir = $dir
+  }
 }
 
 function Set-CatletChassisAssetTag {

--- a/test/e2e/RemoteAccess.E2E.Tests.ps1
+++ b/test/e2e/RemoteAccess.E2E.Tests.ps1
@@ -2,6 +2,31 @@
 #Requires -RunAsAdministrator
 #Requires -Module Pester
 #Requires -Module Eryph.ComputeClient
+<#
+.SYNOPSIS
+  E2E for the egs remote-access auth path on WINDOWS catlets.
+
+.NOTES
+  egs-service runs on Linux too. The same code (multi-key auth, slot
+  family, KvpAuthEnabled gate) is exercised end-to-end here only on
+  Windows because the harness needs: an offline NTFS VHD mount, the
+  PsDirect admin channel (Hyper-V VMBus is Windows-guest only), and
+  Windows-specific binary swap + cbi disable.
+
+  Linux coverage is a follow-up:
+    - parent: dbosoft/ubuntu-24.04/starter (or similar)
+    - binary swap: linux-x64 publish into /opt/eryph/guest-services/bin
+      via cloud-init or a host-side ssh-as-default-user copy
+    - flag file: /etc/opt/eryph/guest-services/service-control.conf
+      (KEY=VALUE; PlatformServiceControlFlags reads it on startup)
+    - admin channel: ssh-as-default-user via Get-CatletIp; Linux sshd
+      IS enabled by default on cloud-init-provisioned images, unlike
+      Windows.
+
+  Unit tests cross-platform: PlatformServiceControlFlags + parser tests
+  cover both Windows REG_DWORD shape and Linux KEY=VALUE shape on every
+  CI run.
+#>
 param (
     [Parameter()]
     [ValidateSet('winsrv2019', 'winsrv2022', 'winsrv2025')]

--- a/test/e2e/RemoteAccess.E2E.Tests.ps1
+++ b/test/e2e/RemoteAccess.E2E.Tests.ps1
@@ -1,0 +1,227 @@
+#Requires -Version 7.4
+#Requires -RunAsAdministrator
+#Requires -Module Pester
+#Requires -Module Eryph.ComputeClient
+param (
+    [Parameter()]
+    [ValidateSet('winsrv2019', 'winsrv2022', 'winsrv2025')]
+    [string] $OSVersion = 'winsrv2022',
+
+    [Parameter()]
+    [string] $PublishPath
+)
+
+BeforeAll {
+  $PSNativeCommandUseErrorActionPreference = $true
+  $ErrorActionPreference = 'Stop'
+  . $PSScriptRoot/Helpers.ps1
+
+  if (-not $PublishPath) {
+    $PublishPath = "$PSScriptRoot/../../src/Eryph.GuestServices.Service/bin/Release/net10.0/win-x64/publish"
+  }
+  $resolvedPublishPath = (Resolve-Path -LiteralPath $PublishPath).Path
+
+  # Channels in this suite:
+  #
+  #   1. egs-service over vsock (egs-tool proxy) — the system under test.
+  #        Public key  -> catlet's C:\ProgramData\eryph\guest-services\id_egs.pub
+  #                       (written below via the offline VHD mount)
+  #        Private key -> host's C:\ProgramData\eryph\guest-services\private\id_egs
+  #                       (used as IdentityFile by every test below)
+  #
+  #   2. PowerShell Direct (Hyper-V VMBus) — the admin channel for any
+  #      operation that must SURVIVE a stop/start of eryph-guest-services
+  #      (notably, the restart triggered by KvpAuthEnabled changes). It
+  #      uses a hardcoded throwaway Administrator password set via
+  #      cloud-config below; the catlet is destroyed in AfterAll.
+  $hostEgsPublicKey = (egs-tool get-ssh-key).Trim()
+  if (-not $hostEgsPublicKey) {
+    throw "egs-tool get-ssh-key returned empty — run 'egs-tool initialize' first."
+  }
+  $adminPassword = 'RaE2e!Pw9_Throwaway'
+
+  $catletConfigTemplate = Get-Content -Raw -Path $PSScriptRoot/remote-access-catlet.yaml
+  $catletConfig = $catletConfigTemplate `
+    -replace '<<PARENT>>', "dbosoft/$OSVersion-standard/starter"
+
+  $project = New-TestProject
+  $catletName = New-CatletName
+  Write-Host "Creating BASE catlet $catletName in project $($project.Name) ..."
+  $catlet = New-Catlet -Config $catletConfig -Name $catletName `
+    -ProjectName $project.Name `
+    -Variables @{ adminPassword = $adminPassword } `
+    -SkipVariablesPrompt
+  $script:CatletAdminCredential = New-Object System.Management.Automation.PSCredential('Administrator',
+    (ConvertTo-SecureString $adminPassword -AsPlainText -Force))
+
+  $state = (Get-VM -Id $catlet.VmId).State
+  if ($state -ne 'Off') { throw "Expected catlet to be Off after creation; got $state." }
+
+  Write-Host "Replacing egs-service binaries offline (publish=$resolvedPublishPath) ..."
+  Update-EgsServiceBinariesOffline -VmId $catlet.VmId -PublishPath $resolvedPublishPath
+
+  Write-Host "Writing host's egs-tool public key into offline VHD as id_egs.pub ..."
+  Write-OfflineEgsClientKey -VmId $catlet.VmId -PublicKey $hostEgsPublicKey
+
+  Write-Host "Starting catlet $($catlet.Name) ..."
+  Start-Catlet -Id $catlet.Id -Force
+
+  Write-Host "Waiting for provisioning to complete (KVP eryph.provisioning.state) ..."
+  $finalState = Wait-ForProvisioningComplete -VmId $catlet.VmId `
+    -Timeout (New-TimeSpan -Minutes 10)
+  Write-Host "Provisioning state: $finalState"
+
+  Write-Host "Waiting for egs-service SSH listener (get-status=available) ..."
+  $savedPref = $PSNativeCommandUseErrorActionPreference
+  $PSNativeCommandUseErrorActionPreference = $false
+  try {
+    Wait-Assert -Timeout (New-TimeSpan -Minutes 5) -Interval (New-TimeSpan -Seconds 3) {
+      $status = egs-tool get-status $catlet.VmId
+      if ($status -ne 'available') { throw "guest services not available: $status" }
+    }
+    Write-Host "egs-service is available — refreshing SSH config aliases ..."
+    # Refreshes ~/.ssh/config entries (IdentityFile pointing at the host's
+    # local egs-tool private key). No KVP write here — that lives in
+    # add-ssh-config and the per-test contexts decide whether to call it.
+    egs-tool update-ssh-config | Out-Null
+  }
+  finally {
+    $PSNativeCommandUseErrorActionPreference = $savedPref
+  }
+
+  # Path to the host's egs-tool private key — the matching half of the
+  # public key we just wrote into the catlet's id_egs.pub. Used as the
+  # "provisioned identity" in the tests below.
+  $provisionedKey = Join-Path $env:ProgramData 'eryph\guest-services\private\id_egs'
+  if (-not (Test-Path -LiteralPath $provisionedKey)) {
+    throw "Local egs-tool key not found at $provisionedKey; run 'egs-tool initialize' first."
+  }
+}
+
+AfterAll {
+  if ($env:EGS_E2E_KEEP_VM) {
+    Write-Host "EGS_E2E_KEEP_VM is set — leaving catlet $($catlet.Name) (project $($project.Name)) for inspection."
+    return
+  }
+  if ($catlet) {
+    Remove-Catlet -Id $catlet.Id -Force -ErrorAction SilentlyContinue
+  }
+  if ($project) {
+    Remove-EryphProject -Id $project.Id -Force -ErrorAction SilentlyContinue
+  }
+}
+
+Describe 'Remote-access client auth' {
+
+  Context 'baseline' {
+
+    It 'provisioned (offline-written id_egs.pub) authorizes' {
+      # Anchors the rest of the suite. Uses the on-disk client-key path
+      # exclusively — no KVP entry has been written yet.
+      $exit = Test-CatletSshWithKey -VmId $catlet.VmId -IdentityFile $provisionedKey
+      $exit | Should -Be 0
+    }
+  }
+
+  Context 'side-by-side: KVP-pushed key authorizes alongside provisioned key' {
+
+    BeforeAll {
+      # Push an ephemeral keypair into a named slot in the External KVP
+      # pool — a key the catlet has never seen on disk. Pre-PR behaviour
+      # would return the cached/provisioned key and skip KVP entirely;
+      # post-PR both sources must contribute to the authorized set.
+      $ephemeral = New-EphemeralSshKey -Comment 'remote-access-e2e-named-slot'
+      Push-CatletExternalKvp -VmId $catlet.VmId `
+        -Key "eryph:guest-services:client-public-key:remote-access-e2e-named" `
+        -Value $ephemeral.PublicKey
+    }
+
+    AfterAll {
+      if ($ephemeral) {
+        Remove-Item -LiteralPath $ephemeral.TempDir -Recurse -Force -ErrorAction SilentlyContinue
+      }
+    }
+
+    It 'ephemeral key in named slot authorizes' {
+      $exit = Test-CatletSshWithKey -VmId $catlet.VmId -IdentityFile $ephemeral.PrivateKeyPath
+      $exit | Should -Be 0
+    }
+
+    It 'provisioned key still authorizes (cache + KVP both in the set)' {
+      $exit = Test-CatletSshWithKey -VmId $catlet.VmId -IdentityFile $provisionedKey
+      $exit | Should -Be 0
+    }
+  }
+
+  Context 'add-ssh-config dual-write reaches both slots' {
+
+    BeforeAll {
+      # The host-side add-ssh-config writer dual-writes legacy +
+      # ":<hostname>" slots. After it runs the catlet's External KVP must
+      # show both.
+      egs-tool add-ssh-config $catlet.VmId | Out-Null
+    }
+
+    It 'writes both legacy and named slot for this host' {
+      $data = egs-tool get-data --json $catlet.VmId | ConvertFrom-Json -AsHashtable
+      $hostSlot = "eryph:guest-services:client-public-key:$($env:COMPUTERNAME.ToLowerInvariant())"
+      $data.external.ContainsKey('eryph:guest-services:client-public-key') | Should -BeTrue
+      $data.external.ContainsKey($hostSlot) | Should -BeTrue
+      $data.external['eryph:guest-services:client-public-key'] | Should -Be $data.external[$hostSlot]
+    }
+
+    It 'host can still ssh with its egs-tool key after the dual-write' {
+      $exit = Test-CatletSshWithKey -VmId $catlet.VmId -IdentityFile $provisionedKey
+      $exit | Should -Be 0
+    }
+  }
+
+  Context 'KvpAuthEnabled hardening flag' {
+
+    BeforeAll {
+      $hardeningEphemeral = New-EphemeralSshKey -Comment 'remote-access-e2e-hardening'
+      Push-CatletExternalKvp -VmId $catlet.VmId `
+        -Key "eryph:guest-services:client-public-key:remote-access-e2e-hardening" `
+        -Value $hardeningEphemeral.PublicKey
+    }
+
+    AfterAll {
+      # Make sure the flag is cleared even if a test bails mid-way.
+      try { Set-CatletKvpAuthEnabled -Catlet $catlet -Value $null -Credential $script:CatletAdminCredential } catch { }
+      if ($hardeningEphemeral) {
+        Remove-Item -LiteralPath $hardeningEphemeral.TempDir -Recurse -Force -ErrorAction SilentlyContinue
+      }
+    }
+
+    It 'KVP-pushed key authorizes when KvpAuthEnabled is unset (default ON)' {
+      Set-CatletKvpAuthEnabled -Catlet $catlet -Value $null -Credential $script:CatletAdminCredential
+      $exit = Test-CatletSshWithKey -VmId $catlet.VmId -IdentityFile $hardeningEphemeral.PrivateKeyPath
+      $exit | Should -Be 0
+    }
+
+    It 'KvpAuthEnabled=0 rejects KVP-pushed key' {
+      Set-CatletKvpAuthEnabled -Catlet $catlet -Value 0 -Credential $script:CatletAdminCredential
+      # The flag is read on every auth attempt — no service restart needed.
+      $exit = Test-CatletSshWithKey -VmId $catlet.VmId -IdentityFile $hardeningEphemeral.PrivateKeyPath
+      $exit | Should -Not -Be 0
+    }
+
+    It 'KvpAuthEnabled=0 keeps the provisioned key working (only KVP is gated)' {
+      Set-CatletKvpAuthEnabled -Catlet $catlet -Value 0 -Credential $script:CatletAdminCredential
+      $exit = Test-CatletSshWithKey -VmId $catlet.VmId -IdentityFile $provisionedKey
+      $exit | Should -Be 0
+    }
+
+    It 'KvpAuthEnabled=1 restores KVP-pushed key authorization' {
+      Set-CatletKvpAuthEnabled -Catlet $catlet -Value 1 -Credential $script:CatletAdminCredential
+      $exit = Test-CatletSshWithKey -VmId $catlet.VmId -IdentityFile $hardeningEphemeral.PrivateKeyPath
+      $exit | Should -Be 0
+    }
+
+    It 'deleting the value (back to default) keeps KVP keys authorized' {
+      Set-CatletKvpAuthEnabled -Catlet $catlet -Value $null -Credential $script:CatletAdminCredential
+      $exit = Test-CatletSshWithKey -VmId $catlet.VmId -IdentityFile $hardeningEphemeral.PrivateKeyPath
+      $exit | Should -Be 0
+    }
+  }
+}

--- a/test/e2e/RemoteAccess.E2E.Tests.ps1
+++ b/test/e2e/RemoteAccess.E2E.Tests.ps1
@@ -47,7 +47,10 @@ BeforeAll {
   if (-not $hostEgsPublicKey) {
     throw "egs-tool get-ssh-key returned empty — run 'egs-tool initialize' first."
   }
-  $adminPassword = 'RaE2e!Pw9_Throwaway'
+  # Throwaway Administrator password generated per run — never persisted
+  # outside this catlet (which is destroyed in AfterAll). Generated rather
+  # than hardcoded so secret scanners don't false-positive on the source.
+  $adminPassword = New-ThrowawayPassword
 
   $catletConfigTemplate = Get-Content -Raw -Path $PSScriptRoot/remote-access-catlet.yaml
   $catletConfig = $catletConfigTemplate `
@@ -210,7 +213,9 @@ Describe 'Remote-access client auth' {
 
     It 'KvpAuthEnabled=0 rejects KVP-pushed key' {
       Set-CatletKvpAuthEnabled -Catlet $catlet -Value 0 -Credential $script:CatletAdminCredential
-      # The flag is read on every auth attempt — no service restart needed.
+      # Set-CatletKvpAuthEnabled writes the registry, then restarts the
+      # eryph-guest-services unit via PsDirect — the flag is cached at
+      # service start, not re-read on every auth attempt.
       $exit = Test-CatletSshWithKey -VmId $catlet.VmId -IdentityFile $hardeningEphemeral.PrivateKeyPath
       $exit | Should -Not -Be 0
     }

--- a/test/e2e/RemoteAccess.Linux.E2E.Tests.ps1
+++ b/test/e2e/RemoteAccess.Linux.E2E.Tests.ps1
@@ -4,17 +4,26 @@
 #Requires -Module Eryph.ComputeClient
 <#
 .SYNOPSIS
-  E2E for the egs remote-access auth path on WINDOWS catlets.
+  E2E for the egs remote-access auth path on LINUX catlets.
 
 .NOTES
-  Linux coverage lives in RemoteAccess.Linux.E2E.Tests.ps1 (same assertion
-  surface, different parent gene + online binary swap via direct sshd
-  instead of offline VHD mount + PsDirect).
+  Mirror of RemoteAccess.E2E.Tests.ps1 (the Windows version), exercising
+  the same code (multi-key reader, KvpAuthEnabled gate, dual-write
+  add-ssh-config) end-to-end on Linux.
+
+  Architectural deltas from the Windows suite:
+    - No offline VHD mount. Catlet boots with the parent gene's
+      pre-installed (older) egs-service. BeforeAll ssh-es in,
+      stops/swaps/restarts to put the local build under test.
+    - Admin channel is direct sshd (Linux has no Hyper-V VMBus PSDirect).
+      The linux-starter fodder gene installs the host's egs-tool public
+      key in the OS user's authorized_keys for this channel.
+    - Hardening flag is /etc/opt/eryph/guest-services/service-control.conf
+      (KEY=VALUE) not the Windows registry.
 #>
 param (
     [Parameter()]
-    [ValidateSet('winsrv2019', 'winsrv2022', 'winsrv2025')]
-    [string] $OSVersion = 'winsrv2022',
+    [string] $OSVersion = 'ubuntu-24.04',
 
     [Parameter()]
     [string] $PublishPath
@@ -26,59 +35,61 @@ BeforeAll {
   . $PSScriptRoot/Helpers.ps1
 
   if (-not $PublishPath) {
-    $PublishPath = "$PSScriptRoot/../../src/Eryph.GuestServices.Service/bin/Release/net10.0/win-x64/publish"
+    $PublishPath = "$PSScriptRoot/../../src/Eryph.GuestServices.Service/bin/Release/net10.0/linux-x64/publish"
   }
   $resolvedPublishPath = (Resolve-Path -LiteralPath $PublishPath).Path
 
-  # Channels in this suite:
-  #
-  #   1. egs-service over vsock (egs-tool proxy) — the system under test.
-  #        Public key  -> catlet's C:\ProgramData\eryph\guest-services\id_egs.pub
-  #                       (written below via the offline VHD mount)
+  # Channels (cf. the Windows e2e header):
+  #   1. egs-service over vsock (egs-tool proxy) — system under test.
+  #        Public key  -> catlet's /etc/opt/eryph/guest-services/id_egs.pub
+  #                       (written below via the admin sshd channel after
+  #                        the binary swap)
   #        Private key -> host's C:\ProgramData\eryph\guest-services\private\id_egs
-  #                       (used as IdentityFile by every test below)
-  #
-  #   2. PowerShell Direct (Hyper-V VMBus) — the admin channel for any
-  #      operation that must SURVIVE a stop/start of eryph-guest-services
-  #      (notably, the restart triggered by KvpAuthEnabled changes). It
-  #      uses a hardcoded throwaway Administrator password set via
-  #      cloud-config below; the catlet is destroyed in AfterAll.
+  #   2. Direct sshd as $adminUsername — admin channel for binary swap,
+  #      service-control.conf edits, systemctl restart. Independent of
+  #      eryph-guest-services lifecycle.
   $hostEgsPublicKey = (egs-tool get-ssh-key).Trim()
   if (-not $hostEgsPublicKey) {
     throw "egs-tool get-ssh-key returned empty — run 'egs-tool initialize' first."
   }
-  $adminPassword = 'RaE2e!Pw9_Throwaway'
+  $adminUsername = 'e2euser'
+  $adminPassword = 'RaE2eLinux!Pw9_Throwaway'
 
-  $catletConfigTemplate = Get-Content -Raw -Path $PSScriptRoot/remote-access-catlet.yaml
+  $catletConfigTemplate = Get-Content -Raw -Path $PSScriptRoot/remote-access-linux-catlet.yaml
   $catletConfig = $catletConfigTemplate `
-    -replace '<<PARENT>>', "dbosoft/$OSVersion-standard/starter"
+    -replace '<<PARENT>>', "dbosoft/$OSVersion/starter"
 
   $project = New-TestProject
   $catletName = New-CatletName
   Write-Host "Creating BASE catlet $catletName in project $($project.Name) ..."
   $catlet = New-Catlet -Config $catletConfig -Name $catletName `
     -ProjectName $project.Name `
-    -Variables @{ adminPassword = $adminPassword } `
+    -Variables @{
+      adminUsername = $adminUsername
+      adminPassword = $adminPassword
+      sshPublicKey = $hostEgsPublicKey
+    } `
     -SkipVariablesPrompt
-  $script:CatletAdminCredential = New-Object System.Management.Automation.PSCredential('Administrator',
-    (ConvertTo-SecureString $adminPassword -AsPlainText -Force))
-
-  $state = (Get-VM -Id $catlet.VmId).State
-  if ($state -ne 'Off') { throw "Expected catlet to be Off after creation; got $state." }
-
-  Write-Host "Replacing egs-service binaries offline (publish=$resolvedPublishPath) ..."
-  Update-EgsServiceBinariesOffline -VmId $catlet.VmId -PublishPath $resolvedPublishPath
-
-  Write-Host "Writing host's egs-tool public key into offline VHD as id_egs.pub ..."
-  Write-OfflineEgsClientKey -VmId $catlet.VmId -PublicKey $hostEgsPublicKey
 
   Write-Host "Starting catlet $($catlet.Name) ..."
   Start-Catlet -Id $catlet.Id -Force
 
-  Write-Host "Waiting for provisioning to complete (KVP eryph.provisioning.state) ..."
-  $finalState = Wait-ForProvisioningComplete -VmId $catlet.VmId `
+  Write-Host "Waiting for direct sshd as '$adminUsername' ..."
+  Wait-LinuxCatletSshReady -Catlet $catlet -Username $adminUsername `
     -Timeout (New-TimeSpan -Minutes 10)
-  Write-Host "Provisioning state: $finalState"
+
+  Write-Host "Replacing egs-service binaries online (publish=$resolvedPublishPath) ..."
+  Update-EgsServiceLinuxOnline -Catlet $catlet -Username $adminUsername `
+    -PublishPath $resolvedPublishPath
+
+  Write-Host "Writing host's egs-tool public key into /etc/opt/eryph/guest-services/id_egs.pub ..."
+  Write-LinuxEgsClientKey -Catlet $catlet -Username $adminUsername `
+    -PublicKey $hostEgsPublicKey
+
+  # Restart so the freshly-written id_egs.pub is picked up (egs-service
+  # reads it on startup, same as on Windows).
+  Invoke-CatletAdminSshLinux -Catlet $catlet -Username $adminUsername `
+    -Command 'sudo systemctl restart eryph-guest-services' 2>&1 | Out-Null
 
   Write-Host "Waiting for egs-service SSH listener (get-status=available) ..."
   $savedPref = $PSNativeCommandUseErrorActionPreference
@@ -89,18 +100,12 @@ BeforeAll {
       if ($status -ne 'available') { throw "guest services not available: $status" }
     }
     Write-Host "egs-service is available — refreshing SSH config aliases ..."
-    # Refreshes ~/.ssh/config entries (IdentityFile pointing at the host's
-    # local egs-tool private key). No KVP write here — that lives in
-    # add-ssh-config and the per-test contexts decide whether to call it.
     egs-tool update-ssh-config | Out-Null
   }
   finally {
     $PSNativeCommandUseErrorActionPreference = $savedPref
   }
 
-  # Path to the host's egs-tool private key — the matching half of the
-  # public key we just wrote into the catlet's id_egs.pub. Used as the
-  # "provisioned identity" in the tests below.
   $provisionedKey = Join-Path $env:ProgramData 'eryph\guest-services\private\id_egs'
   if (-not (Test-Path -LiteralPath $provisionedKey)) {
     throw "Local egs-tool key not found at $provisionedKey; run 'egs-tool initialize' first."
@@ -120,13 +125,11 @@ AfterAll {
   }
 }
 
-Describe 'Remote-access client auth' {
+Describe 'Remote-access client auth (Linux)' {
 
   Context 'baseline' {
 
-    It 'provisioned (offline-written id_egs.pub) authorizes' {
-      # Anchors the rest of the suite. Uses the on-disk client-key path
-      # exclusively — no KVP entry has been written yet.
+    It 'provisioned id_egs.pub authorizes' {
       $exit = Test-CatletSshWithKey -VmId $catlet.VmId -IdentityFile $provisionedKey
       $exit | Should -Be 0
     }
@@ -135,13 +138,9 @@ Describe 'Remote-access client auth' {
   Context 'side-by-side: KVP-pushed key authorizes alongside provisioned key' {
 
     BeforeAll {
-      # Push an ephemeral keypair into a named slot in the External KVP
-      # pool — a key the catlet has never seen on disk. Pre-PR behaviour
-      # would return the cached/provisioned key and skip KVP entirely;
-      # post-PR both sources must contribute to the authorized set.
-      $ephemeral = New-EphemeralSshKey -Comment 'remote-access-e2e-named-slot'
+      $ephemeral = New-EphemeralSshKey -Comment 'remote-access-linux-e2e-named-slot'
       Push-CatletExternalKvp -VmId $catlet.VmId `
-        -Key "eryph:guest-services:client-public-key:remote-access-e2e-named" `
+        -Key "eryph:guest-services:client-public-key:remote-access-linux-e2e-named" `
         -Value $ephemeral.PublicKey
     }
 
@@ -165,9 +164,6 @@ Describe 'Remote-access client auth' {
   Context 'add-ssh-config dual-write reaches both slots' {
 
     BeforeAll {
-      # The host-side add-ssh-config writer dual-writes legacy +
-      # ":<hostname>" slots. After it runs the catlet's External KVP must
-      # show both.
       egs-tool add-ssh-config $catlet.VmId | Out-Null
     }
 
@@ -185,50 +181,50 @@ Describe 'Remote-access client auth' {
     }
   }
 
-  Context 'KvpAuthEnabled hardening flag' {
+  Context 'KvpAuthEnabled hardening flag (Linux service-control.conf)' {
 
     BeforeAll {
-      $hardeningEphemeral = New-EphemeralSshKey -Comment 'remote-access-e2e-hardening'
+      $hardeningEphemeral = New-EphemeralSshKey -Comment 'remote-access-linux-e2e-hardening'
       Push-CatletExternalKvp -VmId $catlet.VmId `
-        -Key "eryph:guest-services:client-public-key:remote-access-e2e-hardening" `
+        -Key "eryph:guest-services:client-public-key:remote-access-linux-e2e-hardening" `
         -Value $hardeningEphemeral.PublicKey
     }
 
     AfterAll {
-      # Make sure the flag is cleared even if a test bails mid-way.
-      try { Set-CatletKvpAuthEnabled -Catlet $catlet -Value $null -Credential $script:CatletAdminCredential } catch { }
+      try {
+        Set-CatletKvpAuthEnabledLinux -Catlet $catlet -Username $adminUsername -Value $null
+      } catch { }
       if ($hardeningEphemeral) {
         Remove-Item -LiteralPath $hardeningEphemeral.TempDir -Recurse -Force -ErrorAction SilentlyContinue
       }
     }
 
     It 'KVP-pushed key authorizes when KvpAuthEnabled is unset (default ON)' {
-      Set-CatletKvpAuthEnabled -Catlet $catlet -Value $null -Credential $script:CatletAdminCredential
+      Set-CatletKvpAuthEnabledLinux -Catlet $catlet -Username $adminUsername -Value $null
       $exit = Test-CatletSshWithKey -VmId $catlet.VmId -IdentityFile $hardeningEphemeral.PrivateKeyPath
       $exit | Should -Be 0
     }
 
     It 'KvpAuthEnabled=0 rejects KVP-pushed key' {
-      Set-CatletKvpAuthEnabled -Catlet $catlet -Value 0 -Credential $script:CatletAdminCredential
-      # The flag is read on every auth attempt — no service restart needed.
+      Set-CatletKvpAuthEnabledLinux -Catlet $catlet -Username $adminUsername -Value 0
       $exit = Test-CatletSshWithKey -VmId $catlet.VmId -IdentityFile $hardeningEphemeral.PrivateKeyPath
       $exit | Should -Not -Be 0
     }
 
     It 'KvpAuthEnabled=0 keeps the provisioned key working (only KVP is gated)' {
-      Set-CatletKvpAuthEnabled -Catlet $catlet -Value 0 -Credential $script:CatletAdminCredential
+      Set-CatletKvpAuthEnabledLinux -Catlet $catlet -Username $adminUsername -Value 0
       $exit = Test-CatletSshWithKey -VmId $catlet.VmId -IdentityFile $provisionedKey
       $exit | Should -Be 0
     }
 
     It 'KvpAuthEnabled=1 restores KVP-pushed key authorization' {
-      Set-CatletKvpAuthEnabled -Catlet $catlet -Value 1 -Credential $script:CatletAdminCredential
+      Set-CatletKvpAuthEnabledLinux -Catlet $catlet -Username $adminUsername -Value 1
       $exit = Test-CatletSshWithKey -VmId $catlet.VmId -IdentityFile $hardeningEphemeral.PrivateKeyPath
       $exit | Should -Be 0
     }
 
     It 'deleting the value (back to default) keeps KVP keys authorized' {
-      Set-CatletKvpAuthEnabled -Catlet $catlet -Value $null -Credential $script:CatletAdminCredential
+      Set-CatletKvpAuthEnabledLinux -Catlet $catlet -Username $adminUsername -Value $null
       $exit = Test-CatletSshWithKey -VmId $catlet.VmId -IdentityFile $hardeningEphemeral.PrivateKeyPath
       $exit | Should -Be 0
     }

--- a/test/e2e/RemoteAccess.Linux.E2E.Tests.ps1
+++ b/test/e2e/RemoteAccess.Linux.E2E.Tests.ps1
@@ -53,7 +53,10 @@ BeforeAll {
     throw "egs-tool get-ssh-key returned empty — run 'egs-tool initialize' first."
   }
   $adminUsername = 'e2euser'
-  $adminPassword = 'RaE2eLinux!Pw9_Throwaway'
+  # Throwaway password generated per run — never persisted outside this
+  # catlet (which is destroyed in AfterAll). Generated rather than
+  # hardcoded so secret scanners don't false-positive on the source.
+  $adminPassword = New-ThrowawayPassword
 
   $catletConfigTemplate = Get-Content -Raw -Path $PSScriptRoot/remote-access-linux-catlet.yaml
   $catletConfig = $catletConfigTemplate `

--- a/test/e2e/Run-RemoteAccessE2ETests.ps1
+++ b/test/e2e/Run-RemoteAccessE2ETests.ps1
@@ -1,0 +1,73 @@
+#Requires -Version 7.4
+<#
+.SYNOPSIS
+  Runs the remote-access client-auth e2e tests against a fresh eryph catlet.
+  Covers multi-key authorization, add-ssh-config dual-write, and the
+  KvpAuthEnabled hardening gate.
+
+.DESCRIPTION
+  Uses the offline-injection pattern (mirrors Run-ProvisioningE2ETests.ps1):
+  publishes the local egs-service and egs-tool, creates a stopped catlet,
+  mounts its VHD, replaces egs-service binaries, writes id_egs.pub (host's
+  egs-tool public key) into the offline image, disables cloudbase-init,
+  then starts the catlet. First boot runs the new build end-to-end.
+  Catlet + project are torn down in AfterAll unless $env:EGS_E2E_KEEP_VM
+  is set.
+
+  Requires:
+    - Elevated PowerShell 7.4+ (Hyper-V WMI + egs-tool admin paths)
+    - eryph host with `egs-tool initialize` already run
+    - Pester 5.x, Eryph.ComputeClient
+    - The dbosoft/$OSVersion-standard/starter parent gene cached locally
+#>
+param (
+    [Parameter()]
+    [ValidateSet('winsrv2019', 'winsrv2022', 'winsrv2025')]
+    [string] $OSVersion = 'winsrv2022',
+
+    [Parameter()]
+    [switch] $SkipBuild
+)
+
+$PSNativeCommandUseErrorActionPreference = $true
+$ErrorActionPreference = 'Stop'
+
+Write-Host "Installing required PowerShell modules ..."
+Install-Module -Name Pester -MinimumVersion 5.5 -Force -Scope CurrentUser -SkipPublisherCheck
+Install-Module -Name Eryph.ComputeClient -Force -Scope CurrentUser
+
+if (-not $SkipBuild) {
+  Write-Host "Publishing egs-service for win-x64 ..."
+  dotnet publish "$PSScriptRoot/../../src/Eryph.GuestServices.Service/Eryph.GuestServices.Service.csproj" `
+    -c Release -r win-x64 --nologo
+
+  Write-Host "Publishing egs-tool for win-x64 ..."
+  dotnet publish "$PSScriptRoot/../../src/Eryph.GuestServices.Tool/Eryph.GuestServices.Tool.csproj" `
+    -c Release -r win-x64 --nologo
+}
+
+$publishPath = Resolve-Path "$PSScriptRoot/../../src/Eryph.GuestServices.Service/bin/Release/net10.0/win-x64/publish"
+$toolPublishPath = Resolve-Path "$PSScriptRoot/../../src/Eryph.GuestServices.Tool/bin/Release/net10.0-windows/win-x64/publish"
+
+# Use the locally-built egs-tool for this session — the named-slot
+# dual-write in add-ssh-config is only in the local build.
+$env:Path = "$($toolPublishPath.Path);$env:Path"
+Write-Host "Using egs-tool from: $toolPublishPath"
+Write-Host "egs-tool version: $(egs-tool --version)"
+
+Write-Host "Running Pester suite ..."
+$container = New-PesterContainer -Path "$PSScriptRoot/RemoteAccess.E2E.Tests.ps1" `
+  -Data @{
+    OSVersion = $OSVersion
+    PublishPath = $publishPath.Path
+  }
+
+$config = New-PesterConfiguration
+$config.Output.Verbosity = 'Detailed'
+$config.Run.Container = $container
+$config.Run.Exit = $true
+$config.TestResult.Enabled = $true
+$config.TestResult.OutputFormat = 'NUnit3'
+$config.TestResult.OutputPath = "$PSScriptRoot/TEST-remoteaccess-pesterResults.xml"
+
+Invoke-Pester -Configuration $config

--- a/test/e2e/Run-RemoteAccessLinuxE2ETests.ps1
+++ b/test/e2e/Run-RemoteAccessLinuxE2ETests.ps1
@@ -1,0 +1,68 @@
+#Requires -Version 7.4
+<#
+.SYNOPSIS
+  Runs the remote-access client-auth e2e tests against a fresh eryph
+  Ubuntu catlet.
+
+.DESCRIPTION
+  Publishes egs-service linux-x64 and egs-tool win-x64 (the tool always
+  runs on the host), spins up an Ubuntu catlet, swaps the gene-installed
+  egs-service with the local build over direct sshd, writes id_egs.pub,
+  restarts the service, then runs the Pester suite. Catlet + project
+  are torn down in AfterAll unless $env:EGS_E2E_KEEP_VM is set.
+
+  Requires:
+    - Elevated PowerShell 7.4+ (egs-tool admin paths)
+    - eryph host with `egs-tool initialize` already run
+    - Pester 5.x, Eryph.ComputeClient
+    - The dbosoft/$OSVersion/starter parent gene + the
+      dbosoft/starter-food/2.0:linux-starter fodder gene cached locally
+#>
+param (
+    [Parameter()]
+    [string] $OSVersion = 'ubuntu-24.04',
+
+    [Parameter()]
+    [switch] $SkipBuild
+)
+
+$PSNativeCommandUseErrorActionPreference = $true
+$ErrorActionPreference = 'Stop'
+
+Write-Host "Installing required PowerShell modules ..."
+Install-Module -Name Pester -MinimumVersion 5.5 -Force -Scope CurrentUser -SkipPublisherCheck
+Install-Module -Name Eryph.ComputeClient -Force -Scope CurrentUser
+
+if (-not $SkipBuild) {
+  Write-Host "Publishing egs-service for linux-x64 ..."
+  dotnet publish "$PSScriptRoot/../../src/Eryph.GuestServices.Service/Eryph.GuestServices.Service.csproj" `
+    -c Release -r linux-x64 --nologo
+
+  Write-Host "Publishing egs-tool for win-x64 ..."
+  dotnet publish "$PSScriptRoot/../../src/Eryph.GuestServices.Tool/Eryph.GuestServices.Tool.csproj" `
+    -c Release -r win-x64 --nologo
+}
+
+$publishPath = Resolve-Path "$PSScriptRoot/../../src/Eryph.GuestServices.Service/bin/Release/net10.0/linux-x64/publish"
+$toolPublishPath = Resolve-Path "$PSScriptRoot/../../src/Eryph.GuestServices.Tool/bin/Release/net10.0-windows/win-x64/publish"
+
+$env:Path = "$($toolPublishPath.Path);$env:Path"
+Write-Host "Using egs-tool from: $toolPublishPath"
+Write-Host "egs-tool version: $(egs-tool --version)"
+
+Write-Host "Running Pester suite ..."
+$container = New-PesterContainer -Path "$PSScriptRoot/RemoteAccess.Linux.E2E.Tests.ps1" `
+  -Data @{
+    OSVersion = $OSVersion
+    PublishPath = $publishPath.Path
+  }
+
+$config = New-PesterConfiguration
+$config.Output.Verbosity = 'Detailed'
+$config.Run.Container = $container
+$config.Run.Exit = $true
+$config.TestResult.Enabled = $true
+$config.TestResult.OutputFormat = 'NUnit3'
+$config.TestResult.OutputPath = "$PSScriptRoot/TEST-remoteaccess-linux-pesterResults.xml"
+
+Invoke-Pester -Configuration $config

--- a/test/e2e/remote-access-catlet.yaml
+++ b/test/e2e/remote-access-catlet.yaml
@@ -1,0 +1,48 @@
+name: remote-access-e2e
+parent: <<PARENT>>
+cpu:
+  count: 2
+memory:
+  startup: 2048
+
+# The remote-access e2e uses the offline-injection pattern: cloudbase-init
+# is disabled, egs-service is replaced with the local build, and the host's
+# egs-tool public key is written into id_egs.pub on the VHD before first
+# boot. We deliberately do NOT include gene:dbosoft/guest-services:win-install
+# — that gene's installer normally runs *via* cbi, which is disabled here.
+#
+# The cloud-config sets a known Administrator password so the test
+# harness can use PowerShell Direct (Invoke-Command -VMId -Credential)
+# to perform host→guest admin operations (notably, restarting
+# eryph-guest-services after toggling KvpAuthEnabled). PowerShell Direct
+# rides Hyper-V's VMBus, so it needs no networking on the catlet, no
+# OpenSSH server, no firewall config — and crucially it is INDEPENDENT
+# of the eryph-guest-services lifecycle, so we can stop/start that
+# service without killing our own admin channel.
+#
+# The password is a test fixture only — the catlet is thrown away in
+# AfterAll. Do NOT reuse this value for anything that survives a test
+# run.
+variables:
+  - name: adminPassword
+    required: true
+
+fodder:
+  - name: remote-access-e2e-cloud-config
+    type: cloud-config
+    content: |
+      #cloud-config
+      # Windows NetBIOS caps hostnames at 15 chars; keep this short.
+      hostname: ra-e2e
+      # users: passwd targets NEW user creation. Administrator already
+      # exists on the starter image, so the password must be set via
+      # chpasswd (cloud-init's "set password on existing account"
+      # pattern) and the account explicitly enabled for PSDirect.
+      chpasswd:
+        expire: false
+        users:
+          - name: Administrator
+            type: text
+            password: "{{ adminPassword }}"
+      runcmd:
+        - 'net user Administrator /active:yes'

--- a/test/e2e/remote-access-linux-catlet.yaml
+++ b/test/e2e/remote-access-linux-catlet.yaml
@@ -1,0 +1,41 @@
+name: remote-access-linux-e2e
+parent: <<PARENT>>
+cpu:
+  count: 2
+memory:
+  startup: 2048
+
+# The catlet boots with egs-service pre-installed by the parent gene (an
+# OLDER release). The test BeforeAll swaps the binaries to the local build
+# over the direct-sshd admin channel BEFORE running any assertions.
+#
+# Channels:
+#   1. egs-service over vsock (egs-tool proxy) — the system under test.
+#      The host's egs-tool public key is delivered to the catlet by
+#      writing /etc/opt/eryph/guest-services/id_egs.pub via the admin
+#      channel after binary swap.
+#   2. Direct OpenSSH on TCP/22 — the admin channel for binary swap,
+#      service-control.conf edits, and systemctl restart. Independent of
+#      eryph-guest-services lifecycle. The starter-food/linux-starter
+#      fodder gene installs sshPublicKey into the OS user's
+#      authorized_keys for this channel.
+#
+# Username + Password are throwaway test fixtures; catlet is destroyed in
+# AfterAll.
+variables:
+  - name: adminUsername
+    required: true
+  - name: adminPassword
+    required: true
+  - name: sshPublicKey
+    required: true
+
+fodder:
+  - source: gene:dbosoft/starter-food/2.0:linux-starter
+    variables:
+      - name: Username
+        value: '{{ adminUsername }}'
+      - name: Password
+        value: '{{ adminPassword }}'
+      - name: sshPublicKey
+        value: '{{ sshPublicKey }}'


### PR DESCRIPTION
## Multi-key client auth + KvpAuthEnabled hardening — cross-platform

Reworks `egs-service` client-key authorization from a single-key scalar to a multi-key set, adds an operator hardening flag, and verifies the whole flow on both Windows and Linux catlets.

### Auth model

`IClientKeyProvider.IsAuthorizedAsync(IKeyPair candidate)` returns `true` iff the candidate matches the union of:

- the **locally provisioned key** on disk (`id_egs.pub` written by geneset / cloud-init at catlet creation), **and**
- every entry in the `eryph:guest-services:client-public-key` slot family in the External KVP pool — the legacy single slot **plus** any number of named slots (`…client-public-key:<host>`). Each slot value parses authorized_keys-style: multi-line, blank lines and `#` comments tolerated, malformed lines skipped (one bad entry can't lock out the rest).

`egs-tool add-ssh-config` now dual-writes the legacy slot **and** a per-host named slot (`…:host` etc.), so a new tool works against pre-upgrade guests and multiple hosts no longer evict each other.

### Hardening flag — cross-platform

New operator switch `KvpAuthEnabled`: when off, only the locally provisioned key authorizes (KVP-delivered keys are rejected). Cached at service start, restart `eryph-guest-services` to change.

| OS | Backed by | Off value |
| --- | --- | --- |
| Windows | `HKLM\SOFTWARE\eryph\guest-services\KvpAuthEnabled` (`REG_DWORD`) | `0` |
| Linux | `/etc/opt/eryph/guest-services/service-control.conf` (`KEY=VALUE` lines) | `KvpAuthEnabled=0` or `false` |

`RegistryServiceControlFlags` is renamed `PlatformServiceControlFlags` and now also covers the pre-existing `RemoteAccessEnabled` / `ProvisioningEnabled` flags on Linux — which were Windows-only before. Docs: `docs/user/reference/settings.md` documents both backends.

### Tests

- **65 service unit tests** (was 17) cover the multi-key reader (legacy + named slots, side-by-side, malformed/empty tolerance, real-world `authorized_keys` fixture), the dual-write reader contract, every hardening state, both REG_DWORD and KEY=VALUE shapes of the flag interpreter, and the Linux config-line parser. Full solution: 1370 tests green.
- **Two Pester e2e suites**, both pass end-to-end on a real catlet:
  - `RemoteAccess.E2E.Tests.ps1` — `dbosoft/winsrv2022-standard/starter` via offline VHD inject + PowerShell Direct (Hyper-V VMBus) for admin operations.
  - `RemoteAccess.Linux.E2E.Tests.ps1` — `dbosoft/ubuntu-24.04/starter` + `dbosoft/starter-food/2.0:linux-starter` fodder for the admin user, online binary swap via direct sshd, flag writes to `service-control.conf` over the same channel.