### PR TITLE
Update eryph commands for the guest-services API

### DIFF
--- a/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphAddKeyCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphAddKeyCommand.cs
@@ -73,7 +73,7 @@ public class EryphAddKeyCommand : AsyncCommand<EryphAddKeyCommand.Settings>
             expiresAt = DateTimeOffset.UtcNow.Add(parsed);
         }
 
-        var body = new AddSshKeyRequestBody(publicKey)
+        var body = new AddAccessKeyRequestBody(publicKey)
         {
             Ttl = ttlIso,
             ExpiresAt = expiresAt,
@@ -82,7 +82,7 @@ public class EryphAddKeyCommand : AsyncCommand<EryphAddKeyCommand.Settings>
         try
         {
             await connection.CreateCatletsClient(EryphConnection.RemoteAccessScope)
-                .AddSshKeyAsync(catletId, body);
+                .AddAccessKeyAsync(catletId, body);
         }
         catch (Exception ex)
         {

--- a/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphGetStatusCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphGetStatusCommand.cs
@@ -1,0 +1,69 @@
+using Eryph.ComputeClient.Models;
+using Eryph.GuestServices.Tool.Eryph;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Eryph.GuestServices.Tool.Commands.Eryph;
+
+// egs-tool eryph get-status <catletId>
+//
+// Reads the catlet guest's services state (agent status/version, provisioning
+// state, shell) via the compute client's operation and prints it.
+public class EryphGetStatusCommand : AsyncCommand<EryphGetStatusCommand.Settings>
+{
+    public class Settings : EryphConnectionSettings
+    {
+        [CommandArgument(0, "<CatletId>")]
+        public string CatletId { get; set; } = string.Empty;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var connection = EryphConnection.Resolve(settings.ClientId, settings.Configuration);
+        if (connection is null)
+        {
+            AnsiConsole.MarkupLineInterpolated(
+                $"[red]Could not find an eryph connection. Is eryph configured or eryph-zero running?[/]");
+            return -1;
+        }
+
+        string operationId;
+        try
+        {
+            operationId = (await connection.CreateCatletsClient(EryphConnection.CatletsReadScope)
+                .GetGuestServicesAsync(settings.CatletId)).Value.Id;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine(
+                $"[red]Failed to read the guest services status: {ex.Message.EscapeMarkup()}[/]");
+            return -1;
+        }
+
+        var operation = await EryphOperations.WaitForCompletionAsync(
+            connection.CreateOperationsClient(), operationId);
+        if (operation is null)
+        {
+            AnsiConsole.MarkupLine("[red]Timed out waiting for the guest services status.[/]");
+            return -1;
+        }
+
+        if (operation.Status == OperationStatus.Failed)
+        {
+            AnsiConsole.MarkupLine("[red]The guest services status could not be read.[/]");
+            return -1;
+        }
+
+        if (operation.Result is not GuestServicesStatusOperationResult result)
+        {
+            AnsiConsole.MarkupLine("[red]The operation did not return a guest services status.[/]");
+            return -1;
+        }
+
+        AnsiConsole.MarkupLine($"Guest services: {(result.GuestServicesStatus ?? "unknown").EscapeMarkup()}");
+        AnsiConsole.MarkupLine($"Version:        {(result.GuestServicesVersion ?? "-").EscapeMarkup()}");
+        AnsiConsole.MarkupLine($"Provisioning:   {(result.ProvisioningState ?? "-").EscapeMarkup()}");
+        AnsiConsole.MarkupLine($"Shell:          {(result.Shell ?? "-").EscapeMarkup()}");
+        return 0;
+    }
+}

--- a/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphRemoveKeyCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphRemoveKeyCommand.cs
@@ -29,7 +29,7 @@ public class EryphRemoveKeyCommand : AsyncCommand<EryphRemoveKeyCommand.Settings
         try
         {
             await connection.CreateCatletsClient(EryphConnection.RemoteAccessScope)
-                .RemoveSshKeyAsync(settings.CatletId);
+                .RemoveAccessKeyAsync(settings.CatletId);
         }
         catch (Exception ex)
         {

--- a/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphSetShellCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphSetShellCommand.cs
@@ -1,0 +1,71 @@
+using Eryph.ComputeClient.Models;
+using Eryph.GuestServices.Tool.Eryph;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Eryph.GuestServices.Tool.Commands.Eryph;
+
+// egs-tool eryph set-shell <catletId> <shell> [--args <args>]
+//
+// Sets the shell the guest's SSH server spawns for interactive sessions, via the
+// guest-services settings. Pass an empty shell to clear the override.
+public class EryphSetShellCommand : AsyncCommand<EryphSetShellCommand.Settings>
+{
+    public class Settings : EryphConnectionSettings
+    {
+        [CommandArgument(0, "<CatletId>")]
+        public string CatletId { get; set; } = string.Empty;
+
+        [CommandArgument(1, "<Shell>")]
+        public string Shell { get; set; } = string.Empty;
+
+        [CommandOption("--args <ARGS>")]
+        public string? Args { get; set; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var connection = EryphConnection.Resolve(settings.ClientId, settings.Configuration);
+        if (connection is null)
+        {
+            AnsiConsole.MarkupLineInterpolated(
+                $"[red]Could not find an eryph connection. Is eryph configured or eryph-zero running?[/]");
+            return -1;
+        }
+
+        var body = new GuestServicesSettingsBody
+        {
+            Shell = settings.Shell,
+            ShellArgs = settings.Args,
+        };
+
+        string operationId;
+        try
+        {
+            operationId = (await connection.CreateCatletsClient(EryphConnection.RemoteAccessScope)
+                .SetGuestServicesSettingsAsync(settings.CatletId, body)).Value.Id;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Failed to set the shell: {ex.Message.EscapeMarkup()}[/]");
+            return -1;
+        }
+
+        var operation = await EryphOperations.WaitForCompletionAsync(
+            connection.CreateOperationsClient(), operationId);
+        if (operation is null)
+        {
+            AnsiConsole.MarkupLine("[red]Timed out waiting for the shell to be set.[/]");
+            return -1;
+        }
+
+        if (operation.Status == OperationStatus.Failed)
+        {
+            AnsiConsole.MarkupLine("[red]The shell could not be set.[/]");
+            return -1;
+        }
+
+        AnsiConsole.MarkupLine("[green]The shell was set.[/]");
+        return 0;
+    }
+}

--- a/src/Eryph.GuestServices.Tool/Eryph.GuestServices.Tool.csproj
+++ b/src/Eryph.GuestServices.Tool/Eryph.GuestServices.Tool.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Eryph.ClientRuntime.Configuration" Version="0.10.0" />
-    <PackageReference Include="Eryph.ComputeClient" Version="0.15.0-beta.20" />
+    <PackageReference Include="Eryph.ComputeClient" Version="0.15.0-beta.21" />
     <PackageReference Include="Eryph.IdentityModel.Clients" Version="0.7.0" />
     <!-- Eryph.ComputeClient (built for older TFMs) compiles against
          Microsoft.Bcl.AsyncInterfaces 8.0.0. Bumping the explicit ref to the

--- a/src/Eryph.GuestServices.Tool/Eryph/EryphConnection.cs
+++ b/src/Eryph.GuestServices.Tool/Eryph/EryphConnection.cs
@@ -97,8 +97,8 @@ public sealed class EryphConnection
     }
 
     // Builds an absolute API URI for a path relative to the compute endpoint,
-    // including the v1 version segment, e.g. catlets/<id>/ssh-keys ->
-    // https://host/compute/v1/catlets/<id>/ssh-keys.
+    // including the v1 version segment, e.g. catlets/<id>/guest-services/ssh-channel/connect ->
+    // https://host/compute/v1/catlets/<id>/guest-services/ssh-channel/connect.
     public Uri BuildComputeUri(string relativePath)
     {
         var baseUri = ComputeEndpoint.AbsoluteUri.TrimEnd('/');

--- a/src/Eryph.GuestServices.Tool/Eryph/EryphOperations.cs
+++ b/src/Eryph.GuestServices.Tool/Eryph/EryphOperations.cs
@@ -1,0 +1,43 @@
+using Eryph.ComputeClient;
+using Eryph.ComputeClient.Models;
+
+namespace Eryph.GuestServices.Tool.Eryph;
+
+// Shared operation polling for the eryph commands. eryph's API never blocks on
+// an operation, so the client starts it and polls until it terminates.
+internal static class EryphOperations
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan Interval = TimeSpan.FromSeconds(1);
+
+    // Polls until the operation reaches a terminal state; returns it (Completed or
+    // Failed), or null on timeout. Transient poll failures are retried.
+    public static async Task<Operation?> WaitForCompletionAsync(OperationsClient operations, string operationId)
+    {
+        var deadline = DateTimeOffset.UtcNow + Timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            Operation operation;
+            try
+            {
+                operation = (await operations.GetAsync(operationId)).Value;
+            }
+            catch (Exception)
+            {
+                // Resilient poll: a transient network/auth blip — or an HTTP request
+                // timeout, which surfaces as TaskCanceledException (an
+                // OperationCanceledException) — must not abort the wait. There is no
+                // external cancellation token here, so retry until the deadline.
+                await Task.Delay(Interval);
+                continue;
+            }
+
+            if (operation.Status == OperationStatus.Completed || operation.Status == OperationStatus.Failed)
+                return operation;
+
+            await Task.Delay(Interval);
+        }
+
+        return null;
+    }
+}

--- a/src/Eryph.GuestServices.Tool/Eryph/EryphProxy.cs
+++ b/src/Eryph.GuestServices.Tool/Eryph/EryphProxy.cs
@@ -10,7 +10,7 @@ namespace Eryph.GuestServices.Tool.Eryph;
 //   1. CatletsClient.OpenSshChannel  -> starts the OpenSshChannel operation.
 //   2. poll OperationsClient.Get     -> until it completes; read the one-time
 //                                       channel token from the SshChannelOperationResult.
-//   3. GET catlets/{id}/ssh-channel/connect?token=...  (WebSocket) -> bridge the
+//   3. GET catlets/{id}/guest-services/ssh-channel/connect?token=...  (WebSocket) -> bridge the
 //      local stdin/stdout to that socket. The WebSocket leg is a raw ClientWebSocket
 //      because OpenAPI/the generated client does not model WebSocket upgrades.
 // Protocol-agnostic: SSH runs end-to-end over the channel, eryph only relays the
@@ -71,7 +71,7 @@ public static class EryphProxy
         }
 
         var connectUri = connection.BuildComputeUri(
-            $"catlets/{Uri.EscapeDataString(catletId)}/ssh-channel/connect?token={Uri.EscapeDataString(channelToken)}");
+            $"catlets/{Uri.EscapeDataString(catletId)}/guest-services/ssh-channel/connect?token={Uri.EscapeDataString(channelToken)}");
         var wsUri = new UriBuilder(connectUri)
         {
             Scheme = connectUri.Scheme == Uri.UriSchemeHttps ? "wss" : "ws",

--- a/src/Eryph.GuestServices.Tool/Program.cs
+++ b/src/Eryph.GuestServices.Tool/Program.cs
@@ -81,6 +81,14 @@ app.Configure(config =>
         eryph.AddCommand<EryphRemoveKeyCommand>("remove-key")
             .WithDescription(
                 "Revokes the caller's key on the given catlet via eryph.");
+
+        eryph.AddCommand<EryphGetStatusCommand>("get-status")
+            .WithDescription(
+                "Prints the guest services and provisioning status of the given catlet.");
+
+        eryph.AddCommand<EryphSetShellCommand>("set-shell")
+            .WithDescription(
+                "Sets the SSH session shell on the given catlet via eryph.");
     });
 });
 


### PR DESCRIPTION
Moves the egs-tool `eryph` commands onto the guest-services compute API (`Eryph.ComputeClient 0.15.0-beta.21`):

- `add-key`/`remove-key` call `AddAccessKey`/`RemoveAccessKey`; `proxy` connects under `catlets/{id}/guest-services/ssh-channel`.
- New `eryph get-status` (guest-services + provisioning status incl. shell) and `eryph set-shell`, via a shared operation poller.

Verified end-to-end against a local catlet (get-status reads live state; set-shell writes and clears, confirmed by read-back).