### PR TITLE
Skip licensing module on reboot resume

### DIFF
--- a/src/Eryph.GuestServices.Provisioning/Modules/LicensingModule.cs
+++ b/src/Eryph.GuestServices.Provisioning/Modules/LicensingModule.cs
@@ -35,6 +35,17 @@ internal sealed class LicensingModule(ILogger<LicensingModule> logger) : IModule
         IModuleContext context,
         CancellationToken cancellationToken)
     {
+        // One-shot guard: the only path in this module that requests a reboot
+        // is rearm. After the reboot, IsEvaluationLicenseAsync still reports
+        // true (rearm extends the grace timer; it does not change the SKU),
+        // so re-running would rearm again, burning another of Windows' finite
+        // rearm slots and eventually tripping the per-module reboot cap.
+        if (context.IsRebootResume)
+        {
+            logger.LogInformation("Resuming after rearm-triggered reboot; licensing module is done for this instance.");
+            return ModuleOutcome.Ok();
+        }
+
         var license = userData.CloudConfig.License ?? new LicenseConfig();
 
         var explicitKey = NonBlank(license.ProductKey);

--- a/test/Eryph.GuestServices.Provisioning.Tests/Modules/LicensingModuleTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Modules/LicensingModuleTests.cs
@@ -423,4 +423,28 @@ public sealed class LicensingModuleTests
         result.Should().BeOfType<ModuleOutcome.Completed>();
         await os.Received(1).RearmLicenseAsync(Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task Reboot_resume_skips_rearm_and_activation()
+    {
+        // After a rearm-triggered reboot, IsEvaluationLicenseAsync still
+        // returns true (rearm extends the grace timer, doesn't change the SKU).
+        // Re-running rearm would burn another rearm slot and eventually trip
+        // the per-module reboot cap. The whole module must short-circuit.
+        var os = NewOs(resolvedAvmaKey: "AVMA-KEY", isEvaluation: true);
+        var module = new LicensingModule(NullLogger<LicensingModule>.Instance);
+
+        var result = await module.ApplyAsync(
+            ResolvedUserData.Empty(new CloudConfigModel()),
+            new TestModuleContext(os, isRebootResume: true),
+            CancellationToken.None);
+
+        result.Should().BeOfType<ModuleOutcome.Completed>();
+        await os.DidNotReceive().RearmLicenseAsync(Arg.Any<CancellationToken>());
+        await os.DidNotReceive().ApplyLicenseAsync(
+            Arg.Any<LicenseSpec>(), Arg.Any<CancellationToken>());
+        await os.DidNotReceive().ResolveVolumeActivationKeyAsync(
+            Arg.Any<VolumeActivationKeyType>(), Arg.Any<CancellationToken>());
+        await os.DidNotReceive().IsEvaluationLicenseAsync(Arg.Any<CancellationToken>());
+    }
 }


### PR DESCRIPTION
The rearm path in `LicensingModule` returns `ModuleOutcome.Reboot`. On resume, `IsEvaluationLicenseAsync` still reports `true` (rearm extends the grace timer; it does not change the SKU), so the module would rearm again — burning another of Windows' finite rearm slots and eventually tripping `MaxPerModule=3`.

Add the same one-shot `IModuleContext.IsRebootResume` guard `SetHostnameModule` uses. `SetLocaleModule` already self-gates inside `BuildLocaleScript` (the `if ($currentSys -ne '{locale}')` check), so it does not need the same fix.