### PR TITLE
Capture the agent's operational log in collect-logs (#45)

### DIFF
--- a/docs/user/howto/collect-logs-for-support.md
+++ b/docs/user/howto/collect-logs-for-support.md
@@ -16,6 +16,7 @@ The command never prompts and overwrites the output file if it exists.
 | Entry | Source | When useful |
 | --- | --- | --- |
 | `state.json` | `%ProgramData%\eryph\provisioning\state.json` | The agent's view of what ran. Look here first. |
+| `logs/agent.log` | `%ProgramData%\eryph\guest-services\logs\agent.log` (Linux: `/var/log/eryph/guest-services/agent.log`) | The whole agent's operational log — datasource discovery, every module, reboots, and remote-access (SSH) events. Look here when something misbehaves. |
 | `logs/<script>.log` | `%ProgramData%\eryph\provisioning\logs\` | Per-script stdout/stderr + exit code from `ScriptsUser` and any other module that writes there. |
 | `scripts/<ordinal>-<filename>` | The staged user-data scripts directory | The scripts as the agent actually ran them — handy for diffing against the fodder. |
 | `version.txt` | generated | The agent version and the time the bundle was made. |
@@ -28,14 +29,17 @@ silently; the bundle is best-effort.
 ```powershell
 Expand-Archive C:\Temp\egs-bundle.zip C:\Temp\egs-bundle\
 Get-Content C:\Temp\egs-bundle\state.json
+Get-Content C:\Temp\egs-bundle\logs\agent.log
 Get-Content C:\Temp\egs-bundle\logs\001-enable_rd.ps1.log
 ```
 
 ## What's *not* in the bundle
 
-- The Windows Event Log. The agent writes Information / Warning /
-  Error events to its own logger; if you've redirected them to the
-  Event Log, export the relevant log separately.
+- The Windows Event Log. The agent's operational log is captured in
+  `logs/agent.log` (above), so you rarely need the Event Log — but the
+  service also mirrors the same events there, so export it separately if
+  you need the OS-side timestamps or events from before `agent.log`
+  rolled over.
 - The OS / Hyper-V system logs.
 - The original cloud-init datasource payload. If you can read it from
   inside the guest (e.g. mount the cidata ISO), include it manually —

--- a/src/Eryph.GuestServices.Core/AgentPaths.cs
+++ b/src/Eryph.GuestServices.Core/AgentPaths.cs
@@ -1,0 +1,35 @@
+namespace Eryph.GuestServices.Core;
+
+/// <summary>
+/// Well-known filesystem paths for the guest-services agent as a whole — the
+/// <c>egs-service</c> process, which hosts both remote access (SSH) and
+/// provisioning. These are deliberately separate from the provisioning-only
+/// state tree (<c>%ProgramData%\eryph\provisioning</c>): the operational log
+/// is a global agent concern, not a provisioning artefact.
+/// </summary>
+public static class AgentPaths
+{
+    // Test-only hook. Production code leaves this null and uses the
+    // platform-default location below.
+    internal static string? RootOverride { get; set; }
+
+    /// <summary>
+    /// Directory holding the agent's operational log(s). Sits alongside the
+    /// service-wide config root that stores the SSH keys.
+    /// <list type="bullet">
+    /// <item>Windows: <c>%ProgramData%\eryph\guest-services\logs</c></item>
+    /// <item>Linux: <c>/var/log/eryph/guest-services</c></item>
+    /// </list>
+    /// </summary>
+    public static string LogsDirectory =>
+        RootOverride is not null
+            ? Path.Combine(RootOverride, "logs")
+            : OperatingSystem.IsWindows()
+                ? Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                    "eryph", "guest-services", "logs")
+                : "/var/log/eryph/guest-services";
+
+    /// <summary>The agent's operational log file (<c>agent.log</c>).</summary>
+    public static string LogFile => Path.Combine(LogsDirectory, "agent.log");
+}

--- a/src/Eryph.GuestServices.Core/Eryph.GuestServices.Core.csproj
+++ b/src/Eryph.GuestServices.Core/Eryph.GuestServices.Core.csproj
@@ -14,7 +14,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- The file log provider needs ILogger/ILoggerProvider only — the
+         lightweight Abstractions package, not the full logging host. -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="Eryph.GuestServices.Service.Tests" />
+    <InternalsVisibleTo Include="Eryph.GuestServices.Provisioning.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Eryph.GuestServices.Core/Logging/FileLogger.cs
+++ b/src/Eryph.GuestServices.Core/Logging/FileLogger.cs
@@ -1,0 +1,70 @@
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Eryph.GuestServices.Core.Logging;
+
+/// <summary>
+/// The <see cref="ILogger"/> returned by <see cref="FileLoggerProvider"/>.
+/// Formats one line per event as
+/// <c>2026-06-12 14:03:01.123 +02:00 [INF] Category[eventId] message</c>,
+/// with the exception (if any) appended on following lines. Level filtering is
+/// left to the host's <c>LoggerFactory</c> (driven by the <c>Logging</c>
+/// section of appsettings.json), which only forwards events that pass the
+/// configured rules.
+/// </summary>
+internal sealed class FileLogger : ILogger
+{
+    private readonly string _category;
+    private readonly FileLoggerProvider _provider;
+
+    public FileLogger(string category, FileLoggerProvider provider)
+    {
+        _category = category;
+        _provider = provider;
+    }
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+            return;
+
+        ArgumentNullException.ThrowIfNull(formatter);
+
+        var message = formatter(state, exception);
+        if (string.IsNullOrEmpty(message) && exception is null)
+            return;
+
+        var builder = new StringBuilder();
+        builder.Append(DateTimeOffset.Now.ToString("yyyy-MM-dd HH:mm:ss.fff zzz"));
+        builder.Append(" [").Append(ShortLevel(logLevel)).Append("] ");
+        builder.Append(_category);
+        if (eventId.Id != 0)
+            builder.Append('[').Append(eventId.Id).Append(']');
+        builder.Append(' ').Append(message);
+        if (exception is not null)
+            builder.Append(Environment.NewLine).Append(exception);
+        builder.Append(Environment.NewLine);
+
+        _provider.Append(builder.ToString());
+    }
+
+    private static string ShortLevel(LogLevel level) => level switch
+    {
+        LogLevel.Trace => "TRC",
+        LogLevel.Debug => "DBG",
+        LogLevel.Information => "INF",
+        LogLevel.Warning => "WRN",
+        LogLevel.Error => "ERR",
+        LogLevel.Critical => "CRT",
+        _ => "???",
+    };
+}

--- a/src/Eryph.GuestServices.Core/Logging/FileLoggerProvider.cs
+++ b/src/Eryph.GuestServices.Core/Logging/FileLoggerProvider.cs
@@ -1,0 +1,118 @@
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Eryph.GuestServices.Core.Logging;
+
+/// <summary>
+/// Minimal, dependency-free <see cref="ILoggerProvider"/> that appends the
+/// agent's operational log to a single file (see <see cref="AgentPaths.LogFile"/>).
+/// <para>
+/// It exists so the support bundle (<c>collect-logs</c>) captures the agent's
+/// own diagnostics. Without it the service's only sink is the Windows Event Log
+/// (wired by <c>AddWindowsService()</c>) / the systemd journal, which the
+/// bundle never reads — so a bundle from a guest that ran no user-data scripts
+/// contained nothing but <c>state.json</c> + <c>version.txt</c> (issue #45).
+/// </para>
+/// <para>
+/// This is a global agent concern, not a provisioning one: it captures
+/// everything the <c>egs-service</c> process logs (remote access included), so
+/// it lives in Core and takes an explicit path rather than reaching into any
+/// feature's path helper.
+/// </para>
+/// <para>
+/// Volume is low (a few hundred lines per boot) so a lock-guarded
+/// open-append-close per line is sufficient and keeps the file unlocked
+/// between writes. A size cap with a single <c>.1</c> backup keeps the file
+/// from growing without bound across reboots.
+/// </para>
+/// </summary>
+public sealed class FileLoggerProvider : ILoggerProvider
+{
+    // 5 MiB before rolling. One backup is kept (agent.log.1); the previous
+    // backup is overwritten. Hundreds of lines per boot means this spans many
+    // boots before rolling, which is what a support engineer wants.
+    private const long DefaultMaxBytes = 5 * 1024 * 1024;
+
+    private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+
+    private readonly string _filePath;
+    private readonly long _maxBytes;
+    private readonly object _gate = new();
+    private bool _disposed;
+
+    public FileLoggerProvider(string filePath, long maxBytes = DefaultMaxBytes)
+    {
+        _filePath = filePath;
+        _maxBytes = maxBytes;
+
+        // Create the log directory eagerly so the file (and the directory
+        // collect-logs harvests) exist even on a guest that never ran a
+        // user-data script. Best-effort: a failure here must not take down
+        // the host's logging pipeline.
+        try
+        {
+            var dir = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    public ILogger CreateLogger(string categoryName) => new FileLogger(categoryName, this);
+
+    /// <summary>
+    /// Appends a fully-formatted line (including its trailing newline) to the
+    /// log file. Serialised across loggers and best-effort: any I/O failure is
+    /// swallowed so a transient file lock can never crash the agent.
+    /// </summary>
+    internal void Append(string line)
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+
+            try
+            {
+                RollIfNeeded();
+
+                // FileShare.ReadWrite so a concurrent reader (or a second
+                // egs-service process — e.g. an operator `run` while the
+                // service is up) does not get an access violation. Lines are
+                // short and rare, so interleaving across processes is benign.
+                using var stream = new FileStream(
+                    _filePath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+                using var writer = new StreamWriter(stream, Utf8NoBom);
+                writer.Write(line);
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+
+    private void RollIfNeeded()
+    {
+        var info = new FileInfo(_filePath);
+        if (!info.Exists || info.Length < _maxBytes)
+            return;
+
+        var backup = _filePath + ".1";
+        try
+        {
+            if (File.Exists(backup))
+                File.Delete(backup);
+            File.Move(_filePath, backup);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            _disposed = true;
+        }
+    }
+}

--- a/src/Eryph.GuestServices.Provisioning/Cli/CollectLogsCommand.cs
+++ b/src/Eryph.GuestServices.Provisioning/Cli/CollectLogsCommand.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.IO.Compression;
 using System.Reflection;
 using System.Text;
+using Eryph.GuestServices.Core;
 using Eryph.GuestServices.Provisioning.Configuration;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -52,7 +53,13 @@ public sealed class CollectLogsCommand : AsyncCommand<CollectLogsCommand.Setting
         if (File.Exists(ProvisioningPaths.StateFile))
             archive.CreateEntryFromFile(ProvisioningPaths.StateFile, "state.json");
 
-        // logs/
+        // logs/ — the agent's own operational log (agent.log + rolled backups)
+        // lives under the service-wide guest-services root; the provisioning
+        // per-script logs live under the provisioning root. Both go under the
+        // same logs/ prefix (filenames don't collide: agent.log vs <script>.log).
+        if (Directory.Exists(AgentPaths.LogsDirectory))
+            AddDirectory(archive, AgentPaths.LogsDirectory, "logs");
+
         if (Directory.Exists(ProvisioningPaths.LogsDirectory))
             AddDirectory(archive, ProvisioningPaths.LogsDirectory, "logs");
 

--- a/src/Eryph.GuestServices.Provisioning/Cli/RunCommand.cs
+++ b/src/Eryph.GuestServices.Provisioning/Cli/RunCommand.cs
@@ -2,6 +2,8 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.Versioning;
 using Eryph.GuestServices.Provisioning.DataSources;
+using Eryph.GuestServices.Core;
+using Eryph.GuestServices.Core.Logging;
 using Eryph.GuestServices.Provisioning.Hosting;
 using Eryph.GuestServices.Provisioning.Reporting;
 using Eryph.GuestServices.Provisioning.Reporting.Events;
@@ -105,7 +107,10 @@ public sealed class RunCommand : AsyncCommand<RunCommand.Settings>
         // ILogger<T> injection. Build a minimal Generic Host shell that only
         // wires logging, hand the container over, and resolve from it.
         var hostBuilder = Host.CreateApplicationBuilder();
-        hostBuilder.Services.AddLogging();
+        // Mirror the run into the agent log so `collect-logs` captures it too —
+        // the one-shot `egs-service run` path otherwise only writes to console.
+        hostBuilder.Services.AddLogging(logging =>
+            logging.AddProvider(new FileLoggerProvider(AgentPaths.LogFile)));
         hostBuilder.Services.AddSimpleInjector(container, opt => opt.AddLogging());
         using var host = hostBuilder.Build();
         host.Services.UseSimpleInjector(container);

--- a/src/Eryph.GuestServices.Service/Program.cs
+++ b/src/Eryph.GuestServices.Service/Program.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Eryph.GuestServices.Core;
 using Eryph.GuestServices.DevTunnels.Ssh.Extensions;
 using Eryph.GuestServices.HvDataExchange.Guest;
+using Eryph.GuestServices.Core.Logging;
 using Eryph.GuestServices.Provisioning.Cli;
 using Eryph.GuestServices.Provisioning.Hosting;
 using Eryph.GuestServices.Service.Services;
@@ -92,7 +93,13 @@ internal static class Program
             ContentRootPath = AppContext.BaseDirectory,
         });
 
-        builder.Services.AddLogging();
+        // File log sink: mirror the whole agent's operational log into
+        // AgentPaths.LogFile so `collect-logs` captures it. The service's other
+        // sinks (Windows Event Log / systemd journal / console) are not in the
+        // support bundle (issue #45). This is a global agent concern, so it
+        // covers remote access as well as provisioning.
+        builder.Services.AddLogging(logging =>
+            logging.AddProvider(new FileLoggerProvider(AgentPaths.LogFile)));
         builder.Services.AddSingleton<IServiceControlFlags, PlatformServiceControlFlags>();
         builder.Services.AddHostedService<SshServerService>();
         builder.Services.AddSingleton<IHostKeyGenerator, HostKeyGenerator>();

--- a/test/Eryph.GuestServices.Provisioning.Tests/Cli/CollectLogsCommandTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Cli/CollectLogsCommandTests.cs
@@ -1,5 +1,6 @@
 using System.IO.Compression;
 using AwesomeAssertions;
+using Eryph.GuestServices.Core;
 using Eryph.GuestServices.Provisioning.Cli;
 
 namespace Eryph.GuestServices.Provisioning.Tests.Cli;
@@ -15,12 +16,16 @@ public sealed class CollectLogsCommandTests : IDisposable
         _root = Path.Combine(Path.GetTempPath(), "egs-collect-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_root);
         ProvisioningPaths.RootOverride = _root;
+        // The agent log lives under a separate (service-wide) root; give it its
+        // own subdir so the two logs/ sources stay distinct in the test.
+        AgentPaths.RootOverride = Path.Combine(_root, "gs");
         _output = Path.Combine(_root, "bundle.zip");
     }
 
     public void Dispose()
     {
         ProvisioningPaths.RootOverride = null;
+        AgentPaths.RootOverride = null;
         if (Directory.Exists(_root))
             Directory.Delete(_root, recursive: true);
     }
@@ -60,12 +65,13 @@ public sealed class CollectLogsCommandTests : IDisposable
     }
 
     [Fact]
-    public async Task ExecuteAsync_includes_logs_directory_when_present()
+    public async Task ExecuteAsync_includes_provisioning_script_logs_when_present()
     {
+        // The provisioning logs dir holds per-script logs (ScriptsUser etc.).
         var logsDir = Path.Combine(_root, "logs");
         Directory.CreateDirectory(logsDir);
-        await File.WriteAllTextAsync(Path.Combine(logsDir, "agent.log"), "hello");
-        await File.WriteAllTextAsync(Path.Combine(logsDir, "trace.log"), "world");
+        await File.WriteAllTextAsync(Path.Combine(logsDir, "001-foo.ps1.log"), "hello");
+        await File.WriteAllTextAsync(Path.Combine(logsDir, "002-bar.ps1.log"), "world");
 
         var sut = new CollectLogsCommand();
         var exit = await sut.ExecuteAsync(
@@ -75,8 +81,28 @@ public sealed class CollectLogsCommandTests : IDisposable
         exit.Should().Be(0);
         using var archive = ZipFile.OpenRead(_output);
         var names = archive.Entries.Select(e => e.FullName).ToArray();
-        names.Should().Contain("logs/agent.log");
-        names.Should().Contain("logs/trace.log");
+        names.Should().Contain("logs/001-foo.ps1.log");
+        names.Should().Contain("logs/002-bar.ps1.log");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_includes_the_agent_log_from_the_guest_services_root()
+    {
+        // The agent's own operational log lives under the service-wide
+        // guest-services root, NOT the provisioning root — collect-logs must
+        // still bundle it (issue #45). It maps under the same logs/ prefix.
+        var agentLogs = AgentPaths.LogsDirectory;
+        Directory.CreateDirectory(agentLogs);
+        await File.WriteAllTextAsync(Path.Combine(agentLogs, "agent.log"), "agent diag");
+
+        var sut = new CollectLogsCommand();
+        var exit = await sut.ExecuteAsync(
+            TestCommandContext.Create("collect-logs"),
+            new CollectLogsCommand.Settings { Output = _output });
+
+        exit.Should().Be(0);
+        using var archive = ZipFile.OpenRead(_output);
+        archive.Entries.Select(e => e.FullName).Should().Contain("logs/agent.log");
     }
 
     [Fact]

--- a/test/Eryph.GuestServices.Service.Tests/Logging/AgentLogWiringTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/Logging/AgentLogWiringTests.cs
@@ -1,0 +1,64 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.Core;
+using Eryph.GuestServices.Core.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Eryph.GuestServices.Service.Tests.Logging;
+
+// All tests here mutate the shared AgentPaths.RootOverride. They live in one
+// class so xunit runs them sequentially (no within-class parallelism).
+public sealed class AgentLogWiringTests : IDisposable
+{
+    private readonly string _root;
+
+    public AgentLogWiringTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "egs-agentpaths-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        AgentPaths.RootOverride = _root;
+    }
+
+    public void Dispose()
+    {
+        AgentPaths.RootOverride = null;
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    [Fact]
+    public void LogFile_is_agent_log_under_the_logs_directory()
+    {
+        AgentPaths.LogsDirectory.Should().Be(Path.Combine(_root, "logs"));
+        AgentPaths.LogFile.Should().Be(Path.Combine(_root, "logs", "agent.log"));
+    }
+
+    [Fact]
+    public void Default_log_path_is_under_the_service_wide_guest_services_root()
+    {
+        AgentPaths.RootOverride = null;
+
+        // Cross-platform: Windows -> %ProgramData%\eryph\guest-services\logs,
+        // Linux -> /var/log/eryph/guest-services. Both carry the service-wide
+        // 'guest-services' segment and the file is always agent.log.
+        AgentPaths.LogsDirectory.Should().Contain("guest-services");
+        AgentPaths.LogFile.Should().EndWith("agent.log");
+        // Must NOT live under the provisioning tree — that was the whole point
+        // of moving the sink out of the provisioning feature.
+        AgentPaths.LogsDirectory.Should().NotContain("provisioning");
+    }
+
+    [Fact]
+    public void AddProvider_with_AgentPaths_LogFile_writes_the_agent_log()
+    {
+        // Faithful to the composition roots (Program.cs / RunCommand), which do
+        // logging.AddProvider(new FileLoggerProvider(AgentPaths.LogFile)).
+        using (var factory = LoggerFactory.Create(builder =>
+                   builder.AddProvider(new FileLoggerProvider(AgentPaths.LogFile))))
+        {
+            factory.CreateLogger("Eryph.Wiring.Test").LogInformation("wired line");
+        }
+
+        File.Exists(AgentPaths.LogFile).Should().BeTrue();
+        File.ReadAllText(AgentPaths.LogFile).Should().Contain("wired line");
+    }
+}

--- a/test/Eryph.GuestServices.Service.Tests/Logging/FileLoggerProviderTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/Logging/FileLoggerProviderTests.cs
@@ -1,0 +1,109 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.Core.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Eryph.GuestServices.Service.Tests.Logging;
+
+public sealed class FileLoggerProviderTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _logPath;
+
+    public FileLoggerProviderTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "egs-filelog-" + Guid.NewGuid().ToString("N"));
+        _logPath = Path.Combine(_dir, "logs", "agent.log");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir))
+            Directory.Delete(_dir, recursive: true);
+    }
+
+    [Fact]
+    public void Constructor_creates_the_log_directory_eagerly()
+    {
+        // The directory must exist even before the first write so a guest that
+        // never logged anything still hands collect-logs a logs\ dir.
+        using var provider = new FileLoggerProvider(_logPath);
+
+        Directory.Exists(Path.GetDirectoryName(_logPath)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Log_writes_a_formatted_line_with_level_category_and_message()
+    {
+        using var provider = new FileLoggerProvider(_logPath);
+        var logger = provider.CreateLogger("Eryph.Test.Category");
+
+        logger.LogInformation("hello world");
+
+        var content = File.ReadAllText(_logPath);
+        content.Should().Contain("[INF]");
+        content.Should().Contain("Eryph.Test.Category");
+        content.Should().Contain("hello world");
+        content.Should().EndWith(Environment.NewLine);
+    }
+
+    [Fact]
+    public void Log_appends_the_exception_after_the_message()
+    {
+        using var provider = new FileLoggerProvider(_logPath);
+        var logger = provider.CreateLogger("Cat");
+
+        logger.LogError(new InvalidOperationException("boom"), "it failed");
+
+        var content = File.ReadAllText(_logPath);
+        content.Should().Contain("[ERR]");
+        content.Should().Contain("it failed");
+        content.Should().Contain("InvalidOperationException");
+        content.Should().Contain("boom");
+    }
+
+    [Fact]
+    public void Log_skips_entries_with_empty_message_and_no_exception()
+    {
+        using var provider = new FileLoggerProvider(_logPath);
+        var logger = provider.CreateLogger("Cat");
+
+        logger.Log(LogLevel.Information, default, string.Empty, null, (s, _) => s);
+
+        // Nothing meaningful to record — the file should not even be created.
+        File.Exists(_logPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Log_rolls_over_to_a_backup_when_the_size_cap_is_exceeded()
+    {
+        // Tiny cap so a couple of lines trips the roll.
+        using var provider = new FileLoggerProvider(_logPath, maxBytes: 64);
+        var logger = provider.CreateLogger("Cat");
+
+        // First write creates agent.log; the file now exceeds 64 bytes.
+        logger.LogInformation(new string('a', 100));
+        // Second write sees the over-cap file, rolls it to .1, starts fresh.
+        logger.LogInformation("after-roll");
+
+        var backup = _logPath + ".1";
+        File.Exists(backup).Should().BeTrue();
+        File.ReadAllText(backup).Should().Contain(new string('a', 100));
+
+        var current = File.ReadAllText(_logPath);
+        current.Should().Contain("after-roll");
+        current.Should().NotContain(new string('a', 100));
+    }
+
+    [Fact]
+    public void Append_does_not_throw_after_dispose()
+    {
+        var provider = new FileLoggerProvider(_logPath);
+        var logger = provider.CreateLogger("Cat");
+        provider.Dispose();
+
+        // Best-effort: logging after disposal is a no-op, never an exception.
+        var act = () => logger.LogInformation("late");
+        act.Should().NotThrow();
+        File.Exists(_logPath).Should().BeFalse();
+    }
+}

--- a/test/e2e/Provisioning.E2E.Tests.ps1
+++ b/test/e2e/Provisioning.E2E.Tests.ps1
@@ -12,13 +12,16 @@
   - The catlet config (`provisioning-catlet.yaml`) is the TEST INPUT — its
     cloud-config fodder is what our agent is asked to process. eryph-zero
     compiles fodder into a ConfigDrive ISO that gets attached to the catlet.
-  - We do NOT add the dbosoft/guest-services gene; the parent gives us
-    Windows + cloudbase-init. We install our agent offline via VHD mount.
+  - We do NOT add the dbosoft/guest-services gene; the parent already ships
+    egs-service baked into C:\Program Files\eryph\guest-services\bin\. We
+    overwrite those binaries with our locally-built ones offline via VHD mount.
+  - Newer base images no longer ship cloudbase-init (egs-service is the sole
+    provisioning engine). The offline cloudbase-init disable is therefore
+    best-effort and a no-op when cbi is absent (Test-Path guarded); it stays
+    in place for older images that still bundle it.
   - Before first start we mount the catlet's VHD, copy our locally-built
-    egs-service binaries into C:\Program Files\eryph\guest-services\bin\,
-    register egs-service as an automatic Windows service via the offline
-    SYSTEM hive, and disable cloudbase-init by renaming its install dir AND
-    setting its service Start=Disabled.
+    egs-service binaries into the existing bin dir, and (if present) disable
+    cloudbase-init by renaming its install dir AND setting Start=Disabled.
   - On first boot, only egs-service runs. Its ProvisioningHostedService
     discovers the ConfigDrive datasource, processes our cloud-config, and
     reports completion via KVP. SetHostnameModule may trigger a reboot;
@@ -391,6 +394,29 @@ Describe 'Embedded provisioning at first boot' {
         -Script "& 'C:\Program Files\eryph\guest-services\bin\egs-service.exe' status --json"
       $r.ExitCode | Should -Be 0
       ($r.Output | ConvertFrom-Json -AsHashtable).completedStages | Should -Contain 'Final'
+    }
+
+    It 'collect-logs captures the agent''s own operational log (issue #45)' {
+      # The agent writes its operational log to a file
+      # (%ProgramData%\eryph\guest-services\logs\agent.log) so the support
+      # bundle is useful even when no user-data scripts ran — without it the
+      # only sink was the Windows Event Log, which collect-logs never reads.
+      # Build the bundle, then inspect it in-guest: the egs SSH server has no
+      # SFTP subsystem so scp can't pull it. Both probes are single-quoted
+      # (no double quotes) so they survive the ssh.exe "powershell -Command"
+      # wrapping in Invoke-GuestPS.
+      $hostName = "$($catlet.VmId).hyper-v.alt"
+      $build = Invoke-GuestPS -HostName $hostName `
+        -Script "& 'C:\Program Files\eryph\guest-services\bin\egs-service.exe' collect-logs C:\Windows\Temp\egs-e2e-bundle.zip"
+      $build.ExitCode | Should -Be 0
+
+      $probe = @'
+Add-Type -AssemblyName System.IO.Compression.FileSystem; $z=[System.IO.Compression.ZipFile]::OpenRead('C:\Windows\Temp\egs-e2e-bundle.zip'); try { $e=$z.Entries | Where-Object FullName -eq 'logs/agent.log'; if ($e) { 'agent.log=' + $e.Length } else { 'agent.log=MISSING' } } finally { $z.Dispose() }
+'@
+      $r = Invoke-GuestPS -HostName $hostName -Script $probe
+      $r.ExitCode | Should -Be 0
+      $r.Output.Trim() | Should -Match '^agent\.log=\d+$'
+      [int]($r.Output.Trim() -replace 'agent\.log=', '') | Should -BeGreaterThan 0
     }
   }
 }


### PR DESCRIPTION
`collect-logs` produced a near-empty bundle (just `state.json` + `version.txt`) whenever a guest ran no user-data scripts: the agent's diagnostics only went to the Windows Event Log / systemd journal, which the bundle never reads (#45).

Add a small, dependency-free file log sink in `Eryph.GuestServices.Core` (`FileLoggerProvider` + `AgentPaths`) that appends the whole `egs-service` process's operational log — remote access and provisioning alike — to a service-wide file:

- Windows: `%ProgramData%\eryph\guest-services\logs\agent.log`
- Linux: `/var/log/eryph/guest-services/agent.log`

It's wired into both composition roots that run the agent (the Windows-service host and the one-shot `egs-service run`), and `collect-logs` now bundles that directory alongside the provisioning per-script logs. Size-capped with one rolled backup; best-effort so logging can never crash the agent.