### PR TITLE
Set the hostname from the datasource local-hostname

### DIFF
--- a/src/Eryph.GuestServices.Provisioning/Modules/SetHostnameModule.cs
+++ b/src/Eryph.GuestServices.Provisioning/Modules/SetHostnameModule.cs
@@ -29,7 +29,7 @@ internal sealed class SetHostnameModule(ILogger<SetHostnameModule> logger) : IMo
             return ModuleOutcome.Ok();
         }
 
-        var desired = PickName(config);
+        var desired = PickName(config, context.DataSource.Hostname);
         if (desired is null)
         {
             logger.LogDebug("No hostname or fqdn specified; nothing to do.");
@@ -80,7 +80,7 @@ internal sealed class SetHostnameModule(ILogger<SetHostnameModule> logger) : IMo
         }
     }
 
-    private static string? PickName(CloudConfigModel config)
+    private static string? PickName(CloudConfigModel config, string? dataSourceHostname)
     {
         // Cloud-init's prefer_fqdn_over_hostname swaps the precedence: when
         // true AND an fqdn is available, the fqdn wins over hostname.
@@ -94,6 +94,16 @@ internal sealed class SetHostnameModule(ILogger<SetHostnameModule> logger) : IMo
 
         if (!string.IsNullOrWhiteSpace(config.Fqdn))
             return ExtractNetBiosName(config.Fqdn);
+
+        // Fall back to the datasource-provided hostname (NoCloud / ConfigDrive
+        // `local-hostname`, EC2 / Azure metadata). cloud-init's cc_set_hostname
+        // resolves the name via get_hostname_fqdn(), which uses the datasource
+        // hostname when the cloud-config specifies neither hostname nor fqdn.
+        // eryph delivers a catlet's name as meta-data `local-hostname` (not a
+        // cloud-config `hostname:`), so without this fallback a normal catlet
+        // never gets its hostname applied.
+        if (!string.IsNullOrWhiteSpace(dataSourceHostname))
+            return ExtractNetBiosName(dataSourceHostname.Trim());
 
         return null;
     }

--- a/test/Eryph.GuestServices.Provisioning.Tests/Modules/SetHostnameModuleTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Modules/SetHostnameModuleTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Eryph.GuestServices.Provisioning.DataSources;
 using Eryph.GuestServices.Provisioning.Modules;
 using Eryph.GuestServices.Provisioning.UserData;
 using Eryph.GuestServices.Provisioning.Windows;
@@ -238,5 +239,86 @@ public sealed class SetHostnameModuleTests
             CancellationToken.None);
 
         result.Should().BeOfType<ModuleOutcome.Completed>();
+    }
+
+    // Regression for the "hostname never changes" bug: eryph delivers a
+    // catlet's name as the datasource `local-hostname` (meta-data), not as a
+    // cloud-config `hostname:`. With neither hostname nor fqdn in the
+    // cloud-config, the module must fall back to the datasource hostname —
+    // mirroring cloud-init's get_hostname_fqdn() fallback.
+    [Fact]
+    public async Task Uses_datasource_hostname_when_cloud_config_specifies_none()
+    {
+        var os = Substitute.For<IWindowsOs>();
+        os.SetComputerNameAsync("egs-box", Arg.Any<CancellationToken>())
+            .Returns(SetComputerNameResult.SetWithRebootPending);
+        var module = new SetHostnameModule(NullLogger<SetHostnameModule>.Instance);
+
+        var context = new TestModuleContext(os, new DataSourceResult
+        {
+            SourceName = "NoCloud",
+            InstanceId = "i",
+            Hostname = "egs-box",
+        });
+
+        var result = await module.ApplyAsync(
+            ResolvedUserData.Empty(new CloudConfigModel()),
+            context,
+            CancellationToken.None);
+
+        result.Should().BeOfType<ModuleOutcome.RebootRequested>();
+        await os.Received().SetComputerNameAsync("egs-box", Arg.Any<CancellationToken>());
+    }
+
+    // The cloud-config hostname is higher precedence than the datasource
+    // local-hostname (cloud-init: cfg['hostname'] wins over the datasource).
+    [Fact]
+    public async Task Cloud_config_hostname_wins_over_datasource_hostname()
+    {
+        var os = Substitute.For<IWindowsOs>();
+        os.SetComputerNameAsync("from-config", Arg.Any<CancellationToken>())
+            .Returns(SetComputerNameResult.AlreadySet);
+        var module = new SetHostnameModule(NullLogger<SetHostnameModule>.Instance);
+
+        var context = new TestModuleContext(os, new DataSourceResult
+        {
+            SourceName = "NoCloud",
+            InstanceId = "i",
+            Hostname = "from-datasource",
+        });
+
+        await module.ApplyAsync(
+            ResolvedUserData.Empty(new CloudConfigModel { Hostname = "from-config" }),
+            context,
+            CancellationToken.None);
+
+        await os.Received().SetComputerNameAsync("from-config", Arg.Any<CancellationToken>());
+        await os.DidNotReceive().SetComputerNameAsync("from-datasource", Arg.Any<CancellationToken>());
+    }
+
+    // A dotted datasource hostname is reduced to its first NetBIOS label, the
+    // same as a cloud-config fqdn.
+    [Fact]
+    public async Task Datasource_hostname_uses_first_netbios_label()
+    {
+        var os = Substitute.For<IWindowsOs>();
+        os.SetComputerNameAsync("box", Arg.Any<CancellationToken>())
+            .Returns(SetComputerNameResult.AlreadySet);
+        var module = new SetHostnameModule(NullLogger<SetHostnameModule>.Instance);
+
+        var context = new TestModuleContext(os, new DataSourceResult
+        {
+            SourceName = "NoCloud",
+            InstanceId = "i",
+            Hostname = "box.example.com",
+        });
+
+        var result = await module.ApplyAsync(
+            ResolvedUserData.Empty(new CloudConfigModel()),
+            context,
+            CancellationToken.None);
+
+        result.Should().BeOfType<ModuleOutcome.Completed>();
+        await os.Received().SetComputerNameAsync("box", Arg.Any<CancellationToken>());
     }
 }

--- a/test/e2e/Hostname.E2E.Tests.ps1
+++ b/test/e2e/Hostname.E2E.Tests.ps1
@@ -1,0 +1,131 @@
+#Requires -Version 7.4
+#Requires -RunAsAdministrator
+
+<#
+.SYNOPSIS
+  End-to-end test: a plain catlet (no cloud-config `hostname:`) gets its
+  computer name from the datasource `local-hostname` that eryph derives from
+  the catlet name.
+
+.DESCRIPTION
+  Regression coverage for "hostname is not changed". eryph sets a catlet's
+  hostname via the NoCloud meta-data key `local-hostname`, not a cloud-config
+  `hostname:`. SetHostnameModule used to read only the cloud-config, so a
+  normal catlet kept the Windows sysprep default. This suite deploys a catlet
+  with NO hostname fodder and asserts the guest computer name became the
+  catlet name (NetBIOS-uppercased, truncated to 15 chars).
+
+  Same offline-install mechanics as Provisioning.E2E.Tests.ps1: mount the VHD
+  before first boot, copy our egs-service binaries in, disable cloudbase-init
+  if present, boot, and let the embedded agent provision.
+
+.PREREQUISITES
+  - Run as Administrator (Mount-VHD + offline reg load).
+  - Hyper-V management cmdlets available.
+  - eryph-zero installed and `egs-tool initialize` completed.
+  - Parent gene cached (dbosoft/winsrv2022-standard/starter by default).
+#>
+param (
+    [Parameter()]
+    [ValidateSet('winsrv2019', 'winsrv2022', 'winsrv2025')]
+    [string] $OSVersion = 'winsrv2022',
+
+    [Parameter()]
+    [string] $PublishPath
+)
+
+BeforeAll {
+  $PSNativeCommandUseErrorActionPreference = $true
+  $ErrorActionPreference = 'Stop'
+  . $PSScriptRoot/Helpers.ps1
+
+  if (-not $PublishPath) {
+    $PublishPath = "$PSScriptRoot/../../src/Eryph.GuestServices.Service/bin/Release/net10.0/win-x64/publish"
+  }
+  $resolvedPublishPath = (Resolve-Path -LiteralPath $PublishPath).Path
+
+  $catletConfig = (Get-Content -Raw -Path $PSScriptRoot/hostname-catlet.yaml) `
+    -replace '<<PARENT>>', "dbosoft/$OSVersion-standard/starter"
+
+  $project = New-TestProject
+  $catletName = New-CatletName
+  # The Windows computer name is the catlet name, NetBIOS-normalized:
+  # uppercased and truncated to 15 chars. New-CatletName yields a 15-char
+  # 'egs<yyMMddHHmmss>' so no truncation is expected, but normalize anyway.
+  $script:expectedComputerName = $catletName.ToUpperInvariant()
+  if ($script:expectedComputerName.Length -gt 15) {
+    $script:expectedComputerName = $script:expectedComputerName.Substring(0, 15)
+  }
+
+  Write-Host "Creating PLAIN catlet $catletName (no hostname fodder); expected computer name $script:expectedComputerName ..."
+  $catlet = New-Catlet -Config $catletConfig -Name $catletName -ProjectName $project.Name
+
+  $state = (Get-VM -Id $catlet.VmId).State
+  if ($state -ne 'Off') { throw "Expected catlet to be Off after creation; got $state." }
+
+  Write-Host "Replacing egs-service binaries offline (publish=$resolvedPublishPath) ..."
+  Update-EgsServiceBinariesOffline -VmId $catlet.VmId -PublishPath $resolvedPublishPath
+
+  Write-Host "Starting catlet $($catlet.Name) ..."
+  Start-Catlet -Id $catlet.Id -Force
+
+  Write-Host "Waiting for provisioning to complete (KVP eryph.provisioning.state) ..."
+  $finalState = Wait-ForProvisioningComplete -VmId $catlet.VmId -Timeout (New-TimeSpan -Minutes 12)
+  Write-Host "Provisioning state: $finalState"
+
+  Write-Host "Waiting for egs-service SSH listener (get-status=available) ..."
+  $savedPref = $PSNativeCommandUseErrorActionPreference
+  $PSNativeCommandUseErrorActionPreference = $false
+  try {
+    Wait-Assert -Timeout (New-TimeSpan -Minutes 5) -Interval (New-TimeSpan -Seconds 3) {
+      $status = egs-tool get-status $catlet.VmId
+      if ($status -ne 'available') { throw "guest services not available: $status" }
+    }
+    egs-tool add-ssh-config $catlet.VmId | Out-Null
+    for ($i = 0; $i -lt 40; $i++) {
+      ssh.exe -o StrictHostKeyChecking=no -o ConnectTimeout=5 "$($catlet.VmId).hyper-v.alt" 'hostname' 2>$null | Out-Null
+      if ($LASTEXITCODE -eq 0) { break }
+      Start-Sleep -Seconds 3
+    }
+  }
+  finally { $PSNativeCommandUseErrorActionPreference = $savedPref }
+
+  function script:Invoke-GuestPS {
+    param([string] $HostName, [string] $Script)
+    $output = ssh.exe -o StrictHostKeyChecking=no $HostName "powershell -NoProfile -Command `"$Script`""
+    return @{ ExitCode = $LASTEXITCODE; Output = ($output | Out-String).Trim() }
+  }
+}
+
+AfterAll {
+  . $PSScriptRoot/Helpers.ps1
+  if ($catlet) {
+    try {
+      Save-GuestDiagnostics -CatletId $catlet.Id `
+        -OutputDir (Join-Path $PSScriptRoot "diagnostics/$($catlet.Name)")
+    } catch { Write-Host "Guest diagnostics collection failed (non-fatal): $_" }
+  }
+  if ($env:EGS_E2E_KEEP_VM) {
+    Write-Host "EGS_E2E_KEEP_VM set — leaving catlet $($catlet.Name) for inspection."
+    return
+  }
+  if ($catlet) { Remove-Catlet -Id $catlet.Id -Force -ErrorAction SilentlyContinue }
+  if ($project) { Remove-EryphProject -Id $project.Id -Force -ErrorAction SilentlyContinue }
+}
+
+Describe 'Hostname from datasource local-hostname' {
+
+  It 'set the computer name to the catlet name (no cloud-config hostname)' {
+    $hostName = "$($catlet.VmId).hyper-v.alt"
+    $r = Invoke-GuestPS -HostName $hostName -Script '$env:COMPUTERNAME'
+    $r.ExitCode | Should -Be 0
+    $r.Output | Should -Be $script:expectedComputerName
+  }
+
+  It 'is not the Windows sysprep default (WIN-*)' {
+    $hostName = "$($catlet.VmId).hyper-v.alt"
+    $r = Invoke-GuestPS -HostName $hostName -Script '$env:COMPUTERNAME'
+    $r.ExitCode | Should -Be 0
+    $r.Output | Should -Not -Match '^WIN-'
+  }
+}

--- a/test/e2e/Run-HostnameE2ETests.ps1
+++ b/test/e2e/Run-HostnameE2ETests.ps1
@@ -1,0 +1,53 @@
+#Requires -Version 7.4
+#Requires -RunAsAdministrator
+
+<#
+.SYNOPSIS
+  Runs the hostname-from-datasource e2e test against a fresh base catlet.
+
+.DESCRIPTION
+  Publishes egs-service (Release/win-x64), then drives Hostname.E2E.Tests.ps1
+  which deploys a catlet with NO cloud-config hostname and asserts the guest
+  computer name became the catlet name (delivered as the datasource
+  `local-hostname`). Requires Administrator (Mount-VHD + offline registry edit).
+#>
+param (
+    [Parameter()]
+    [ValidateSet('winsrv2019', 'winsrv2022', 'winsrv2025')]
+    [string] $OSVersion = 'winsrv2022',
+
+    [Parameter()]
+    [switch] $SkipBuild
+)
+
+$PSNativeCommandUseErrorActionPreference = $true
+$ErrorActionPreference = 'Stop'
+
+Write-Host "Installing required PowerShell modules ..."
+Install-Module -Name Pester -MinimumVersion 5.5 -Force -Scope CurrentUser -SkipPublisherCheck
+Install-Module -Name Eryph.ComputeClient -Force -Scope CurrentUser
+
+if (-not $SkipBuild) {
+  Write-Host "Publishing egs-service for win-x64 ..."
+  dotnet publish "$PSScriptRoot/../../src/Eryph.GuestServices.Service/Eryph.GuestServices.Service.csproj" `
+    -c Release -r win-x64 --nologo
+}
+
+$publishPath = Resolve-Path "$PSScriptRoot/../../src/Eryph.GuestServices.Service/bin/Release/net10.0/win-x64/publish"
+
+Write-Host "Running Hostname Pester suite ..."
+$container = New-PesterContainer -Path "$PSScriptRoot/Hostname.E2E.Tests.ps1" `
+  -Data @{
+    OSVersion = $OSVersion
+    PublishPath = $publishPath.Path
+  }
+
+$config = New-PesterConfiguration
+$config.Output.Verbosity = 'Detailed'
+$config.Run.Container = $container
+$config.Run.Exit = $true
+$config.TestResult.Enabled = $true
+$config.TestResult.OutputFormat = 'NUnit3'
+$config.TestResult.OutputPath = "$PSScriptRoot/TEST-hostname-pesterResults.xml"
+
+Invoke-Pester -Configuration $config

--- a/test/e2e/hostname-catlet.yaml
+++ b/test/e2e/hostname-catlet.yaml
@@ -1,0 +1,16 @@
+name: hostname-e2e
+parent: <<PARENT>>
+cpu:
+  count: 2
+memory:
+  startup: 2048
+
+# Deliberately NO cloud-config `hostname:` fodder. eryph delivers the catlet's
+# name as the datasource meta-data `local-hostname` (NoCloud), which is how a
+# normal catlet's hostname is set. This suite proves SetHostnameModule honors
+# that datasource hostname — the regression behind "hostname is not changed":
+# the module used to read only cloud-config and ignore `local-hostname`, so a
+# plain catlet kept the Windows sysprep default (WIN-XXXXXXXXXXX).
+#
+# The catlet is provisioned by our offline-injected egs-service; cloudbase-init
+# is disabled (or absent) so our agent owns the lifecycle.


### PR DESCRIPTION
A plain catlet's hostname was never applied — the guest kept the Windows sysprep default (`WIN-XXXXXXXXXXX`). eryph delivers a catlet's name as the NoCloud meta-data key `local-hostname`, but `SetHostnameModule.PickName()` only read the cloud-config `hostname:`/`fqdn:` and ignored the datasource hostname, so with no explicit `hostname:` fodder the module ran and did nothing.

Add a fallback to `context.DataSource.Hostname` (parsed from `local-hostname`) after the cloud-config checks, applying the same NetBIOS first-label/truncation rules. This mirrors cloud-init's `cc_set_hostname`, which resolves the name via `get_hostname_fqdn()` and falls back to the datasource hostname when the config specifies neither. Cloud-config `hostname:`/`fqdn:` still take precedence.

Verified live on a fresh `winsrv2022-standard/starter` catlet (stock build leaves it `WIN-...`; the fixed build sets it to the catlet name). Unit tests cover the fallback, cloud-config precedence, and dotted-name handling; a new `Hostname.E2E.Tests.ps1` deploys a catlet with no hostname fodder and asserts the guest name became the catlet name.