### PR TITLE
Rename the 'eryph' subcommand group to 'catlet'

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ Start-Catlet -Name my-vm
 
 ### Remote SSH access
 
-Reach a catlet's guest SSH **from any machine** — the `egs-tool eryph` commands tunnel the same guest SSH server through eryph's authorized compute API (the bytes are relayed host-side over the Hyper-V socket; SSH runs end-to-end). No Hyper-V host access and **no administrator rights** are needed: the commands run as the operator and authenticate with the operator's eryph identity. The eryph client must hold the `compute:catlets:remote-access` scope.
+Reach a catlet's guest SSH **from any machine** — the `egs-tool catlet` commands tunnel the same guest SSH server through eryph's authorized compute API (the bytes are relayed host-side over the Hyper-V socket; SSH runs end-to-end). No Hyper-V host access and **no administrator rights** are needed: the commands run as the operator and authenticate with the operator's eryph identity. The eryph client must hold the `compute:catlets:remote-access` scope.
 
 ```powershell
 # Write an SSH alias for a catlet that tunnels through eryph
-egs-tool eryph add-ssh-config <catlet-id>
+egs-tool catlet add-ssh-config <catlet-id>
 
 # Connect (the alias's ProxyCommand bridges through eryph)
 ssh <catlet>.<project>.eryph.alt
@@ -87,12 +87,12 @@ ssh <catlet-id>.eryph.alt       # canonical, always unique
 **Keys.** By default the alias uses a **per-user managed key**, created on demand and stored in your own profile with a user-only ACL (so Windows OpenSSH will load it). Bring your own key with `--identity`:
 
 ```powershell
-egs-tool eryph add-ssh-config <catlet-id> --identity C:\Users\me\.ssh\id_ed25519
+egs-tool catlet add-ssh-config <catlet-id> --identity C:\Users\me\.ssh\id_ed25519
 ```
 
 The public key still has to be authorized in the guest — pre-inject it at build time, or push it at runtime.
 
-**Build time** — set the `sshPublicKey` variable of the [`dbosoft/guest-services`](https://genepool.eryph.io/b/dbosoft/guest-services) install gene in the catlet spec. Use the output of `egs-tool eryph get-client-key`:
+**Build time** — set the `sshPublicKey` variable of the [`dbosoft/guest-services`](https://genepool.eryph.io/b/dbosoft/guest-services) install gene in the catlet spec. Use the output of `egs-tool catlet get-client-key`:
 
 ```yaml
 name: my-vm
@@ -101,18 +101,18 @@ fodder:
   - source: gene:dbosoft/guest-services:win-install   # use linux-install on Linux
     variables:
       - name: sshPublicKey
-        value: 'ecdsa-sha2-nistp256 AAAA... egs'        # from: egs-tool eryph get-client-key
+        value: 'ecdsa-sha2-nistp256 AAAA... egs'        # from: egs-tool catlet get-client-key
 ```
 
 **Runtime** — authorize a key on a running catlet:
 
 ```powershell
 # Authorize the alias's key in the guest immediately
-egs-tool eryph add-ssh-config <catlet-id> --add-key
+egs-tool catlet add-ssh-config <catlet-id> --add-key
 
 # Or manage authorized keys directly (optionally with an expiry)
-egs-tool eryph add-key    <catlet-id> [--public-key <path|->] [--ttl 8h]
-egs-tool eryph remove-key <catlet-id>
+egs-tool catlet add-key    <catlet-id> [--public-key <path|->] [--ttl 8h]
+egs-tool catlet remove-key <catlet-id>
 ```
 
 Select a specific eryph client / configuration with `--client-id <id>` and `--configuration <name>`; otherwise the default eryph connection is used.
@@ -227,7 +227,7 @@ What's **not** supported (yet): jinja2 templating, part-handler, boothook execut
 
 ## Requirements
 
-**Host**: Windows 10/11 Pro/Enterprise/Education or Windows Server 2016+, Hyper-V enabled, administrator privileges. (The `egs-tool eryph` subcommands instead run on any machine with an eryph connection, without admin.)
+**Host**: Windows 10/11 Pro/Enterprise/Education or Windows Server 2016+, Hyper-V enabled, administrator privileges. (The `egs-tool catlet` subcommands instead run on any machine with an eryph connection, without admin.)
 
 **Guest**: Windows Server 2016+ / Windows 10+ or a modern Linux distribution with systemd. Hyper-V integration services enabled.
 
@@ -244,7 +244,7 @@ The guest SSH server uses public-key authentication only — passwords are disab
   egs-tool initialize    # regenerate keys if needed
   ```
 
-- **eryph remote flow** — the operator's key is authorized through the compute API. The default is a per-user managed key (user-only ACL, created on demand); `egs-tool eryph get-client-key` prints its public key for fodder pre-injection, and `--identity` selects your own key. See [Remote SSH access](#remote-ssh-access).
+- **eryph remote flow** — the operator's key is authorized through the compute API. The default is a per-user managed key (user-only ACL, created on demand); `egs-tool catlet get-client-key` prints its public key for fodder pre-injection, and `--identity` selects your own key. See [Remote SSH access](#remote-ssh-access).
 
 ---
 
@@ -266,16 +266,16 @@ The guest SSH server uses public-key authentication only — passwords are disab
 
 Flags: `--overwrite`, `--recursive` (directory commands), `--reset` (`set-shell`).
 
-### `egs-tool eryph` (remote access over eryph)
+### `egs-tool catlet` (remote access over eryph)
 
 Run on any machine with an eryph connection — not just the Hyper-V host — and authenticate with the operator's eryph identity (no admin rights).
 
 | Command | What |
 |---|---|
-| `eryph add-ssh-config <catlet-id> [--identity <key>] [--add-key]` | Write an SSH alias that tunnels through eryph |
-| `eryph add-key <catlet-id> [--public-key <path\|->] [--ttl <dur>]` | Authorize a public key in the guest (optionally expiring) |
-| `eryph remove-key <catlet-id>` | Revoke the caller's authorized key |
-| `eryph get-client-key` | Print the per-user managed public key (for fodder pre-injection) |
+| `catlet add-ssh-config <catlet-id> [--identity <key>] [--add-key]` | Write an SSH alias that tunnels through eryph |
+| `catlet add-key <catlet-id> [--public-key <path\|->] [--ttl <dur>]` | Authorize a public key in the guest (optionally expiring) |
+| `catlet remove-key <catlet-id>` | Revoke the caller's authorized key |
+| `catlet get-client-key` | Print the per-user managed public key (for fodder pre-injection) |
 
 Common flags: `--client-id <id>`, `--configuration <name>` to select the eryph connection. Requires the `compute:catlets:remote-access` scope.
 
@@ -305,7 +305,7 @@ Get-VM | Select-Object Name, Id
 Get-Catlet | Select-Object Name, Id, VmId
 ```
 
-The `egs-tool eryph` commands take a **catlet id**; the Hyper-V socket commands take a **VM id**.
+The `egs-tool catlet` commands take a **catlet id**; the Hyper-V socket commands take a **VM id**.
 
 ---
 
@@ -313,7 +313,7 @@ The `egs-tool eryph` commands take a **catlet id**; the Hyper-V socket commands 
 
 - **`get-status` returns `unknown`** — agent not running or Hyper-V integration services disabled in the VM.
 - **SSH `Connection refused` / banner timeout** — the agent crashed; check `Get-EventLog -LogName Application -Source egs-service` in the VM.
-- **`egs-tool eryph` cannot connect** — confirm an eryph connection is configured (or eryph-zero is running) and the client has the `compute:catlets:remote-access` scope; select a specific one with `--configuration` / `--client-id`.
+- **`egs-tool catlet` cannot connect** — confirm an eryph connection is configured (or eryph-zero is running) and the client has the `compute:catlets:remote-access` scope; select a specific one with `--configuration` / `--client-id`.
 - **Provisioning reports `failed`** — read `eryph.provisioning.error` via `egs-tool get-data --json <VM-ID>`; the agent also writes `%ProgramData%\eryph\provisioning\state.json` and per-script logs under `%ProgramData%\eryph\provisioning\logs\`.
 - **Re-running provisioning** — `egs-service reset` (then reboot the VM, or use `egs-service run` for a one-shot synchronous run). See [docs/user/howto/reset-and-rerun.md](docs/user/howto/reset-and-rerun.md).
 

--- a/docs/rfcs/0030-eryph-remote-channel.md
+++ b/docs/rfcs/0030-eryph-remote-channel.md
@@ -23,7 +23,7 @@ We want a remote operator to reach a catlet's egs SSH service through
 eryph's **authenticated fabric** — eryph authorizes the channel, the
 host agent opens the hvsocket, and SSH runs end-to-end so eryph never
 sees plaintext. This RFC covers the **guest-services side**: the
-`egs-tool eryph` command group, the guest-side key/expiry changes, and
+`egs-tool catlet` command group, the guest-side key/expiry changes, and
 the libraries eryph consumes. The eryph-side design (compute API
 endpoint, operation/saga, agent web host, reverse-proxy) lives in the
 eryph repo at `docs/internal/egs-remote-channel.md`; this RFC pins the
@@ -34,7 +34,7 @@ contract both sides share.
 ```
 egs-tool (operator machine)                 eryph                         host agent            guest
   ssh <catlet>.eryph.alt                  ComputeApi                   (HyperV module)        egs-service
-  └ ProxyCommand: egs-tool eryph proxy <catletId>
+  └ ProxyCommand: egs-tool catlet proxy <catletId>
         │ user creds (existing eryph connection)
         ├──WS (bearer; compute:catlets:remote-access)──►│
         │                                               │ start OpenSshChannel operation
@@ -53,7 +53,7 @@ service id (`0000138a-facb-11e6-bd58-64006a7986d3`, vsock port 5002).
 Any other guest port is the operator's problem to forward **over** this
 SSH session (`ssh -L`), never a second eryph channel.
 
-## `egs-tool eryph` command group
+## `egs-tool catlet` command group
 
 Rebuilt on the same client stack the removed integration used
 (`Eryph.ClientRuntime.Configuration`, `Eryph.IdentityModel.Clients`,
@@ -70,11 +70,11 @@ Rebuilt on the same client stack the removed integration used
 
 | Command | Purpose |
 |---|---|
-| `egs-tool eryph add-ssh-config <catletId> [--identity <path>] [--add-key]` | Write a single `<catlet>.<project>.eryph.alt` alias whose `ProxyCommand` is `egs-tool eryph proxy <catletId>`. `--identity` selects the private key (BYOK); omitted ⇒ managed key. `--add-key` also runs the key push (flow 2). |
-| `egs-tool eryph proxy <catletId>` | Data plane. Authenticate via the user connection, open the WS to the compute API, bridge stdin/stdout. Invoked by SSH `ProxyCommand`; protocol-agnostic. |
-| `egs-tool eryph get-client-key` | Print the managed client **public** key (for pasting into a catlet spec / fodder to pre-inject — flow 1). |
-| `egs-tool eryph add-key <catletId> [--public-key <path\|->] [--ttl <duration>]` | Push a public key to the catlet's guest via eryph (flow 2). Omitted `--public-key` ⇒ managed key. |
-| `egs-tool eryph remove-key <catletId>` | Revoke: eryph clears this operator's KVP slot in the guest. |
+| `egs-tool catlet add-ssh-config <catletId> [--identity <path>] [--add-key]` | Write a single `<catlet>.<project>.eryph.alt` alias whose `ProxyCommand` is `egs-tool catlet proxy <catletId>`. `--identity` selects the private key (BYOK); omitted ⇒ managed key. `--add-key` also runs the key push (flow 2). |
+| `egs-tool catlet proxy <catletId>` | Data plane. Authenticate via the user connection, open the WS to the compute API, bridge stdin/stdout. Invoked by SSH `ProxyCommand`; protocol-agnostic. |
+| `egs-tool catlet get-client-key` | Print the managed client **public** key (for pasting into a catlet spec / fodder to pre-inject — flow 1). |
+| `egs-tool catlet add-key <catletId> [--public-key <path\|->] [--ttl <duration>]` | Push a public key to the catlet's guest via eryph (flow 2). Omitted `--public-key` ⇒ managed key. |
+| `egs-tool catlet remove-key <catletId>` | Revoke: eryph clears this operator's KVP slot in the guest. |
 
 `add-ssh-config <vmId>` and `<vmId>.hyper-v.alt` (VM-level, local
 hvsocket) are unchanged and coexist exactly as the

--- a/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphAddKeyCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphAddKeyCommand.cs
@@ -5,7 +5,7 @@ using Spectre.Console.Cli;
 
 namespace Eryph.GuestServices.Tool.Commands.Eryph;
 
-// egs-tool eryph add-key <catletId> [--public-key <path|->] [--ttl <duration>]
+// egs-tool catlet add-key <catletId> [--public-key <path|->] [--ttl <duration>]
 //
 // Pushes a public key to the catlet's guest via eryph (the runtime flow). The
 // key is read from --public-key (a path, or "-" for stdin) or the managed key

--- a/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphAddSshConfigCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphAddSshConfigCommand.cs
@@ -5,7 +5,7 @@ using Spectre.Console.Cli;
 
 namespace Eryph.GuestServices.Tool.Commands.Eryph;
 
-// egs-tool eryph add-ssh-config <catletId> [--identity <path>] [--add-key]
+// egs-tool catlet add-ssh-config <catletId> [--identity <path>] [--add-key]
 //
 // Resolves a single catlet via the compute client and writes one
 // "<catlet>.<project>.eryph.alt" SSH alias whose ProxyCommand bridges through

--- a/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphGetClientKeyCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphGetClientKeyCommand.cs
@@ -7,7 +7,7 @@ using Spectre.Console.Cli;
 
 namespace Eryph.GuestServices.Tool.Commands.Eryph;
 
-// egs-tool eryph get-client-key
+// egs-tool catlet get-client-key
 //
 // Prints the managed client PUBLIC key in OpenSSH authorized_keys form, for
 // pasting into a catlet spec / fodder to pre-inject (the build-time flow).

--- a/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphGetStatusCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphGetStatusCommand.cs
@@ -5,7 +5,7 @@ using Spectre.Console.Cli;
 
 namespace Eryph.GuestServices.Tool.Commands.Eryph;
 
-// egs-tool eryph get-status <catletId>
+// egs-tool catlet get-status <catletId>
 //
 // Reads the catlet guest's services state (agent status/version, provisioning
 // state, shell) via the compute client's operation and prints it.

--- a/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphRemoveKeyCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphRemoveKeyCommand.cs
@@ -4,7 +4,7 @@ using Spectre.Console.Cli;
 
 namespace Eryph.GuestServices.Tool.Commands.Eryph;
 
-// egs-tool eryph remove-key <catletId>
+// egs-tool catlet remove-key <catletId>
 //
 // Revokes the caller's own key via the compute client. The server derives the
 // subject from the bearer token, so no key is sent.

--- a/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphSetShellCommand.cs
+++ b/src/Eryph.GuestServices.Tool/Commands/Eryph/EryphSetShellCommand.cs
@@ -5,7 +5,7 @@ using Spectre.Console.Cli;
 
 namespace Eryph.GuestServices.Tool.Commands.Eryph;
 
-// egs-tool eryph set-shell <catletId> <shell> [--args <args>]
+// egs-tool catlet set-shell <catletId> <shell> [--args <args>]
 //
 // Sets the shell the guest's SSH server spawns for interactive sessions, via the
 // guest-services settings. Pass an empty shell to clear the override.

--- a/src/Eryph.GuestServices.Tool/Eryph/EryphProxy.cs
+++ b/src/Eryph.GuestServices.Tool/Eryph/EryphProxy.cs
@@ -5,7 +5,7 @@ using Eryph.ComputeClient.Models;
 namespace Eryph.GuestServices.Tool.Eryph;
 
 // The eryph data plane. Invoked by SSH as the ProxyCommand
-// (egs-tool eryph proxy <catletId>). Two-step, using the typed Eryph.ComputeClient
+// (egs-tool catlet proxy <catletId>). Two-step, using the typed Eryph.ComputeClient
 // (eryph's async operation model — the API never blocks on an operation):
 //   1. CatletsClient.OpenSshChannel  -> starts the OpenSshChannel operation.
 //   2. poll OperationsClient.Get     -> until it completes; read the one-time
@@ -38,7 +38,7 @@ public static class EryphProxy
         var operations = connection.CreateOperationsClient();
 
         // 1. Start the control-plane operation. The agent (via the saga) prepares the hvsocket and
-        // mints a one-time token; we do not push a key here (use `eryph add-key` for the added-key flow).
+        // mints a one-time token; we do not push a key here (use `catlet add-key` for the added-key flow).
         string operationId;
         try
         {

--- a/src/Eryph.GuestServices.Tool/Program.cs
+++ b/src/Eryph.GuestServices.Tool/Program.cs
@@ -61,7 +61,7 @@ app.Configure(config =>
         .WithDescription(
             "Configures the shell that interactive SSH sessions spawn in the VM.");
 
-    config.AddBranch("eryph", eryph =>
+    config.AddBranch("catlet", eryph =>
     {
         eryph.SetDescription(
             "Remote access to eryph catlets through the eryph-authorized channel.");
@@ -120,12 +120,12 @@ if (args is ["proxy", var vmId])
     return 0;
 }
 
-// The eryph data-plane proxy is, like the VM-level proxy above, kept out of
+// The catlet data-plane proxy is, like the VM-level proxy above, kept out of
 // Spectre.Console.Cli so nothing interferes with the redirected stdin/stdout it
 // bridges to the eryph channel. Unlike the VM proxy it must NOT require host
 // admin: it runs on the operator's machine and authenticates with the
 // operator's eryph identity.
-if (args.Length >= 3 && args[0] == "eryph" && args[1] == "proxy")
+if (args.Length >= 3 && args[0] == "catlet" && args[1] == "proxy")
 {
     var catletId = args[2];
     // Validate the id even though the generated alias only ever writes a safe one:

--- a/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
+++ b/src/Eryph.GuestServices.Tool/SshConfigHelper.cs
@@ -250,7 +250,7 @@ public static class SshConfigHelper
         && value.All(c => char.IsAsciiLetterOrDigit(c) || c is '-' or '_' or '.');
 
     // Writes a single per-catlet SSH config whose ProxyCommand bridges to the
-    // eryph channel (egs-tool eryph proxy <catletId>) rather than a local
+    // eryph channel (egs-tool catlet proxy <catletId>) rather than a local
     // hvsocket. Per-catlet and on demand: unlike the removed bulk
     // update-ssh-config it never enumerates or rewrites other catlets' configs.
     public static async Task<IReadOnlyList<string>> EnsureCatletConfigAsync(
@@ -476,7 +476,7 @@ public static class SshConfigHelper
         // other shell-significant character) would otherwise be split into extra
         // tokens — or worse, alter the proxy command line — when the SSH client
         // executes the ProxyCommand.
-        var proxyCommand = new StringBuilder($"egs-tool.exe eryph proxy {catletId}");
+        var proxyCommand = new StringBuilder($"egs-tool.exe catlet proxy {catletId}");
         if (!string.IsNullOrEmpty(configurationName))
             proxyCommand.Append($" --configuration \"{configurationName}\"");
         if (!string.IsNullOrEmpty(clientId))

--- a/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
+++ b/test/Eryph.GuestServices.Tool.Tests/SshConfigHelperTests.cs
@@ -208,7 +208,7 @@ public class SshConfigHelperTests : IDisposable
         // BYOK path outside the user profile cannot be '~'-anchored, but is still
         // forward-slashed so the MSYS ssh in embedded shells can open it.
         content.Should().Contain("IdentityFile \"C:/Users/Jane Doe/.ssh/id_eryph\"");
-        content.Should().Contain($"ProxyCommand egs-tool.exe eryph proxy {catletId} "
+        content.Should().Contain($"ProxyCommand egs-tool.exe catlet proxy {catletId} "
             + "--configuration \"config-b\" --client-id \"client-a\"");
     }
 
@@ -358,7 +358,7 @@ public class SshConfigHelperTests : IDisposable
         var content = await File.ReadAllTextAsync(
             Path.Combine(SshConfigHelper.CatletSshConfigPath, $"{catletId}.config"));
 
-        content.Should().Contain($"ProxyCommand egs-tool.exe eryph proxy {catletId}");
+        content.Should().Contain($"ProxyCommand egs-tool.exe catlet proxy {catletId}");
         content.Should().NotContain("--configuration");
         content.Should().NotContain("--client-id");
     }


### PR DESCRIPTION
@
Renames the `egs-tool eryph` remote-access subcommand group to `egs-tool catlet`, so the command reads as the object the operator acts on (a catlet) rather than the product. Updates the generated SSH `ProxyCommand`, its tests, the invocation strings in the README and RFC 0030, and the command-file header comments.

Internal class/folder/namespace names (`EryphProxy`, `Commands/Eryph/`, `…Tool.Eryph`) are intentionally left as-is: they name the eryph-authorized channel mechanism, not the user-facing verb.

No backward-compatibility alias is provided, and none is needed — this feature has not been released yet, so no persisted SSH configs reference the old `eryph proxy` ProxyCommand.

Full solution test suite passes (1520 tests, 0 failed); `egs-tool catlet --help` smoke-checked. The e2e suite is unaffected (it only exercises VM-level host-side commands).
@