### PR TITLE
Dedup SSH aliases across VM/catlet configs

### DIFF
--- a/src/Eryph.GuestServices.Tool/Commands/AddSshConfigCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/AddSshConfigCommand.cs
@@ -18,11 +18,14 @@ public class AddSshConfigCommand : AsyncCommand<AddSshConfigCommand.Settings>
 
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
     {
-        if (!string.IsNullOrEmpty(settings.Alias) && SshConfigHelper.IsReservedAlias(settings.Alias))
+        if (!string.IsNullOrEmpty(settings.Alias))
         {
-            AnsiConsole.MarkupLineInterpolated(
-                $"[red]The alias '{settings.Alias}' uses a reserved suffix (.hyper-v.alt or .eryph.alt) that is managed by the eryph guest services. Please choose a different alias.[/]");
-            return -1;
+            var aliasError = SshConfigHelper.GetAliasValidationError(settings.Alias);
+            if (aliasError is not null)
+            {
+                AnsiConsole.MarkupLineInterpolated($"[red]{aliasError} Please choose a different alias.[/]");
+                return -1;
+            }
         }
 
         var keyPair = await ClientKeyHelper.GetKeyPairAsync();

--- a/src/Eryph.GuestServices.Tool/Commands/AddSshConfigCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/AddSshConfigCommand.cs
@@ -18,6 +18,13 @@ public class AddSshConfigCommand : AsyncCommand<AddSshConfigCommand.Settings>
 
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
     {
+        if (!string.IsNullOrEmpty(settings.Alias) && SshConfigHelper.IsReservedAlias(settings.Alias))
+        {
+            AnsiConsole.MarkupLineInterpolated(
+                $"[red]The alias '{settings.Alias}' uses a reserved suffix (.hyper-v.alt or .eryph.alt) that is managed by the eryph guest services. Please choose a different alias.[/]");
+            return -1;
+        }
+
         var keyPair = await ClientKeyHelper.GetKeyPairAsync();
         if (keyPair is null)
         {

--- a/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
+++ b/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
@@ -24,12 +24,15 @@ public static class SshConfigHelper
     // Returns a human-readable error, or null when the alias is acceptable.
     public static string? GetAliasValidationError(string alias)
     {
-        // Whitespace/control characters would split into multiple host patterns
-        // or, in the case of a newline, inject arbitrary directives into the
-        // generated SSH config. Do not echo the alias here: a control character
-        // (e.g. ESC) in it could inject terminal escape sequences when printed.
-        if (alias.Any(c => char.IsWhiteSpace(c) || char.IsControl(c)))
-            return "The alias must not contain whitespace or control characters.";
+        // Restrict to a safe host-token charset. Anything outside it could change
+        // how the generated 'Host' line is parsed: whitespace splits it into
+        // multiple patterns, a newline injects arbitrary directives, and
+        // ssh_config metacharacters such as '#' (comment), '!' (negation) and
+        // '*'/'?' (patterns) alter its meaning. Do not echo the alias in this
+        // message: a control character (e.g. ESC) in it could inject terminal
+        // escape sequences when printed.
+        if (!alias.All(IsAllowedAliasChar))
+            return "The alias may only contain letters, digits, '.', '-' and '_'.";
 
         if (IsReservedAlias(alias))
             return $"The alias '{alias}' uses a reserved suffix (.hyper-v.alt or .eryph.alt) "
@@ -37,6 +40,9 @@ public static class SshConfigHelper
 
         return null;
     }
+
+    private static bool IsAllowedAliasChar(char c) =>
+        char.IsAsciiLetterOrDigit(c) || c is '.' or '-' or '_';
 
     // Test seam: overrides the config root so the writers and the alias-dedup
     // sweep can be exercised against a temp directory instead of the real user

--- a/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
+++ b/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
@@ -117,7 +117,13 @@ public static class SshConfigHelper
         // could silently resolve to a different (often stale/stopped) VM and the
         // ProxyCommand would connect to the wrong vmId. Evict the alias from any
         // other config so the VM we are configuring now owns it.
-        await RemoveAliasesFromOtherConfigsAsync(aliases, ownConfigPath);
+        //
+        // Only the user-supplied alias is swept: the per-VM "<vmId>.hyper-v.alt"
+        // token is unique by construction and can never legitimately collide, so
+        // it must not be fed to the sweep (doing so could strip another VM's
+        // canonical token from its config).
+        if (!string.IsNullOrEmpty(alias))
+            await RemoveAliasesFromOtherConfigsAsync([alias], ownConfigPath);
 
         await WriteConfig(
             ownConfigPath,
@@ -130,10 +136,11 @@ public static class SshConfigHelper
 
     // Removes the given <paramref name="aliases"/> from every auto-generated VM
     // and catlet config file except <paramref name="ownConfigPath"/>. A file
-    // that still has at least one alias left is rewritten; a file whose Host
-    // line would become empty is deleted. VM config files always retain their
-    // unique "&lt;vmId&gt;.hyper-v.alt" token, so they are only ever rewritten,
-    // never deleted, by this sweep.
+    // that still has at least one alias left is rewritten. A file whose Host
+    // line would be emptied is left untouched: that only happens when the alias
+    // is that config's sole identity (e.g. a VM's "&lt;vmId&gt;.hyper-v.alt"
+    // token typed verbatim as another VM's alias), and silently deleting it
+    // would orphan an existing host. Keeping it preserves reachability.
     private static async Task RemoveAliasesFromOtherConfigsAsync(
         IReadOnlyList<string> aliases,
         string ownConfigPath)
@@ -185,19 +192,9 @@ public static class SshConfigHelper
             return;
 
         if (keptAliases.Count == 0)
-        {
-            try
-            {
-                File.Delete(file);
-            }
-            catch
-            {
-                // An orphaned config with no aliases matches nothing, so a failed
-                // delete is harmless.
-            }
-
+            // The alias is this config's only identity; stripping it would leave
+            // a dangling, unreachable host. Leave the file as-is.
             return;
-        }
 
         lines[hostLineIndex] = "Host " + string.Join(' ', keptAliases);
         try

--- a/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
+++ b/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
@@ -138,6 +138,16 @@ public static class SshConfigHelper
         Directory.CreateDirectory(VmSshConfigPath);
         var ownConfigPath = Path.Combine(VmSshConfigPath, $"{vmId}.config");
 
+        // Write our own config before sweeping the others. If WriteConfig fails,
+        // having already stripped the alias from its previous owner would lose
+        // it entirely; doing this first means a later sweep failure only leaves
+        // the pre-existing duplicate behind.
+        await WriteConfig(
+            ownConfigPath,
+            aliases,
+            vmId,
+            keyFilePath);
+
         // An SSH alias must resolve to exactly one host. The user-supplied alias
         // is not constrained to a single VM, so re-using it for another VM (or
         // an alias that already names a catlet) would leave two 'Host <alias>'
@@ -153,12 +163,6 @@ public static class SshConfigHelper
         // canonical token from its config).
         if (!string.IsNullOrEmpty(alias))
             await RemoveAliasesFromOtherConfigsAsync([alias], ownConfigPath);
-
-        await WriteConfig(
-            ownConfigPath,
-            aliases,
-            vmId,
-            keyFilePath);
 
         return aliases;
     }

--- a/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
+++ b/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
@@ -20,6 +20,23 @@ public static class SshConfigHelper
     public static bool IsReservedAlias(string alias) =>
         ReservedAliasSuffixes.Any(suffix => alias.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
 
+    // Validates a user-supplied alias before it is written into a 'Host' line.
+    // Returns a human-readable error, or null when the alias is acceptable.
+    public static string? GetAliasValidationError(string alias)
+    {
+        // Whitespace/control characters would split into multiple host patterns
+        // or, in the case of a newline, inject arbitrary directives into the
+        // generated SSH config.
+        if (alias.Any(c => char.IsWhiteSpace(c) || char.IsControl(c)))
+            return $"The alias '{alias}' must not contain whitespace or control characters.";
+
+        if (IsReservedAlias(alias))
+            return $"The alias '{alias}' uses a reserved suffix (.hyper-v.alt or .eryph.alt) "
+                + "that is managed by the eryph guest services.";
+
+        return null;
+    }
+
     // Test seam: overrides the config root so the writers and the alias-dedup
     // sweep can be exercised against a temp directory instead of the real user
     // profile. Null in production.
@@ -157,7 +174,10 @@ public static class SshConfigHelper
         IReadOnlyList<string> aliases,
         string ownConfigPath)
     {
-        var aliasesToRemove = new HashSet<string>(aliases, StringComparer.Ordinal);
+        // Match case-insensitively: SSH host aliases are effectively
+        // case-insensitive, so 'web' and 'WEB' must be treated as the same
+        // alias or the sweep would leave a casing-only duplicate behind.
+        var aliasesToRemove = new HashSet<string>(aliases, StringComparer.OrdinalIgnoreCase);
         var ownFullPath = Path.GetFullPath(ownConfigPath);
 
         foreach (var directory in new[] { VmSshConfigPath, CatletSshConfigPath })
@@ -197,7 +217,10 @@ public static class SshConfigHelper
         if (hostLineIndex < 0)
             return;
 
-        var tokens = lines[hostLineIndex].Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        // Split on any whitespace (space or tab, both valid ssh-config
+        // separators) so the sweep is robust to hand-edited files.
+        var tokens = lines[hostLineIndex].Split(
+            (char[]?)null, StringSplitOptions.RemoveEmptyEntries);
         // tokens[0] is the "Host" keyword; the remainder are the aliases.
         var keptAliases = tokens.Skip(1).Where(t => !aliasesToRemove.Contains(t)).ToList();
         if (keptAliases.Count == tokens.Length - 1)

--- a/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
+++ b/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
@@ -8,6 +8,18 @@ public static class SshConfigHelper
 {
     private const string Border = "# ------ eryph guest services ------";
 
+    // Suffixes reserved for the auto-generated canonical hosts:
+    // "<vmId>.hyper-v.alt" for VMs and "<...>.eryph.alt" for catlets. A
+    // user-supplied alias must not use them: a "*.hyper-v.alt" alias could
+    // shadow another VM's canonical token, and a "*.eryph.alt" alias collides
+    // with catlet hosts that update-ssh-config regenerates (and catlet.d is
+    // Included before vm.d, so the catlet would even shadow the VM). Rejecting
+    // these keeps every user alias outside the generated namespaces.
+    private static readonly string[] ReservedAliasSuffixes = [".hyper-v.alt", ".eryph.alt"];
+
+    public static bool IsReservedAlias(string alias) =>
+        ReservedAliasSuffixes.Any(suffix => alias.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+
     // Test seam: overrides the config root so the writers and the alias-dedup
     // sweep can be exercised against a temp directory instead of the real user
     // profile. Null in production.

--- a/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
+++ b/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
@@ -32,7 +32,7 @@ public static class SshConfigHelper
         // message: a control character (e.g. ESC) in it could inject terminal
         // escape sequences when printed.
         if (!alias.All(IsAllowedAliasChar))
-            return "The alias may only contain letters, digits, '.', '-' and '_'.";
+            return "The alias may only contain ASCII letters, digits, '.', '-' and '_'.";
 
         if (IsReservedAlias(alias))
             return $"The alias '{alias}' uses a reserved suffix (.hyper-v.alt or .eryph.alt) "

--- a/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
+++ b/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
@@ -8,9 +8,14 @@ public static class SshConfigHelper
 {
     private const string Border = "# ------ eryph guest services ------";
 
+    // Test seam: overrides the config root so the writers and the alias-dedup
+    // sweep can be exercised against a temp directory instead of the real user
+    // profile. Null in production.
+    internal static string? RootPathOverride { get; set; }
+
     // The config should be in the local (non-roaming) profile as the connection
     // only works on the specific machine.
-    private static string EryphSshConfigPath => Path.Combine(
+    private static string EryphSshConfigPath => RootPathOverride ?? Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         ".eryph",
         "guest-services",
@@ -102,13 +107,108 @@ public static class SshConfigHelper
            aliases = [alias, ..aliases];
 
         Directory.CreateDirectory(VmSshConfigPath);
+        var ownConfigPath = Path.Combine(VmSshConfigPath, $"{vmId}.config");
+
+        // An SSH alias must resolve to exactly one host. The user-supplied alias
+        // is not constrained to a single VM, so re-using it for another VM (or
+        // an alias that already names a catlet) would leave two 'Host <alias>'
+        // stanzas across the included config files. OpenSSH processes the
+        // Include glob in lexical order and the first match wins, so the alias
+        // could silently resolve to a different (often stale/stopped) VM and the
+        // ProxyCommand would connect to the wrong vmId. Evict the alias from any
+        // other config so the VM we are configuring now owns it.
+        await RemoveAliasesFromOtherConfigsAsync(aliases, ownConfigPath);
+
         await WriteConfig(
-            Path.Combine(VmSshConfigPath, $"{vmId}.config"),
+            ownConfigPath,
             aliases,
             vmId,
             keyFilePath);
 
         return aliases;
+    }
+
+    // Removes the given <paramref name="aliases"/> from every auto-generated VM
+    // and catlet config file except <paramref name="ownConfigPath"/>. A file
+    // that still has at least one alias left is rewritten; a file whose Host
+    // line would become empty is deleted. VM config files always retain their
+    // unique "&lt;vmId&gt;.hyper-v.alt" token, so they are only ever rewritten,
+    // never deleted, by this sweep.
+    private static async Task RemoveAliasesFromOtherConfigsAsync(
+        IReadOnlyList<string> aliases,
+        string ownConfigPath)
+    {
+        var aliasesToRemove = new HashSet<string>(aliases, StringComparer.Ordinal);
+        var ownFullPath = Path.GetFullPath(ownConfigPath);
+
+        foreach (var directory in new[] { VmSshConfigPath, CatletSshConfigPath })
+        {
+            if (!Directory.Exists(directory))
+                continue;
+
+            foreach (var file in Directory.EnumerateFiles(directory, "*.config", SearchOption.TopDirectoryOnly))
+            {
+                if (string.Equals(Path.GetFullPath(file), ownFullPath, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                await RemoveAliasesFromConfigFileAsync(file, aliasesToRemove);
+            }
+        }
+    }
+
+    private static async Task RemoveAliasesFromConfigFileAsync(
+        string file,
+        HashSet<string> aliasesToRemove)
+    {
+        string[] lines;
+        try
+        {
+            lines = await File.ReadAllLinesAsync(file);
+        }
+        catch
+        {
+            // A config we cannot read cannot be safely rewritten. Leaving it in
+            // place is no worse than the pre-existing state.
+            return;
+        }
+
+        var hostLineIndex = Array.FindIndex(
+            lines,
+            line => line.TrimStart().StartsWith("Host ", StringComparison.Ordinal));
+        if (hostLineIndex < 0)
+            return;
+
+        var tokens = lines[hostLineIndex].Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        // tokens[0] is the "Host" keyword; the remainder are the aliases.
+        var keptAliases = tokens.Skip(1).Where(t => !aliasesToRemove.Contains(t)).ToList();
+        if (keptAliases.Count == tokens.Length - 1)
+            return;
+
+        if (keptAliases.Count == 0)
+        {
+            try
+            {
+                File.Delete(file);
+            }
+            catch
+            {
+                // An orphaned config with no aliases matches nothing, so a failed
+                // delete is harmless.
+            }
+
+            return;
+        }
+
+        lines[hostLineIndex] = "Host " + string.Join(' ', keptAliases);
+        try
+        {
+            await File.WriteAllLinesAsync(file, lines);
+        }
+        catch
+        {
+            // Ignore: failing to drop the alias here only means the duplicate
+            // persists, which is the pre-existing behaviour we are improving.
+        }
     }
 
     private static async Task WriteConfig(

--- a/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
+++ b/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
@@ -26,9 +26,10 @@ public static class SshConfigHelper
     {
         // Whitespace/control characters would split into multiple host patterns
         // or, in the case of a newline, inject arbitrary directives into the
-        // generated SSH config.
+        // generated SSH config. Do not echo the alias here: a control character
+        // (e.g. ESC) in it could inject terminal escape sequences when printed.
         if (alias.Any(c => char.IsWhiteSpace(c) || char.IsControl(c)))
-            return $"The alias '{alias}' must not contain whitespace or control characters.";
+            return "The alias must not contain whitespace or control characters.";
 
         if (IsReservedAlias(alias))
             return $"The alias '{alias}' uses a reserved suffix (.hyper-v.alt or .eryph.alt) "

--- a/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
+++ b/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
@@ -211,9 +211,7 @@ public static class SshConfigHelper
             return;
         }
 
-        var hostLineIndex = Array.FindIndex(
-            lines,
-            line => line.TrimStart().StartsWith("Host ", StringComparison.Ordinal));
+        var hostLineIndex = Array.FindIndex(lines, IsHostLine);
         if (hostLineIndex < 0)
             return;
 
@@ -241,6 +239,17 @@ public static class SshConfigHelper
             // Ignore: failing to drop the alias here only means the duplicate
             // persists, which is the pre-existing behaviour we are improving.
         }
+    }
+
+    // A 'Host' stanza: the keyword (case-insensitive, per ssh_config) followed
+    // by any whitespace (space or tab). Matching only "Host " would miss a
+    // tab-separated line in a hand-edited config.
+    private static bool IsHostLine(string line)
+    {
+        var trimmed = line.TrimStart();
+        return trimmed.Length > 4
+            && trimmed.StartsWith("Host", StringComparison.OrdinalIgnoreCase)
+            && char.IsWhiteSpace(trimmed[4]);
     }
 
     private static async Task WriteConfig(

--- a/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
+++ b/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
@@ -187,10 +187,23 @@ public static class SshConfigHelper
 
         foreach (var directory in new[] { VmSshConfigPath, CatletSshConfigPath })
         {
-            if (!Directory.Exists(directory))
-                continue;
+            string[] files;
+            try
+            {
+                if (!Directory.Exists(directory))
+                    continue;
 
-            foreach (var file in Directory.EnumerateFiles(directory, "*.config", SearchOption.TopDirectoryOnly))
+                files = Directory.GetFiles(directory, "*.config", SearchOption.TopDirectoryOnly);
+            }
+            catch
+            {
+                // Best-effort: a directory we cannot enumerate (permissions, or
+                // removed between the check and the call) just skips its
+                // de-duplication; it must never fail the command.
+                continue;
+            }
+
+            foreach (var file in files)
             {
                 if (string.Equals(Path.GetFullPath(file), ownFullPath, StringComparison.OrdinalIgnoreCase))
                     continue;

--- a/test/Eryph.GuestServices.Tool.Tests/SshConfigCollection.cs
+++ b/test/Eryph.GuestServices.Tool.Tests/SshConfigCollection.cs
@@ -1,0 +1,8 @@
+namespace Eryph.GuestServices.Tool.Tests;
+
+// SshConfigHelperTests mutate the static SshConfigHelper.RootPathOverride.
+// xunit runs collections in parallel by default, so serialise these tests in a
+// single CollectionDefinition to keep them from racing another collection over
+// that global.
+[CollectionDefinition(nameof(SshConfigCollection), DisableParallelization = true)]
+public sealed class SshConfigCollection;

--- a/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
+++ b/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
@@ -1,0 +1,121 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.Tool;
+
+namespace Eryph.GuestServices.Tool.Tests;
+
+public class SshConfigHelperTests : IDisposable
+{
+    private readonly string _root;
+
+    public SshConfigHelperTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "egs-ssh-config-tests", Guid.NewGuid().ToString("N"));
+        SshConfigHelper.RootPathOverride = _root;
+    }
+
+    public void Dispose()
+    {
+        SshConfigHelper.RootPathOverride = null;
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch
+        {
+            // best effort cleanup
+        }
+    }
+
+    [Fact]
+    public async Task EnsureVmConfigAsync_AliasReusedForAnotherVm_LeavesAliasInExactlyOneFile()
+    {
+        var vmA = Guid.NewGuid();
+        var vmB = Guid.NewGuid();
+
+        await SshConfigHelper.EnsureVmConfigAsync(vmA, "shared", @"C:\key");
+        await SshConfigHelper.EnsureVmConfigAsync(vmB, "shared", @"C:\key");
+
+        var owners = await FindHostFilesContainingAliasAsync(SshConfigHelper.VmSshConfigPath, "shared");
+
+        // The alias must resolve to a single host; the most recent writer (vmB)
+        // owns it. Without dedup both files carry 'Host shared' and OpenSSH
+        // first-match-wins picks an arbitrary (often stale) VM.
+        owners.Should().ContainSingle()
+            .Which.Should().Be(Path.Combine(SshConfigHelper.VmSshConfigPath, $"{vmB}.config"));
+    }
+
+    [Fact]
+    public async Task EnsureVmConfigAsync_AliasReusedForAnotherVm_OldVmKeepsItsHyperVAlias()
+    {
+        var vmA = Guid.NewGuid();
+        var vmB = Guid.NewGuid();
+
+        await SshConfigHelper.EnsureVmConfigAsync(vmA, "shared", @"C:\key");
+        await SshConfigHelper.EnsureVmConfigAsync(vmB, "shared", @"C:\key");
+
+        // Stripping the stolen alias must not orphan the old VM: it stays
+        // reachable through its unique <vmId>.hyper-v.alt host.
+        var oldHostLine = await ReadHostLineAsync(
+            Path.Combine(SshConfigHelper.VmSshConfigPath, $"{vmA}.config"));
+        oldHostLine.Should().NotBeNull();
+        oldHostLine!.Split(' ').Should().Contain($"{vmA}.hyper-v.alt")
+            .And.NotContain("shared");
+    }
+
+    [Fact]
+    public async Task EnsureVmConfigAsync_AliasCollidesWithCatlet_AliasIsRemovedFromCatletConfig()
+    {
+        var catletVmId = Guid.NewGuid();
+        // Project "default" yields the bare "<name>.eryph.alt" alias.
+        await SshConfigHelper.EnsureCatletConfigAsync(
+            "catlet-1", "web", "default", catletVmId, @"C:\key");
+
+        var vmId = Guid.NewGuid();
+        await SshConfigHelper.EnsureVmConfigAsync(vmId, "web.eryph.alt", @"C:\key");
+
+        var catletOwners = await FindHostFilesContainingAliasAsync(
+            SshConfigHelper.CatletSshConfigPath, "web.eryph.alt");
+        var vmOwners = await FindHostFilesContainingAliasAsync(
+            SshConfigHelper.VmSshConfigPath, "web.eryph.alt");
+
+        catletOwners.Should().BeEmpty();
+        vmOwners.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task EnsureVmConfigAsync_SameVmRewritten_RemainsSingleFile()
+    {
+        var vmId = Guid.NewGuid();
+
+        await SshConfigHelper.EnsureVmConfigAsync(vmId, "shared", @"C:\key");
+        await SshConfigHelper.EnsureVmConfigAsync(vmId, "shared", @"C:\key");
+
+        Directory.GetFiles(SshConfigHelper.VmSshConfigPath, "*.config").Should().ContainSingle();
+        var owners = await FindHostFilesContainingAliasAsync(SshConfigHelper.VmSshConfigPath, "shared");
+        owners.Should().ContainSingle();
+    }
+
+    private static async Task<IReadOnlyList<string>> FindHostFilesContainingAliasAsync(
+        string directory,
+        string alias)
+    {
+        if (!Directory.Exists(directory))
+            return [];
+
+        var result = new List<string>();
+        foreach (var file in Directory.GetFiles(directory, "*.config"))
+        {
+            var hostLine = await ReadHostLineAsync(file);
+            if (hostLine is not null && hostLine.Split(' ').Contains(alias))
+                result.Add(file);
+        }
+
+        return result;
+    }
+
+    private static async Task<string?> ReadHostLineAsync(string file)
+    {
+        var lines = await File.ReadAllLinesAsync(file);
+        return lines.FirstOrDefault(l => l.StartsWith("Host ", StringComparison.Ordinal));
+    }
+}

--- a/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
+++ b/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
@@ -3,6 +3,7 @@ using Eryph.GuestServices.Tool;
 
 namespace Eryph.GuestServices.Tool.Tests;
 
+[Collection(nameof(SshConfigCollection))]
 public class SshConfigHelperTests : IDisposable
 {
     private readonly string _root;
@@ -98,7 +99,8 @@ public class SshConfigHelperTests : IDisposable
         var aPath = Path.Combine(SshConfigHelper.VmSshConfigPath, $"{vmA}.config");
         File.Exists(aPath).Should().BeTrue();
         var aHostLine = await ReadHostLineAsync(aPath);
-        aHostLine!.Split(' ').Should().Contain($"{vmA}.hyper-v.alt");
+        aHostLine!.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)
+            .Should().Contain($"{vmA}.hyper-v.alt");
     }
 
     [Fact]

--- a/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
+++ b/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
@@ -58,7 +58,8 @@ public class SshConfigHelperTests : IDisposable
         var oldHostLine = await ReadHostLineAsync(
             Path.Combine(SshConfigHelper.VmSshConfigPath, $"{vmA}.config"));
         oldHostLine.Should().NotBeNull();
-        oldHostLine!.Split(' ').Should().Contain($"{vmA}.hyper-v.alt")
+        oldHostLine!.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)
+            .Should().Contain($"{vmA}.hyper-v.alt")
             .And.NotContain("shared");
     }
 
@@ -198,7 +199,10 @@ public class SshConfigHelperTests : IDisposable
         foreach (var file in Directory.GetFiles(directory, "*.config"))
         {
             var hostLine = await ReadHostLineAsync(file);
-            if (hostLine is not null && hostLine.Split(' ').Contains(alias))
+            // Mirror production parsing: split on any whitespace and drop the
+            // leading "Host" keyword before matching aliases.
+            if (hostLine is not null
+                && hostLine.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Skip(1).Contains(alias))
                 result.Add(file);
         }
 
@@ -208,6 +212,12 @@ public class SshConfigHelperTests : IDisposable
     private static async Task<string?> ReadHostLineAsync(string file)
     {
         var lines = await File.ReadAllLinesAsync(file);
-        return lines.FirstOrDefault(l => l.StartsWith("Host ", StringComparison.Ordinal));
+        return lines.FirstOrDefault(l =>
+        {
+            var trimmed = l.TrimStart();
+            return trimmed.Length > 4
+                && trimmed.StartsWith("Host", StringComparison.OrdinalIgnoreCase)
+                && char.IsWhiteSpace(trimmed[4]);
+        });
     }
 }

--- a/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
+++ b/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
@@ -113,6 +113,19 @@ public class SshConfigHelperTests : IDisposable
         owners.Should().ContainSingle();
     }
 
+    [Theory]
+    [InlineData("web.eryph.alt", true)]
+    [InlineData("some-vm.hyper-v.alt", true)]
+    [InlineData("00000000-0000-0000-0000-000000000000.hyper-v.alt", true)]
+    [InlineData("WEB.ERYPH.ALT", true)]
+    [InlineData("myalias", false)]
+    [InlineData("alias.local", false)]
+    [InlineData("eryph.alt", false)]
+    public void IsReservedAlias_DetectsGeneratedNamespaces(string alias, bool expected)
+    {
+        SshConfigHelper.IsReservedAlias(alias).Should().Be(expected);
+    }
+
     private static async Task<IReadOnlyList<string>> FindHostFilesContainingAliasAsync(
         string directory,
         string alias)

--- a/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
+++ b/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
@@ -199,8 +199,9 @@ public class SshConfigHelperTests : IDisposable
         foreach (var file in Directory.GetFiles(directory, "*.config"))
         {
             var hostLine = await ReadHostLineAsync(file);
-            // Mirror production parsing: split on any whitespace and drop the
-            // leading "Host" keyword before matching aliases.
+            // Tokenize like production (split on any whitespace, drop the leading
+            // "Host" keyword). The alias match is intentionally case-sensitive so
+            // the casing tests can assert the exact surviving casing.
             if (hostLine is not null
                 && hostLine.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Skip(1).Contains(alias))
                 result.Add(file);

--- a/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
+++ b/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
@@ -126,6 +126,43 @@ public class SshConfigHelperTests : IDisposable
         SshConfigHelper.IsReservedAlias(alias).Should().Be(expected);
     }
 
+    [Theory]
+    [InlineData("myalias")]
+    [InlineData("web-01.local")]
+    public void GetAliasValidationError_AcceptsPlainAliases(string alias)
+    {
+        SshConfigHelper.GetAliasValidationError(alias).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("has space")]
+    [InlineData("has\ttab")]
+    [InlineData("line\ninject")]
+    [InlineData("web.eryph.alt")]
+    [InlineData("x.hyper-v.alt")]
+    public void GetAliasValidationError_RejectsInvalidAliases(string alias)
+    {
+        SshConfigHelper.GetAliasValidationError(alias).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task EnsureVmConfigAsync_AliasReusedWithDifferentCasing_LeavesAliasInExactlyOneFile()
+    {
+        var vmA = Guid.NewGuid();
+        var vmB = Guid.NewGuid();
+
+        await SshConfigHelper.EnsureVmConfigAsync(vmA, "shared", @"C:\key");
+        await SshConfigHelper.EnsureVmConfigAsync(vmB, "SHARED", @"C:\key");
+
+        var lowerOwners = await FindHostFilesContainingAliasAsync(SshConfigHelper.VmSshConfigPath, "shared");
+        var upperOwners = await FindHostFilesContainingAliasAsync(SshConfigHelper.VmSshConfigPath, "SHARED");
+
+        // Case-only difference must still be treated as the same alias.
+        lowerOwners.Should().BeEmpty();
+        upperOwners.Should().ContainSingle()
+            .Which.Should().Be(Path.Combine(SshConfigHelper.VmSshConfigPath, $"{vmB}.config"));
+    }
+
     private static async Task<IReadOnlyList<string>> FindHostFilesContainingAliasAsync(
         string directory,
         string alias)

--- a/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
+++ b/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
@@ -83,6 +83,24 @@ public class SshConfigHelperTests : IDisposable
     }
 
     [Fact]
+    public async Task EnsureVmConfigAsync_DoesNotStripAnotherVmsHyperVAliasOrDeleteItsConfig()
+    {
+        var vmA = Guid.NewGuid();
+        await SshConfigHelper.EnsureVmConfigAsync(vmA, alias: null, @"C:\key");
+
+        // Pathological: user passes VM A's unique canonical token as VM B's
+        // alias. The sweep must not strip A's only identity nor delete its
+        // config, which would orphan A.
+        var vmB = Guid.NewGuid();
+        await SshConfigHelper.EnsureVmConfigAsync(vmB, $"{vmA}.hyper-v.alt", @"C:\key");
+
+        var aPath = Path.Combine(SshConfigHelper.VmSshConfigPath, $"{vmA}.config");
+        File.Exists(aPath).Should().BeTrue();
+        var aHostLine = await ReadHostLineAsync(aPath);
+        aHostLine!.Split(' ').Should().Contain($"{vmA}.hyper-v.alt");
+    }
+
+    [Fact]
     public async Task EnsureVmConfigAsync_SameVmRewritten_RemainsSingleFile()
     {
         var vmId = Guid.NewGuid();

--- a/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
+++ b/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
@@ -101,6 +101,30 @@ public class SshConfigHelperTests : IDisposable
     }
 
     [Fact]
+    public async Task EnsureVmConfigAsync_StripsAliasFromTabSeparatedHandEditedHostLine()
+    {
+        // A hand-edited config using a tab after Host and between aliases must
+        // still be detected and de-duplicated.
+        Directory.CreateDirectory(SshConfigHelper.VmSshConfigPath);
+        var staleVm = Guid.NewGuid();
+        var stalePath = Path.Combine(SshConfigHelper.VmSshConfigPath, $"{staleVm}.config");
+        await File.WriteAllTextAsync(
+            stalePath,
+            $"Host\tshared\t{staleVm}.hyper-v.alt\n    HostName {staleVm}.hyper-v.alt\n");
+
+        var newVm = Guid.NewGuid();
+        await SshConfigHelper.EnsureVmConfigAsync(newVm, "shared", @"C:\key");
+
+        var owners = await FindHostFilesContainingAliasAsync(SshConfigHelper.VmSshConfigPath, "shared");
+        owners.Should().ContainSingle()
+            .Which.Should().Be(Path.Combine(SshConfigHelper.VmSshConfigPath, $"{newVm}.config"));
+
+        // The stale file keeps its unique token, just loses the stolen alias.
+        var staleHost = await ReadHostLineAsync(stalePath);
+        staleHost!.Should().Contain($"{staleVm}.hyper-v.alt");
+    }
+
+    [Fact]
     public async Task EnsureVmConfigAsync_SameVmRewritten_RemainsSingleFile()
     {
         var vmId = Guid.NewGuid();

--- a/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
+++ b/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
@@ -156,6 +156,7 @@ public class SshConfigHelperTests : IDisposable
     [Theory]
     [InlineData("myalias")]
     [InlineData("web-01.local")]
+    [InlineData("my_alias")]
     public void GetAliasValidationError_AcceptsPlainAliases(string alias)
     {
         SshConfigHelper.GetAliasValidationError(alias).Should().BeNull();
@@ -165,6 +166,10 @@ public class SshConfigHelperTests : IDisposable
     [InlineData("has space")]
     [InlineData("has\ttab")]
     [InlineData("line\ninject")]
+    [InlineData("a#comment")]
+    [InlineData("!negated")]
+    [InlineData("glob*")]
+    [InlineData("question?")]
     [InlineData("web.eryph.alt")]
     [InlineData("x.hyper-v.alt")]
     public void GetAliasValidationError_RejectsInvalidAliases(string alias)


### PR DESCRIPTION
`add-ssh-config <vmid> <alias>` only overwrote its own `vm.d\{vmid}.config` file and never checked whether the alias was already claimed by another VM (or a catlet). Two `Host <alias>` stanzas across the `Include` glob meant OpenSSH (first-match-wins, lexical glob order) could resolve the alias to a stale/stopped VM, so the `ProxyCommand` connected to the wrong vmId and the socket failed — purely client-side, healed by picking a new alias or deleting the local config.

Changes:
- `EnsureVmConfigAsync` evicts the (user-supplied) alias from every other `vm.d`/`catlet.d` config before writing, so the VM being configured owns it. Files keeping another alias are rewritten; a file whose `Host` line would be left empty is **left untouched** (never deleted), so an existing host is never orphaned. The unique `<vmId>.hyper-v.alt` token is never fed to the sweep. Matching is case-insensitive and tolerant of tab/space separators.
- `add-ssh-config` rejects aliases that use a reserved generated suffix (`.hyper-v.alt` / `.eryph.alt`) or that contain whitespace/control characters, keeping every user alias outside the generated namespaces and out of the `Host` line as a single safe token.

Tests (`SshConfigHelperTests`, via a `RootPathOverride` seam): alias reused across VMs / with different casing lands in exactly one file, the old VM stays reachable via its `hyper-v.alt`, a verbatim-token alias never orphans another VM, reserved/invalid aliases are rejected, and same-VM rewrites stay a single file.