### PR TITLE
Run SSH exec requests through the configured shell

### DIFF
--- a/src/Eryph.GuestServices.Core/Constants.cs
+++ b/src/Eryph.GuestServices.Core/Constants.cs
@@ -52,10 +52,12 @@ public static class Constants
 
     /// <summary>
     /// The KVP key (External pool) that overrides the shell command spawned
-    /// for an interactive SSH session. When unset, the service falls back to
-    /// the SSH-sent <c>SHELL</c> environment variable, then to the platform
-    /// default (<c>powershell.exe</c> on Windows, <c>$SHELL</c> or
-    /// <c>/bin/bash</c> on Linux).
+    /// for an SSH session — both interactive shells and non-interactive
+    /// <c>exec</c> (remote command) requests, which run the command through this
+    /// shell. When unset, the service falls back to the SSH-sent <c>SHELL</c>
+    /// environment variable (interactive only), then to the platform default
+    /// (<c>powershell.exe</c> on Windows, <c>$SHELL</c> or <c>/bin/bash</c> on
+    /// Linux).
     /// </summary>
     public static readonly string ShellKey = "eryph:guest-services:shell";
 

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/CommandForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/CommandForwarder.cs
@@ -1,14 +1,22 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using Microsoft.DevTunnels.Ssh;
 
 namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions.Forwarders;
 
-public sealed class CommandForwarder(string command) : IDisposable
+public sealed class CommandForwarder : IDisposable
 {
+    private readonly string _command;
+    private readonly IShellSelector _selector;
     private readonly CancellationTokenSource _cts = new();
     private Process? _process;
 
     private int _isRunning;
+
+    public CommandForwarder(string command, IShellSelector? selector = null)
+    {
+        _command = command;
+        _selector = selector ?? DefaultShellSelector.Instance;
+    }
 
     public async Task StartAsync(SshStream stream, CancellationToken cancellation)
     {
@@ -17,21 +25,11 @@ public sealed class CommandForwarder(string command) : IDisposable
 
         try
         {
-            var splitted = command.Split(' ', 2);
-            var fileName = splitted[0];
-            var arguments = splitted.Length > 1 ? splitted[1] : "";
-            _process = new Process();
-            _process.StartInfo = new ProcessStartInfo
-            {
-                FileName = fileName,
-                Arguments = arguments,
-                RedirectStandardInput = true,
-                RedirectStandardOutput = true,
-                RedirectStandardError = false,
-                UseShellExecute = false,
-                CreateNoWindow = false,
-            };
-
+            // An `exec` request carries no SSH `env` (those route to ShellService
+            // on the interactive channel), so resolve with no per-session
+            // override: the KVP-configured shell wins, else the platform default.
+            var selection = await _selector.SelectAsync(ShellOverride.Empty, cancellation);
+            _process = new Process { StartInfo = BuildStartInfo(selection.Command, _command) };
             _ = RunAsync(stream);
         }
         catch (Exception ex)
@@ -40,22 +38,83 @@ public sealed class CommandForwarder(string command) : IDisposable
         }
     }
 
+    /// <summary>
+    /// Builds the process start info that runs <paramref name="command"/>
+    /// through <paramref name="shellCommand"/> in non-interactive command mode,
+    /// honoring the OpenSSH <c>$SHELL -c "&lt;command&gt;"</c> contract. The
+    /// command is handed to the shell as a single argument via
+    /// <see cref="ProcessStartInfo.ArgumentList"/> so the shell parses it —
+    /// rather than the previous naive split-on-space that broke pipes, quoting
+    /// and any path containing a space.
+    /// </summary>
+    internal static ProcessStartInfo BuildStartInfo(string shellCommand, string command)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = shellCommand,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            // Capture stderr so it can be returned to the client. Without this
+            // the child's errors went to the service process's own stderr and
+            // were invisible to the caller — surprising for a human and broken
+            // for an AI agent that needs to see why a command failed.
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        startInfo.ArgumentList.Add(NonInteractiveShell.CommandFlagFor(shellCommand));
+        startInfo.ArgumentList.Add(command);
+        return startInfo;
+    }
+
     private async Task RunAsync(SshStream sshStream)
     {
         try
         {
             _process!.Start();
 
-            var outputTask = _process.StandardOutput.BaseStream.CopyToAsync(sshStream, _cts.Token);
+            // This SSH library exposes only a single channel data stream — it
+            // has no SSH extended-data (stderr) support — so stdout and stderr
+            // are merged onto it. That mirrors `ssh host "cmd 2>&1"` and the
+            // interactive PTY path, where a terminal has no separate error
+            // stream. A shared lock serializes the two pumps so their writes
+            // can't interleave mid-chunk and corrupt the channel framing.
+            var writeLock = new SemaphoreSlim(1, 1);
+            var stdoutTask = PumpToChannelAsync(
+                _process.StandardOutput.BaseStream, sshStream, writeLock, _cts.Token);
+            var stderrTask = PumpToChannelAsync(
+                _process.StandardError.BaseStream, sshStream, writeLock, _cts.Token);
             _ = sshStream.CopyToAsync(_process.StandardInput.BaseStream, _cts.Token);
-           
+
             await _process.WaitForExitAsync(_cts.Token);
-            await outputTask;
+            await Task.WhenAll(stdoutTask, stderrTask);
             await sshStream.Channel.CloseAsync(unchecked((uint)_process.ExitCode), _cts.Token);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             await sshStream.Channel.CloseAsync(EryphSignalTypes.Exception, ex.Message, _cts.Token);
+        }
+    }
+
+    private static async Task PumpToChannelAsync(
+        Stream source,
+        Stream channel,
+        SemaphoreSlim writeLock,
+        CancellationToken cancellation)
+    {
+        var buffer = new byte[16 * 1024];
+        int read;
+        while ((read = await source.ReadAsync(buffer, cancellation)) > 0)
+        {
+            await writeLock.WaitAsync(cancellation);
+            try
+            {
+                await channel.WriteAsync(buffer.AsMemory(0, read), cancellation);
+            }
+            finally
+            {
+                writeLock.Release();
+            }
         }
     }
 

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/CommandForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/CommandForwarder.cs
@@ -86,6 +86,10 @@ public sealed class CommandForwarder : IDisposable
         // PTY path, where a terminal has no separate error stream. A shared lock
         // serializes the two pumps so their writes can't interleave mid-chunk
         // and corrupt the channel framing.
+        // Capture the token once: a CancellationToken struct stays usable after
+        // its source is disposed, so Dispose can free _cts without racing the
+        // _cts.Token getter here (which would throw ObjectDisposedException).
+        var cancellation = _cts.Token;
         var writeLock = new SemaphoreSlim(1, 1);
         Task? stdoutTask = null;
         Task? stderrTask = null;
@@ -94,18 +98,18 @@ public sealed class CommandForwarder : IDisposable
             _process!.Start();
 
             stdoutTask = PumpToChannelAsync(
-                _process.StandardOutput.BaseStream, sshStream, writeLock, _cts.Token);
+                _process.StandardOutput.BaseStream, sshStream, writeLock, cancellation);
             stderrTask = PumpToChannelAsync(
-                _process.StandardError.BaseStream, sshStream, writeLock, _cts.Token);
-            _ = sshStream.CopyToAsync(_process.StandardInput.BaseStream, _cts.Token);
+                _process.StandardError.BaseStream, sshStream, writeLock, cancellation);
+            _ = sshStream.CopyToAsync(_process.StandardInput.BaseStream, cancellation);
 
-            await _process.WaitForExitAsync(_cts.Token);
+            await _process.WaitForExitAsync(cancellation);
             await Task.WhenAll(stdoutTask, stderrTask);
-            await sshStream.Channel.CloseAsync(unchecked((uint)_process.ExitCode), _cts.Token);
+            await sshStream.Channel.CloseAsync(unchecked((uint)_process.ExitCode), cancellation);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            await sshStream.Channel.CloseAsync(EryphSignalTypes.Exception, ex.Message, _cts.Token);
+            await sshStream.Channel.CloseAsync(EryphSignalTypes.Exception, ex.Message, cancellation);
         }
         finally
         {
@@ -147,12 +151,19 @@ public sealed class CommandForwarder : IDisposable
 
     public void Dispose()
     {
-        // Cancel before disposing so the read/write pumps observe cancellation
-        // and stop, instead of lingering on an already-disposed token until the
-        // killed process happens to close the pipes (matches PtyForwarder).
+        // Runs on the channel.Closed event path, so it must not throw. Cancel
+        // first so the pumps observe cancellation and stop, instead of lingering
+        // until the killed process closes the pipes (matches PtyForwarder).
         try { _cts.Cancel(); } catch (ObjectDisposedException) { }
-        _cts.Dispose();
-        _process?.Kill(true);
+
+        // Kill throws InvalidOperationException if the process was never started
+        // (Dispose can race a teardown before RunAsync calls Start). Best-effort
+        // — ObjectDisposedException derives from InvalidOperationException, so
+        // this one catch covers both.
+        try { _process?.Kill(true); }
+        catch (InvalidOperationException) { }
+
         _process?.Dispose();
+        _cts.Dispose();
     }
 }

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/CommandForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/CommandForwarder.cs
@@ -29,14 +29,25 @@ public sealed class CommandForwarder : IDisposable
             // on the interactive channel), so resolve with no per-session
             // override: the KVP-configured shell wins, else the platform default.
             var selection = await _selector.SelectAsync(ShellOverride.Empty, cancellation);
+            // Only selection.Command is used: selection.Arguments carries the
+            // shell's *interactive* flags (e.g. `-i`, `-WindowStyle Hidden`),
+            // which are wrong for a non-interactive exec. The command-mode flag
+            // (`-c` / `-Command` / `/c`) is supplied by BuildStartInfo instead.
             _process = new Process { StartInfo = BuildStartInfo(selection.Command, _command) };
-            _ = RunAsync(stream);
+            ObserveFault(RunAsync(stream));
         }
         catch (Exception ex)
         {
             await stream.Channel.CloseAsync(EryphSignalTypes.Exception, ex.Message, cancellation);
         }
     }
+
+    // Keeps the fire-and-forget RunAsync from surfacing its fault as an
+    // unobserved task exception — e.g. the OperationCanceledException that
+    // WaitForExitAsync throws when Dispose cancels the token mid-run.
+    private static void ObserveFault(Task task) =>
+        _ = task.ContinueWith(static t => _ = t.Exception,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
 
     /// <summary>
     /// Builds the process start info that runs <paramref name="command"/>
@@ -120,6 +131,10 @@ public sealed class CommandForwarder : IDisposable
 
     public void Dispose()
     {
+        // Cancel before disposing so the read/write pumps observe cancellation
+        // and stop, instead of lingering on an already-disposed token until the
+        // killed process happens to close the pipes (matches PtyForwarder).
+        try { _cts.Cancel(); } catch (ObjectDisposedException) { }
         _cts.Dispose();
         _process?.Kill(true);
         _process?.Dispose();

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/CommandForwarder.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Forwarders/CommandForwarder.cs
@@ -80,20 +80,22 @@ public sealed class CommandForwarder : IDisposable
 
     private async Task RunAsync(SshStream sshStream)
     {
+        // This SSH library exposes only a single channel data stream — it has
+        // no SSH extended-data (stderr) support — so stdout and stderr are
+        // merged onto it. That mirrors `ssh host "cmd 2>&1"` and the interactive
+        // PTY path, where a terminal has no separate error stream. A shared lock
+        // serializes the two pumps so their writes can't interleave mid-chunk
+        // and corrupt the channel framing.
+        var writeLock = new SemaphoreSlim(1, 1);
+        Task? stdoutTask = null;
+        Task? stderrTask = null;
         try
         {
             _process!.Start();
 
-            // This SSH library exposes only a single channel data stream — it
-            // has no SSH extended-data (stderr) support — so stdout and stderr
-            // are merged onto it. That mirrors `ssh host "cmd 2>&1"` and the
-            // interactive PTY path, where a terminal has no separate error
-            // stream. A shared lock serializes the two pumps so their writes
-            // can't interleave mid-chunk and corrupt the channel framing.
-            var writeLock = new SemaphoreSlim(1, 1);
-            var stdoutTask = PumpToChannelAsync(
+            stdoutTask = PumpToChannelAsync(
                 _process.StandardOutput.BaseStream, sshStream, writeLock, _cts.Token);
-            var stderrTask = PumpToChannelAsync(
+            stderrTask = PumpToChannelAsync(
                 _process.StandardError.BaseStream, sshStream, writeLock, _cts.Token);
             _ = sshStream.CopyToAsync(_process.StandardInput.BaseStream, _cts.Token);
 
@@ -104,6 +106,20 @@ public sealed class CommandForwarder : IDisposable
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             await sshStream.Channel.CloseAsync(EryphSignalTypes.Exception, ex.Message, _cts.Token);
+        }
+        finally
+        {
+            // Dispose the per-run lock, but only once both pumps have stopped
+            // touching it. On the success path they completed above; on the
+            // error/cancel path cancel so they unwind rather than block, then
+            // wait out the teardown race before disposing.
+            if (stdoutTask is not null && stderrTask is not null
+                && !(stdoutTask.IsCompleted && stderrTask.IsCompleted))
+            {
+                try { _cts.Cancel(); } catch (ObjectDisposedException) { }
+                try { await Task.WhenAll(stdoutTask, stderrTask); } catch { /* teardown race */ }
+            }
+            writeLock.Dispose();
         }
     }
 

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/IShellSelector.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/IShellSelector.cs
@@ -1,7 +1,10 @@
 namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions;
 
 /// <summary>
-/// Resolves the command + arguments to spawn for an interactive SSH session.
+/// Resolves the command + arguments to spawn for an SSH session. The
+/// interactive shell path uses both the command and the arguments; the
+/// non-interactive <c>exec</c> path uses only the command (it supplies its own
+/// command-mode flag and ignores the interactive arguments).
 /// </summary>
 public interface IShellSelector
 {

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/NonInteractiveShell.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/NonInteractiveShell.cs
@@ -14,7 +14,7 @@ public static class NonInteractiveShell
     /// <c>cmd</c> uses <c>/c</c>, and every other (POSIX) shell defaults to
     /// <c>-c</c>.
     /// </summary>
-    public static string CommandFlagFor(string shellCommand)
+    public static string CommandFlagFor(string? shellCommand)
     {
         // Reduce "C:\Program Files\PowerShell\7\pwsh.exe" or "/bin/bash" to a
         // bare, extension-less, lower-case name. Split on both separators so a

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/NonInteractiveShell.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/NonInteractiveShell.cs
@@ -1,0 +1,35 @@
+namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions;
+
+/// <summary>
+/// Maps a shell executable to the flag that makes it run a single command
+/// string non-interactively. This is the SSH <c>exec</c> request equivalent of
+/// OpenSSH's <c>$SHELL -c "&lt;command&gt;"</c> contract: the shell — not our
+/// own tokenizer — parses pipes, quotes, redirection and globbing.
+/// </summary>
+public static class NonInteractiveShell
+{
+    /// <summary>
+    /// Returns the command-mode flag for <paramref name="shellCommand"/>,
+    /// inferred from its file name. PowerShell variants use <c>-Command</c>,
+    /// <c>cmd</c> uses <c>/c</c>, and every other (POSIX) shell defaults to
+    /// <c>-c</c>.
+    /// </summary>
+    public static string CommandFlagFor(string shellCommand)
+    {
+        // Reduce "C:\Program Files\PowerShell\7\pwsh.exe" or "/bin/bash" to a
+        // bare, extension-less, lower-case name. Split on both separators so a
+        // Windows-style path is handled even when running on Linux.
+        var trimmed = (shellCommand ?? string.Empty).Trim();
+        var lastSeparator = trimmed.LastIndexOfAny(['/', '\\']);
+        var fileName = lastSeparator >= 0 ? trimmed[(lastSeparator + 1)..] : trimmed;
+        var dot = fileName.LastIndexOf('.');
+        var name = (dot > 0 ? fileName[..dot] : fileName).ToLowerInvariant();
+
+        return name switch
+        {
+            "pwsh" or "powershell" => "-Command",
+            "cmd" => "/c",
+            _ => "-c",
+        };
+    }
+}

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Services/CommandService.cs
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Services/CommandService.cs
@@ -8,9 +8,19 @@ using Microsoft.DevTunnels.Ssh.Services;
 namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions.Services;
 
 [ServiceActivation(ChannelRequest = ChannelRequestTypes.Command)]
-public class CommandService(SshSession session) : SshService(session)
+public class CommandService : SshService
 {
+    private readonly IShellSelector? _shellSelector;
     private readonly ConcurrentDictionary<uint, CommandForwarder> _forwarders = new();
+
+    // Microsoft.DevTunnels.Ssh activation picks the 2-arg ctor when a config
+    // object (the shell selector) is present in SshSessionConfiguration.Services.
+    public CommandService(SshSession session) : this(session, null) { }
+
+    public CommandService(SshSession session, IShellSelector? shellSelector) : base(session)
+    {
+        _shellSelector = shellSelector;
+    }
 
     protected override Task OnChannelRequestAsync(
         SshChannel channel,
@@ -24,7 +34,7 @@ public class CommandService(SshSession session) : SshService(session)
         }
 
         var execRequest = request.Request.ConvertTo<CommandRequestMessage>();
-        var forwarder = new CommandForwarder(execRequest.Command ?? "");
+        var forwarder = new CommandForwarder(execRequest.Command ?? "", _shellSelector);
 
         if (!_forwarders.TryAdd(channel.ChannelId, forwarder))
         {

--- a/src/Eryph.GuestServices.Service/Services/SshServerService.cs
+++ b/src/Eryph.GuestServices.Service/Services/SshServerService.cs
@@ -53,9 +53,11 @@ internal sealed class SshServerService(
         var config = new SshSessionConfiguration(useSecurity: true);
 
         config.Services.Add(typeof(SubsystemService), null);
-        config.Services.Add(typeof(CommandService), null);
         // The shell selector is passed as the service activation config object.
-        // DevTunnels.Ssh activates the matching 2-arg ctor on ShellService.
+        // DevTunnels.Ssh activates the matching 2-arg ctor. Both the interactive
+        // ShellService and the exec CommandService run the client request through
+        // the selected shell, so they share the selector.
+        config.Services.Add(typeof(CommandService), shellSelector);
         config.Services.Add(typeof(ShellService), shellSelector);
         config.Services.Add(typeof(UploadFileService), null);
         config.Services.Add(typeof(DownloadFileService), null);

--- a/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/CommandForwarderTests.cs
+++ b/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/CommandForwarderTests.cs
@@ -1,0 +1,66 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.DevTunnels.Ssh.Extensions.Forwarders;
+
+namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests;
+
+/// <summary>
+/// Regression tests for the SSH <c>exec</c> path. The remote command must be
+/// run through the selected shell (OpenSSH's <c>$SHELL -c "&lt;command&gt;"</c>
+/// contract) and handed over as a single argument — the previous
+/// split-on-space exec'd the first token directly, so pipes, <c>&amp;&amp;</c>,
+/// quoting and any path containing a space were silently broken.
+/// </summary>
+public class CommandForwarderTests
+{
+    [Fact]
+    public void BuildStartInfo_RunsCommandThroughShell()
+    {
+        var startInfo = CommandForwarder.BuildStartInfo("/bin/bash", "echo hi");
+
+        startInfo.FileName.Should().Be("/bin/bash");
+        startInfo.ArgumentList.Should().Equal("-c", "echo hi");
+    }
+
+    [Fact]
+    public void BuildStartInfo_KeepsPipelineAsSingleArgument()
+    {
+        const string command = "ls -la | grep foo && echo \"done now\"";
+
+        var startInfo = CommandForwarder.BuildStartInfo("/bin/bash", command);
+
+        // The whole pipeline is one argument so bash parses it — not our code.
+        startInfo.ArgumentList.Should().Equal("-c", command);
+    }
+
+    [Fact]
+    public void BuildStartInfo_UsesPowerShellCommandFlag()
+    {
+        const string command = "Get-Process | Where-Object Name -eq foo";
+
+        var startInfo = CommandForwarder.BuildStartInfo("powershell.exe", command);
+
+        startInfo.FileName.Should().Be("powershell.exe");
+        startInfo.ArgumentList.Should().Equal("-Command", command);
+    }
+
+    [Fact]
+    public void BuildStartInfo_RedirectsStdInAndStdOutWithoutShellExecute()
+    {
+        var startInfo = CommandForwarder.BuildStartInfo("/bin/bash", "echo hi");
+
+        startInfo.UseShellExecute.Should().BeFalse();
+        startInfo.RedirectStandardInput.Should().BeTrue();
+        startInfo.RedirectStandardOutput.Should().BeTrue();
+        startInfo.CreateNoWindow.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildStartInfo_RedirectsStdErr_SoErrorsReachTheClient()
+    {
+        // Regression: stderr was previously left attached to the service
+        // process, so command errors never reached the SSH client.
+        var startInfo = CommandForwarder.BuildStartInfo("/bin/bash", "echo hi");
+
+        startInfo.RedirectStandardError.Should().BeTrue();
+    }
+}

--- a/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/CommandForwarderTests.cs
+++ b/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/CommandForwarderTests.cs
@@ -44,6 +44,17 @@ public class CommandForwarderTests
     }
 
     [Fact]
+    public void BuildStartInfo_UsesCmdCommandFlag()
+    {
+        const string command = "dir & echo done";
+
+        var startInfo = CommandForwarder.BuildStartInfo("cmd.exe", command);
+
+        startInfo.FileName.Should().Be("cmd.exe");
+        startInfo.ArgumentList.Should().Equal("/c", command);
+    }
+
+    [Fact]
     public void BuildStartInfo_RedirectsStdInAndStdOutWithoutShellExecute()
     {
         var startInfo = CommandForwarder.BuildStartInfo("/bin/bash", "echo hi");

--- a/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/NonInteractiveShellTests.cs
+++ b/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/NonInteractiveShellTests.cs
@@ -53,6 +53,6 @@ public class NonInteractiveShellTests
         // A blank shell never produces a runnable process — BuildStartInfo would
         // fail at start — but the flag inference must not throw; it returns the
         // POSIX default.
-        NonInteractiveShell.CommandFlagFor(shellCommand!).Should().Be("-c");
+        NonInteractiveShell.CommandFlagFor(shellCommand).Should().Be("-c");
     }
 }

--- a/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/NonInteractiveShellTests.cs
+++ b/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/NonInteractiveShellTests.cs
@@ -43,4 +43,16 @@ public class NonInteractiveShellTests
     {
         NonInteractiveShell.CommandFlagFor(shellCommand).Should().Be(expectedFlag);
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CommandFlagFor_WithBlankInput_FallsBackToPosixFlag(string? shellCommand)
+    {
+        // A blank shell never produces a runnable process — BuildStartInfo would
+        // fail at start — but the flag inference must not throw; it returns the
+        // POSIX default.
+        NonInteractiveShell.CommandFlagFor(shellCommand!).Should().Be("-c");
+    }
 }

--- a/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/NonInteractiveShellTests.cs
+++ b/test/Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests/NonInteractiveShellTests.cs
@@ -1,0 +1,46 @@
+using AwesomeAssertions;
+
+namespace Eryph.GuestServices.DevTunnels.Ssh.Extensions.Tests;
+
+public class NonInteractiveShellTests
+{
+    [Theory]
+    // POSIX shells — bare names and absolute paths both use -c.
+    [InlineData("bash", "-c")]
+    [InlineData("/bin/bash", "-c")]
+    [InlineData("/usr/bin/sh", "-c")]
+    [InlineData("zsh", "-c")]
+    [InlineData("/usr/bin/fish", "-c")]
+    // PowerShell variants use -Command.
+    [InlineData("pwsh", "-Command")]
+    [InlineData("pwsh.exe", "-Command")]
+    [InlineData("powershell.exe", "-Command")]
+    [InlineData(@"C:\Program Files\PowerShell\7\pwsh.exe", "-Command")]
+    // cmd uses /c.
+    [InlineData("cmd", "/c")]
+    [InlineData("cmd.exe", "/c")]
+    [InlineData(@"C:\Windows\System32\cmd.exe", "/c")]
+    // Unknown shells fall back to the POSIX -c form.
+    [InlineData("some-custom-shell", "-c")]
+    public void CommandFlagFor_MapsShellToFlag(string shellCommand, string expectedFlag)
+    {
+        NonInteractiveShell.CommandFlagFor(shellCommand).Should().Be(expectedFlag);
+    }
+
+    [Theory]
+    [InlineData("POWERSHELL.EXE", "-Command")]
+    [InlineData("PowerShell.Exe", "-Command")]
+    [InlineData("CMD.EXE", "/c")]
+    public void CommandFlagFor_IsCaseInsensitive(string shellCommand, string expectedFlag)
+    {
+        NonInteractiveShell.CommandFlagFor(shellCommand).Should().Be(expectedFlag);
+    }
+
+    [Theory]
+    [InlineData("  pwsh.exe  ", "-Command")]
+    [InlineData("  /bin/bash  ", "-c")]
+    public void CommandFlagFor_TrimsSurroundingWhitespace(string shellCommand, string expectedFlag)
+    {
+        NonInteractiveShell.CommandFlagFor(shellCommand).Should().Be(expectedFlag);
+    }
+}

--- a/test/e2e/Helpers.ps1
+++ b/test/e2e/Helpers.ps1
@@ -809,6 +809,52 @@ function Invoke-EgsShellProbe {
   return $raw -replace "`e\[[0-?]*[ -/]*[@-~]", '' -replace "`e\][^`a]*`a", ''
 }
 
+function Invoke-EgsSshCommand {
+  <#
+  .SYNOPSIS
+    Runs a single non-interactive command on the catlet via the SSH `exec`
+    request (`ssh host "<command>"`) and returns its exit code and captured
+    output.
+
+  .DESCRIPTION
+    Unlike the interactive shell channel, exec output is plain channel data
+    that Win32-OpenSSH writes to ssh.exe's stdout, so it can be captured
+    normally — no probe needed. This exercises the server-side
+    CommandService -> CommandForwarder -> IShellSelector path: the command is
+    run through the selected shell, and stdout + stderr are merged back onto
+    the channel. stderr is captured here too (2>&1) so error-stream coverage
+    works.
+
+    Pinned to Windows OpenSSH (see $script:WinSshExe) and relies on the
+    *.hyper-v.alt Host block written by `egs-tool add-ssh-config` for the
+    ProxyCommand, so it must run after Connect-Catlet.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] [Guid] $VmId,
+    [Parameter(Mandatory = $true)] [string] $Command,
+    [Parameter()] [int] $ConnectTimeout = 15
+  )
+
+  $hostName = "$VmId.hyper-v.alt"
+  $savedPref = $PSNativeCommandUseErrorActionPreference
+  $PSNativeCommandUseErrorActionPreference = $false
+  try {
+    $out = & $script:WinSshExe `
+      -o "StrictHostKeyChecking=no" `
+      -o "BatchMode=yes" `
+      -o "ConnectTimeout=$ConnectTimeout" `
+      $hostName $Command 2>&1
+    [pscustomobject]@{
+      ExitCode = $LASTEXITCODE
+      Output   = ($out | Out-String).Trim()
+    }
+  }
+  finally {
+    $PSNativeCommandUseErrorActionPreference = $savedPref
+  }
+}
+
 function Save-GuestDiagnostics {
   <#
     .SYNOPSIS

--- a/test/e2e/Run-ShellLinuxE2ETests.ps1
+++ b/test/e2e/Run-ShellLinuxE2ETests.ps1
@@ -1,0 +1,68 @@
+#Requires -Version 7.4
+<#
+.SYNOPSIS
+  Runs the exec / configurable-shell e2e tests against a fresh eryph Ubuntu
+  catlet.
+
+.DESCRIPTION
+  Publishes egs-service linux-x64 and egs-tool win-x64 (the tool always runs
+  on the host), spins up an Ubuntu catlet, swaps the gene-installed
+  egs-service with the local build over direct sshd, restarts the service,
+  then runs the Pester suite. Catlet + project are torn down in AfterAll
+  unless $env:EGS_E2E_KEEP_VM is set.
+
+  Requires:
+    - Elevated PowerShell 7.4+ (egs-tool admin paths)
+    - eryph host with `egs-tool initialize` already run
+    - Pester 5.x, Eryph.ComputeClient
+    - The dbosoft/$OSVersion/starter parent gene + the
+      dbosoft/starter-food/2.0:linux-starter fodder gene cached locally
+#>
+param (
+    [Parameter()]
+    [string] $OSVersion = 'ubuntu-24.04',
+
+    [Parameter()]
+    [switch] $SkipBuild
+)
+
+$PSNativeCommandUseErrorActionPreference = $true
+$ErrorActionPreference = 'Stop'
+
+Write-Host "Installing required PowerShell modules ..."
+Install-Module -Name Pester -MinimumVersion 5.5 -Force -Scope CurrentUser -SkipPublisherCheck
+Install-Module -Name Eryph.ComputeClient -Force -Scope CurrentUser
+
+if (-not $SkipBuild) {
+  Write-Host "Publishing egs-service for linux-x64 ..."
+  dotnet publish "$PSScriptRoot/../../src/Eryph.GuestServices.Service/Eryph.GuestServices.Service.csproj" `
+    -c Release -r linux-x64 --nologo
+
+  Write-Host "Publishing egs-tool for win-x64 ..."
+  dotnet publish "$PSScriptRoot/../../src/Eryph.GuestServices.Tool/Eryph.GuestServices.Tool.csproj" `
+    -c Release -r win-x64 --nologo
+}
+
+$publishPath = Resolve-Path "$PSScriptRoot/../../src/Eryph.GuestServices.Service/bin/Release/net10.0/linux-x64/publish"
+$toolPublishPath = Resolve-Path "$PSScriptRoot/../../src/Eryph.GuestServices.Tool/bin/Release/net10.0-windows/win-x64/publish"
+
+$env:Path = "$($toolPublishPath.Path);$env:Path"
+Write-Host "Using egs-tool from: $toolPublishPath"
+Write-Host "egs-tool version: $(egs-tool --version)"
+
+Write-Host "Running Pester suite ..."
+$container = New-PesterContainer -Path "$PSScriptRoot/Shell.Linux.E2E.Tests.ps1" `
+  -Data @{
+    OSVersion = $OSVersion
+    PublishPath = $publishPath.Path
+  }
+
+$config = New-PesterConfiguration
+$config.Output.Verbosity = 'Detailed'
+$config.Run.Container = $container
+$config.Run.Exit = $true
+$config.TestResult.Enabled = $true
+$config.TestResult.OutputFormat = 'NUnit3'
+$config.TestResult.OutputPath = "$PSScriptRoot/TEST-shell-linux-pesterResults.xml"
+
+Invoke-Pester -Configuration $config

--- a/test/e2e/Shell.E2E.Tests.ps1
+++ b/test/e2e/Shell.E2E.Tests.ps1
@@ -157,4 +157,64 @@ Describe 'Configurable shell' {
       $output | Should -Not -Match 'PowerShell 7\.'
     }
   }
+
+  # The SSH `exec` request (`ssh host "<command>"`) runs the command through
+  # the selected shell, just like the interactive path — not as a bare,
+  # split-on-space executable. These assert the OpenSSH `$SHELL -c "..."`
+  # contract: shell operators are honored, the configured shell is used, the
+  # remote exit code propagates, and stderr comes back to the client.
+  Context 'exec (remote command)' {
+
+    It 'runs a command through the default shell' {
+      $result = Invoke-EgsSshCommand -VmId $catlet.VmId -Command 'Write-Output egs-exec-ok'
+
+      $result.ExitCode | Should -Be 0
+      $result.Output | Should -Match 'egs-exec-ok'
+    }
+
+    It 'evaluates a pipeline (shell parsing, not a split-on-space exec)' {
+      # A pipe only works if a shell interprets the command. The pre-fix exec
+      # path tried to launch an executable literally named "Write-Output".
+      $result = Invoke-EgsSshCommand -VmId $catlet.VmId `
+        -Command 'Write-Output hello | ForEach-Object { $_.ToUpper() }'
+
+      $result.ExitCode | Should -Be 0
+      $result.Output | Should -Match 'HELLO'
+    }
+
+    It 'uses the default shell (Windows PowerShell) when no override is set' {
+      $result = Invoke-EgsSshCommand -VmId $catlet.VmId `
+        -Command 'Write-Output $PSVersionTable.PSEdition'
+
+      $result.ExitCode | Should -Be 0
+      $result.Output | Should -Match 'Desktop'
+    }
+
+    It 'honors the KVP shell override for exec' {
+      egs-tool set-shell $catlet.VmId --command 'pwsh.exe' | Out-Null
+
+      $result = Invoke-EgsSshCommand -VmId $catlet.VmId `
+        -Command 'Write-Output $PSVersionTable.PSEdition'
+
+      $result.ExitCode | Should -Be 0
+      $result.Output | Should -Match 'Core'
+    }
+
+    It 'propagates the remote exit code' {
+      $result = Invoke-EgsSshCommand -VmId $catlet.VmId -Command 'exit 7'
+
+      $result.ExitCode | Should -Be 7
+    }
+
+    It 'returns stderr to the client' {
+      # stderr is merged onto the channel (the library has no extended-data
+      # support). Both markers must come back; pre-fix the stderr one was lost.
+      $result = Invoke-EgsSshCommand -VmId $catlet.VmId `
+        -Command "[Console]::Error.WriteLine('egs-stderr-marker'); [Console]::Out.WriteLine('egs-stdout-marker')"
+
+      $result.ExitCode | Should -Be 0
+      $result.Output | Should -Match 'egs-stdout-marker'
+      $result.Output | Should -Match 'egs-stderr-marker'
+    }
+  }
 }

--- a/test/e2e/Shell.Linux.E2E.Tests.ps1
+++ b/test/e2e/Shell.Linux.E2E.Tests.ps1
@@ -1,0 +1,193 @@
+#Requires -Version 7.4
+#Requires -RunAsAdministrator
+#Requires -Module Pester
+#Requires -Module Eryph.ComputeClient
+<#
+.SYNOPSIS
+  E2E for the SSH `exec` (remote command) path and configurable shell on
+  LINUX catlets.
+
+.NOTES
+  Linux counterpart of the exec coverage in Shell.E2E.Tests.ps1 (Windows).
+  Exercises the same server-side path — CommandService -> CommandForwarder
+  -> IShellSelector — on linux-x64: the remote command runs through the
+  selected shell (`<shell> -c "<command>"`), the KVP shell override is
+  honored, the remote exit code propagates, and stderr is merged back onto
+  the channel.
+
+  Deploy model mirrors RemoteAccess.Linux.E2E.Tests.ps1: no offline VHD
+  mount. The catlet boots with the parent gene's (older) egs-service;
+  BeforeAll swaps in the local build over the direct-sshd admin channel,
+  writes id_egs.pub, and restarts the unit.
+#>
+param (
+    [Parameter()]
+    [string] $OSVersion = 'ubuntu-24.04',
+
+    [Parameter()]
+    [string] $PublishPath
+)
+
+BeforeAll {
+  $PSNativeCommandUseErrorActionPreference = $true
+  $ErrorActionPreference = 'Stop'
+  . $PSScriptRoot/Helpers.ps1
+
+  if (-not $PublishPath) {
+    $PublishPath = "$PSScriptRoot/../../src/Eryph.GuestServices.Service/bin/Release/net10.0/linux-x64/publish"
+  }
+  $resolvedPublishPath = (Resolve-Path -LiteralPath $PublishPath).Path
+
+  # Channels (cf. RemoteAccess.Linux.E2E.Tests.ps1):
+  #   1. egs-service over vsock (egs-tool proxy) — the system under test.
+  #   2. Direct sshd as $adminUsername — admin channel for the binary swap,
+  #      independent of eryph-guest-services lifecycle.
+  $hostEgsPublicKey = (egs-tool get-ssh-key).Trim()
+  if (-not $hostEgsPublicKey) {
+    throw "egs-tool get-ssh-key returned empty — run 'egs-tool initialize' first."
+  }
+  $adminUsername = 'e2euser'
+  $adminPassword = New-ThrowawayPassword
+
+  $catletConfigTemplate = Get-Content -Raw -Path $PSScriptRoot/remote-access-linux-catlet.yaml
+  $catletConfig = $catletConfigTemplate `
+    -replace '<<PARENT>>', "dbosoft/$OSVersion/starter"
+
+  $project = New-TestProject
+  $catletName = New-CatletName
+  Write-Host "Creating catlet $catletName in project $($project.Name) ..."
+  $catlet = New-Catlet -Config $catletConfig -Name $catletName `
+    -ProjectName $project.Name `
+    -Variables @{
+      adminUsername = $adminUsername
+      adminPassword = $adminPassword
+      sshPublicKey = $hostEgsPublicKey
+    } `
+    -SkipVariablesPrompt
+
+  Write-Host "Starting catlet $($catlet.Name) ..."
+  Start-Catlet -Id $catlet.Id -Force
+
+  Write-Host "Waiting for direct sshd as '$adminUsername' ..."
+  Wait-LinuxCatletSshReady -Catlet $catlet -Username $adminUsername `
+    -Timeout (New-TimeSpan -Minutes 10)
+
+  Write-Host "Replacing egs-service binaries online (publish=$resolvedPublishPath) ..."
+  Update-EgsServiceLinuxOnline -Catlet $catlet -Username $adminUsername `
+    -PublishPath $resolvedPublishPath
+
+  Write-Host "Writing host's egs-tool public key into /etc/opt/eryph/guest-services/id_egs.pub ..."
+  Write-LinuxEgsClientKey -Catlet $catlet -Username $adminUsername `
+    -PublicKey $hostEgsPublicKey
+
+  Invoke-CatletAdminSshLinux -Catlet $catlet -Username $adminUsername `
+    -Command 'sudo systemctl restart eryph-guest-services' 2>&1 | Out-Null
+
+  Write-Host "Waiting for egs-service SSH listener (get-status=available) ..."
+  $savedPref = $PSNativeCommandUseErrorActionPreference
+  $PSNativeCommandUseErrorActionPreference = $false
+  try {
+    Wait-Assert -Timeout (New-TimeSpan -Minutes 5) -Interval (New-TimeSpan -Seconds 3) {
+      $status = egs-tool get-status $catlet.VmId
+      if ($status -ne 'available') { throw "guest services not available: $status" }
+    }
+    Write-Host "egs-service is available."
+  }
+  finally {
+    $PSNativeCommandUseErrorActionPreference = $savedPref
+  }
+
+  # The exec tests connect over the egs proxy via the *.hyper-v.alt Host
+  # block (User egs + IdentityFile + ProxyCommand) that add-ssh-config
+  # writes — same alias the Windows Shell suite uses.
+  egs-tool add-ssh-config $catlet.VmId | Out-Null
+}
+
+AfterAll {
+  # Set $env:EGS_E2E_KEEP_VM=1 to keep the catlet for post-mortem inspection.
+  if ($env:EGS_E2E_KEEP_VM) {
+    Write-Host "EGS_E2E_KEEP_VM is set — leaving catlet $($catlet.Name) (project $($project.Name)) for inspection."
+    return
+  }
+  if ($catlet) {
+    Remove-Catlet -Id $catlet.Id -Force -ErrorAction SilentlyContinue
+  }
+  if ($project) {
+    Remove-EryphProject -Id $project.Id -Force -ErrorAction SilentlyContinue
+  }
+}
+
+Describe 'Configurable shell and exec (Linux)' {
+
+  AfterEach {
+    # Make sure no shell override leaks across tests.
+    egs-tool set-shell $catlet.VmId --reset | Out-Null
+  }
+
+  # The SSH `exec` request (`ssh host "<command>"`) runs the command through
+  # the selected shell — the OpenSSH `$SHELL -c "..."` contract — not as a
+  # bare, split-on-space executable.
+  Context 'exec (remote command)' {
+
+    It 'runs a command through the default shell' {
+      $result = Invoke-EgsSshCommand -VmId $catlet.VmId -Command 'echo egs-exec-ok'
+
+      $result.ExitCode | Should -Be 0
+      $result.Output | Should -Match 'egs-exec-ok'
+    }
+
+    It 'evaluates a pipeline (shell parsing, not a split-on-space exec)' {
+      # A pipe only works if a shell interprets the command. The pre-fix exec
+      # path tried to launch an executable literally named "echo".
+      $result = Invoke-EgsSshCommand -VmId $catlet.VmId `
+        -Command 'echo hello | tr a-z A-Z'
+
+      $result.ExitCode | Should -Be 0
+      $result.Output | Should -Match 'HELLO'
+    }
+
+    It 'propagates the remote exit code' {
+      $result = Invoke-EgsSshCommand -VmId $catlet.VmId -Command 'exit 7'
+
+      $result.ExitCode | Should -Be 7
+    }
+
+    It 'returns stderr to the client' {
+      # stderr is merged onto the channel (the library has no extended-data
+      # support). Both markers must come back; pre-fix the stderr one was lost.
+      $result = Invoke-EgsSshCommand -VmId $catlet.VmId `
+        -Command 'echo egs-stderr-marker 1>&2; echo egs-stdout-marker'
+
+      $result.ExitCode | Should -Be 0
+      $result.Output | Should -Match 'egs-stdout-marker'
+      $result.Output | Should -Match 'egs-stderr-marker'
+    }
+  }
+
+  # The exec path resolves its shell through the same KVP override as the
+  # interactive path. Switching the override changes which shell runs the
+  # command — proven here by toggling a bash-only variable.
+  Context 'configurable shell for exec' {
+
+    It 'runs exec through bash when set as the override' {
+      egs-tool set-shell $catlet.VmId --command '/bin/bash' | Out-Null
+
+      $result = Invoke-EgsSshCommand -VmId $catlet.VmId -Command 'echo $BASH_VERSION'
+
+      $result.ExitCode | Should -Be 0
+      # bash exports BASH_VERSION (e.g. "5.2.21(1)-release").
+      $result.Output | Should -Match '\d+\.\d+'
+    }
+
+    It 'runs exec through /bin/sh when set as the override' {
+      egs-tool set-shell $catlet.VmId --command '/bin/sh' | Out-Null
+
+      $result = Invoke-EgsSshCommand -VmId $catlet.VmId -Command 'echo $BASH_VERSION'
+
+      $result.ExitCode | Should -Be 0
+      # /bin/sh (dash on Ubuntu) has no BASH_VERSION — proves the override is
+      # actually used for exec, not just the ambient default.
+      $result.Output | Should -BeNullOrEmpty
+    }
+  }
+}


### PR DESCRIPTION
The SSH `exec` request (`ssh host "<command>"`) ran the command's first whitespace token as a literal executable, so pipes, `&&`, redirection, globbing and quoted/space-containing arguments were all broken — nothing like OpenSSH's `$SHELL -c "<command>"`. Errors were also lost: the child's stderr went to the service process, never to the client.

Exec now resolves the shell via the same `IShellSelector` the interactive path uses (KVP `set-shell` override → platform default) and runs `<shell> <flag> <command>`, with the command passed as a single argument so the shell parses it. The flag is inferred from the shell name (`-c` / `-Command` / `/c`). stderr is captured and merged onto the channel (this DevTunnels build exposes no SSH extended-data stream), matching `ssh host "cmd 2>&1"` and the PTY path.

Verified on both platforms:
- 23 unit tests (flag inference, single-arg shell wrapping, stderr redirect).
- Windows e2e (winsrv2022) and Linux e2e (ubuntu-24.04): command-through-shell, pipeline, configurable shell drives exec, exit-code propagation, and stderr round-trip.