### PR TITLE
Apply SSH public-keys from NoCloud datasource metadata

### DIFF
--- a/src/Eryph.GuestServices.Provisioning/DataSources/NoCloudDataSource.cs
+++ b/src/Eryph.GuestServices.Provisioning/DataSources/NoCloudDataSource.cs
@@ -350,6 +350,10 @@ public sealed class NoCloudDataSource(
         if (string.IsNullOrWhiteSpace(raw))
             return keys;
 
+        // Order-preserving de-dup: the list keeps insertion order, the set gives
+        // O(1) membership so a large key set stays linear.
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
         void Add(string? value)
         {
             if (string.IsNullOrWhiteSpace(value))
@@ -357,7 +361,7 @@ public sealed class NoCloudDataSource(
             foreach (var line in value.Split('\n'))
             {
                 var key = line.Trim();
-                if (key.Length > 0 && !keys.Contains(key))
+                if (key.Length > 0 && seen.Add(key))
                     keys.Add(key);
             }
         }
@@ -370,9 +374,10 @@ public sealed class NoCloudDataSource(
             if (stream.Documents.Count > 0)
                 root = stream.Documents[0].RootNode;
         }
-        catch
+        catch (YamlDotNet.Core.YamlException)
         {
-            // Not parseable as YAML — treat the whole value as key text.
+            // Not parseable as YAML — treat the whole value as key text. Only
+            // YAML parse failures are swallowed; other exceptions surface.
         }
 
         switch (root)

--- a/src/Eryph.GuestServices.Provisioning/DataSources/NoCloudDataSource.cs
+++ b/src/Eryph.GuestServices.Provisioning/DataSources/NoCloudDataSource.cs
@@ -117,6 +117,13 @@ public sealed class NoCloudDataSource(
 
         metaData.TryGetValue("local-hostname", out var hostname);
 
+        // cloud-init's DataSource.get_public_ssh_keys() applies
+        // normalize_pubkey_data(metadata["public-keys"]) and feeds the result
+        // to the default user. NoCloud meta-data routinely carries the keys
+        // here (not in cloud-config), so without this they would be dropped.
+        metaData.TryGetValue("public-keys", out var publicKeysRaw);
+        var sshPublicKeys = ExtractPublicKeys(publicKeysRaw);
+
         var structuredNetworkConfig = networkConfig is null ? null : TryParseNetworkConfig(networkConfig);
 
         return new DataSourceResult
@@ -127,6 +134,7 @@ public sealed class NoCloudDataSource(
             UserData = userData,
             VendorData = vendorData,
             MetaData = metaData,
+            SshPublicKeys = sshPublicKeys.Count > 0 ? sshPublicKeys : null,
             PlatformMetadata = new CloudConfig.PlatformMetadata
             {
                 LocalHostname = string.IsNullOrWhiteSpace(hostname) ? null : hostname,
@@ -325,6 +333,78 @@ public sealed class NoCloudDataSource(
         }
 
         return result;
+    }
+
+    // Mirrors cloud-init's normalize_pubkey_data(metadata["public-keys"]).
+    // ParseMetaData stores the value either as a plain scalar (a single key, or
+    // newline-joined keys) or as re-serialized YAML text when it was a map/list,
+    // so we re-parse it and collect leaf scalars:
+    //   - scalar          -> split on newlines (one key per non-empty line)
+    //   - list            -> each scalar item
+    //   - map {name: key} -> each value; a value that is itself a list yields
+    //                        each of its scalar items
+    // Order-preserving and de-duplicated.
+    internal static IReadOnlyList<string> ExtractPublicKeys(string? raw)
+    {
+        var keys = new List<string>();
+        if (string.IsNullOrWhiteSpace(raw))
+            return keys;
+
+        void Add(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return;
+            foreach (var line in value.Split('\n'))
+            {
+                var key = line.Trim();
+                if (key.Length > 0 && !keys.Contains(key))
+                    keys.Add(key);
+            }
+        }
+
+        YamlNode? root = null;
+        try
+        {
+            var stream = new YamlStream();
+            stream.Load(new StringReader(raw));
+            if (stream.Documents.Count > 0)
+                root = stream.Documents[0].RootNode;
+        }
+        catch
+        {
+            // Not parseable as YAML — treat the whole value as key text.
+        }
+
+        switch (root)
+        {
+            case YamlSequenceNode seq:
+                foreach (var item in seq.Children)
+                    if (item is YamlScalarNode s)
+                        Add(s.Value);
+                break;
+            case YamlMappingNode map:
+                foreach (var (_, value) in map.Children)
+                {
+                    switch (value)
+                    {
+                        case YamlScalarNode vs:
+                            Add(vs.Value);
+                            break;
+                        case YamlSequenceNode vseq:
+                            foreach (var item in vseq.Children)
+                                if (item is YamlScalarNode s)
+                                    Add(s.Value);
+                            break;
+                    }
+                }
+                break;
+            default:
+                // Scalar root (or unparsed): the raw text is the key(s).
+                Add(raw);
+                break;
+        }
+
+        return keys;
     }
 
     private static string SerializeNode(YamlNode node)

--- a/test/Eryph.GuestServices.Provisioning.Tests/DataSources/NoCloudDataSourceTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/DataSources/NoCloudDataSourceTests.cs
@@ -215,6 +215,9 @@ public sealed class NoCloudDataSourceTests : IDisposable
         result.MetaData.Should().ContainKey("public-keys");
         result.MetaData["public-keys"].Should().Contain("mykey");
         result.MetaData["public-keys"].Should().Contain("ssh-rsa AAAA...");
+        // ...and the key value is extracted for the default user (cloud-init's
+        // get_public_ssh_keys() / normalize_pubkey_data), not just kept as text.
+        result.SshPublicKeys.Should().ContainSingle().Which.Should().Be("ssh-rsa AAAA...");
     }
 
     [Fact]
@@ -270,6 +273,73 @@ public sealed class NoCloudDataSourceTests : IDisposable
         result.MetaData["public-keys"].Should().Contain("otherkey");
         result.MetaData.Should().ContainKey("network-interfaces");
         result.MetaData["network-interfaces"].Should().Contain("iface eth0 inet static");
+        // Both keys from the public-keys map are extracted for the default user.
+        result.SshPublicKeys.Should().BeEquivalentTo(new[]
+        {
+            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDexamplekeydata mykey@host",
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleEd25519KeyData other@host",
+        });
+    }
+
+    [Fact]
+    public async Task ReadAsync_extracts_public_keys_from_a_list()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_root, "meta-data"),
+            "instance-id: iid-local01\n" +
+            "public-keys:\n" +
+            "  - ssh-rsa AAAAkeyone one@host\n" +
+            "  - ssh-ed25519 AAAAkeytwo two@host\n");
+
+        var result = await NewSource().ReadAsync(_root, CancellationToken.None);
+
+        result!.SshPublicKeys.Should().Equal(
+            "ssh-rsa AAAAkeyone one@host",
+            "ssh-ed25519 AAAAkeytwo two@host");
+    }
+
+    [Fact]
+    public async Task ReadAsync_extracts_a_single_scalar_public_key()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_root, "meta-data"),
+            "instance-id: iid-local01\n" +
+            "public-keys: ssh-rsa AAAAonlykey only@host\n");
+
+        var result = await NewSource().ReadAsync(_root, CancellationToken.None);
+
+        result!.SshPublicKeys.Should().ContainSingle()
+            .Which.Should().Be("ssh-rsa AAAAonlykey only@host");
+    }
+
+    [Fact]
+    public async Task ReadAsync_leaves_ssh_keys_null_when_no_public_keys()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_root, "meta-data"),
+            "instance-id: iid-local01\nlocal-hostname: h\n");
+
+        var result = await NewSource().ReadAsync(_root, CancellationToken.None);
+
+        result!.SshPublicKeys.Should().BeNull();
+    }
+
+    [Theory]
+    // Map whose value is itself a list (cloud-init normalize_pubkey_data dict form).
+    [InlineData("name:\n- ssh-rsa A\n- ssh-rsa B", new[] { "ssh-rsa A", "ssh-rsa B" })]
+    // Plain newline-joined scalar.
+    [InlineData("ssh-rsa A\nssh-rsa B", new[] { "ssh-rsa A", "ssh-rsa B" })]
+    // Duplicates are dropped, order preserved.
+    [InlineData("- ssh-rsa A\n- ssh-rsa A\n- ssh-rsa B", new[] { "ssh-rsa A", "ssh-rsa B" })]
+    public void ExtractPublicKeys_normalizes_the_cloud_init_forms(string raw, string[] expected)
+    {
+        NoCloudDataSource.ExtractPublicKeys(raw).Should().Equal(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ExtractPublicKeys_returns_empty_for_blank(string? raw)
+    {
+        NoCloudDataSource.ExtractPublicKeys(raw).Should().BeEmpty();
     }
 
     // ---- Finding 17: seedfrom support -----------------------------------

--- a/test/Eryph.GuestServices.Provisioning.Tests/DataSources/NoCloudDataSourceTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/DataSources/NoCloudDataSourceTests.cs
@@ -273,12 +273,12 @@ public sealed class NoCloudDataSourceTests : IDisposable
         result.MetaData["public-keys"].Should().Contain("otherkey");
         result.MetaData.Should().ContainKey("network-interfaces");
         result.MetaData["network-interfaces"].Should().Contain("iface eth0 inet static");
-        // Both keys from the public-keys map are extracted for the default user.
-        result.SshPublicKeys.Should().BeEquivalentTo(new[]
-        {
+        // Both keys are extracted in document order (mykey then otherkey).
+        // Use Equal, not BeEquivalentTo: extraction is order-preserving and we
+        // want a regression to fail if that ordering ever changes.
+        result.SshPublicKeys.Should().Equal(
             "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDexamplekeydata mykey@host",
-            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleEd25519KeyData other@host",
-        });
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleEd25519KeyData other@host");
     }
 
     [Fact]


### PR DESCRIPTION
The NoCloud datasource parsed `instance-id` and `local-hostname` from meta-data but ignored `public-keys`, so SSH keys delivered the standard NoCloud way (meta-data, not cloud-config) were silently dropped. Only the OpenStack datasource honored datasource-supplied keys; `SshModule` already merges `DataSource.SshPublicKeys` with cloud-config `ssh_authorized_keys`, but NoCloud never populated it.

Parse `public-keys` into `DataSourceResult.SshPublicKeys`, mirroring cloud-init's `normalize_pubkey_data()`: a single scalar (newline-split), a list, or a map of `name: key` (value may itself be a list). Order-preserving and de-duplicated.

This is the SSH-key analog of the hostname-from-`local-hostname` fix (#47). Found by auditing which datasource metadata cloud-init acts on but we drop — Azure ovf-env SSH keys and the unused `PlatformMetadata.PublicKeys` field remain as separate follow-ups.