### PR TITLE
Skip permission-denied files in collect-logs

### DIFF
--- a/src/Eryph.GuestServices.Provisioning/Cli/CollectLogsCommand.cs
+++ b/src/Eryph.GuestServices.Provisioning/Cli/CollectLogsCommand.cs
@@ -98,6 +98,12 @@ public sealed class CollectLogsCommand : AsyncCommand<CollectLogsCommand.Setting
             {
                 // Skip files we can't open (locked log files, etc).
             }
+            catch (UnauthorizedAccessException)
+            {
+                // Skip files we lack permission to read. The agent log dir can
+                // live under a privileged location (e.g. /var/log on Linux), so
+                // a non-elevated collect-logs must stay best-effort, not abort.
+            }
         }
     }
 }

--- a/src/Eryph.GuestServices.Provisioning/Cli/CollectLogsCommand.cs
+++ b/src/Eryph.GuestServices.Provisioning/Cli/CollectLogsCommand.cs
@@ -86,7 +86,15 @@ public sealed class CollectLogsCommand : AsyncCommand<CollectLogsCommand.Setting
 
     private static void AddDirectory(ZipArchive archive, string sourceDir, string entryPrefix)
     {
-        foreach (var file in Directory.EnumerateFiles(sourceDir, "*", SearchOption.AllDirectories))
+        // IgnoreInaccessible so an unreadable subdirectory under a privileged
+        // tree (e.g. /var/log on Linux) is skipped during enumeration instead
+        // of throwing UnauthorizedAccessException before the loop body runs.
+        var options = new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            IgnoreInaccessible = true,
+        };
+        foreach (var file in Directory.EnumerateFiles(sourceDir, "*", options))
         {
             var rel = Path.GetRelativePath(sourceDir, file).Replace('\\', '/');
             var entryName = $"{entryPrefix}/{rel}";

--- a/src/Eryph.GuestServices.Provisioning/Cli/CollectLogsCommand.cs
+++ b/src/Eryph.GuestServices.Provisioning/Cli/CollectLogsCommand.cs
@@ -87,14 +87,33 @@ public sealed class CollectLogsCommand : AsyncCommand<CollectLogsCommand.Setting
     private static void AddDirectory(ZipArchive archive, string sourceDir, string entryPrefix)
     {
         // IgnoreInaccessible so an unreadable subdirectory under a privileged
-        // tree (e.g. /var/log on Linux) is skipped during enumeration instead
-        // of throwing UnauthorizedAccessException before the loop body runs.
+        // tree (e.g. /var/log on Linux) is skipped during the walk instead of
+        // throwing UnauthorizedAccessException.
         var options = new EnumerationOptions
         {
             RecurseSubdirectories = true,
             IgnoreInaccessible = true,
         };
-        foreach (var file in Directory.EnumerateFiles(sourceDir, "*", options))
+
+        // Materialize the listing inside the try so a failure to enumerate the
+        // directory itself — the root being unreadable, or a transient I/O error
+        // mid-walk — skips the whole directory instead of aborting the command.
+        // collect-logs is best-effort; this never throws.
+        List<string> files;
+        try
+        {
+            files = Directory.EnumerateFiles(sourceDir, "*", options).ToList();
+        }
+        catch (IOException)
+        {
+            return;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return;
+        }
+
+        foreach (var file in files)
         {
             var rel = Path.GetRelativePath(sourceDir, file).Replace('\\', '/');
             var entryName = $"{entryPrefix}/{rel}";

--- a/test/Eryph.GuestServices.Provisioning.Tests/Cli/CollectLogsCommandTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Cli/CollectLogsCommandTests.cs
@@ -106,6 +106,37 @@ public sealed class CollectLogsCommandTests : IDisposable
     }
 
     [Fact]
+    public async Task ExecuteAsync_skips_unreadable_log_files_and_still_succeeds()
+    {
+        // Best-effort contract: a log file collect-logs cannot open — locked,
+        // or permission-denied under a privileged tree like /var/log — must be
+        // skipped, not abort the whole bundle. Both failure modes hit the same
+        // skip-and-continue path in AddDirectory.
+        var agentLogs = AgentPaths.LogsDirectory;
+        Directory.CreateDirectory(agentLogs);
+        await File.WriteAllTextAsync(Path.Combine(agentLogs, "agent.log"), "readable");
+        var lockedPath = Path.Combine(agentLogs, "locked.log");
+        await File.WriteAllTextAsync(lockedPath, "locked");
+
+        // Hold it open with no sharing so CreateEntryFromFile's read open is
+        // refused (Windows: sharing violation -> IOException). On Linux the
+        // lock is advisory, so the file is simply bundled — either way the
+        // command must succeed and the readable log must be present.
+        using var hold = new FileStream(
+            lockedPath, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        var sut = new CollectLogsCommand();
+        var exit = await sut.ExecuteAsync(
+            TestCommandContext.Create("collect-logs"),
+            new CollectLogsCommand.Settings { Output = _output });
+
+        exit.Should().Be(0);
+        File.Exists(_output).Should().BeTrue();
+        using var archive = ZipFile.OpenRead(_output);
+        archive.Entries.Select(e => e.FullName).Should().Contain("logs/agent.log");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_returns_two_when_output_missing()
     {
         var sut = new CollectLogsCommand();

--- a/test/Eryph.GuestServices.Provisioning.Tests/Cli/CollectLogsCommandTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Cli/CollectLogsCommandTests.cs
@@ -106,22 +106,24 @@ public sealed class CollectLogsCommandTests : IDisposable
     }
 
     [Fact]
-    public async Task ExecuteAsync_skips_unreadable_log_files_and_still_succeeds()
+    public async Task ExecuteAsync_skips_a_file_it_cannot_open_and_still_succeeds()
     {
-        // Best-effort contract: a log file collect-logs cannot open — locked,
-        // or permission-denied under a privileged tree like /var/log — must be
-        // skipped, not abort the whole bundle. Both failure modes hit the same
-        // skip-and-continue path in AddDirectory.
+        // Best-effort contract: a log file collect-logs cannot open must be
+        // skipped, not abort the whole bundle. This asserts the open-failure
+        // skip path deterministically by holding a file open exclusively
+        // (Windows: CreateEntryFromFile's read open hits a sharing violation ->
+        // IOException). A permission-denied file raises UnauthorizedAccessException
+        // and hits the same catch; that path can't be triggered portably (CI
+        // runs elevated, and POSIX file locks are advisory), so it isn't
+        // asserted here — the catch covers both exception types.
         var agentLogs = AgentPaths.LogsDirectory;
         Directory.CreateDirectory(agentLogs);
         await File.WriteAllTextAsync(Path.Combine(agentLogs, "agent.log"), "readable");
         var lockedPath = Path.Combine(agentLogs, "locked.log");
         await File.WriteAllTextAsync(lockedPath, "locked");
 
-        // Hold it open with no sharing so CreateEntryFromFile's read open is
-        // refused (Windows: sharing violation -> IOException). On Linux the
-        // lock is advisory, so the file is simply bundled — either way the
-        // command must succeed and the readable log must be present.
+        // On Linux the lock is advisory, so the file is simply bundled — either
+        // way the command must succeed and the readable log must be present.
         using var hold = new FileStream(
             lockedPath, FileMode.Open, FileAccess.Read, FileShare.None);
 


### PR DESCRIPTION
Follow-up to the merged #46 (Copilot review). `collect-logs` now bundles the agent log dir, which on Linux lives under a privileged location (`/var/log/eryph/guest-services`). `AddDirectory` only caught `IOException`, so a single permission-denied file would abort the whole command instead of being skipped — contrary to its documented best-effort behavior. Also catch `UnauthorizedAccessException` and skip the file.