### PR TITLE
Match network-config to NICs via .NET NetworkInterface (fixes #53)

### DIFF
--- a/src/Eryph.GuestServices.Provisioning/Modules/ApplyNetworkConfigModule.cs
+++ b/src/Eryph.GuestServices.Provisioning/Modules/ApplyNetworkConfigModule.cs
@@ -37,9 +37,16 @@ internal sealed class ApplyNetworkConfigModule(ILogger<ApplyNetworkConfigModule>
 
         var adapters = await context.Os.GetNetworkAdaptersAsync(cancellationToken).ConfigureAwait(false);
         // The enumeration only returns MAC-bearing NICs; match by exact MAC.
+        // Group rather than ToDictionary so two adapters sharing a MAC (e.g. a
+        // NIC team and its member) can't throw and block the whole config; the
+        // lowest interface index wins deterministically.
         var byMac = adapters
             .Where(a => !string.IsNullOrEmpty(a.MacAddress))
-            .ToDictionary(a => a.MacAddress, StringComparer.OrdinalIgnoreCase);
+            .GroupBy(a => a.MacAddress, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                g => g.Key,
+                g => g.OrderBy(a => a.InterfaceIndex).First(),
+                StringComparer.OrdinalIgnoreCase);
 
         foreach (var (key, ethernet) in network.Ethernets)
         {
@@ -60,7 +67,7 @@ internal sealed class ApplyNetworkConfigModule(ILogger<ApplyNetworkConfigModule>
             if (!byMac.TryGetValue(mac, out var adapter))
             {
                 logger.LogWarning(
-                    "Network-config entry '{Name}' references MAC {Mac} but no matching physical adapter is present; skipping.",
+                    "Network-config entry '{Name}' references MAC {Mac} but no matching adapter is present; skipping.",
                     key, mac);
                 continue;
             }

--- a/src/Eryph.GuestServices.Provisioning/Modules/ApplyNetworkConfigModule.cs
+++ b/src/Eryph.GuestServices.Provisioning/Modules/ApplyNetworkConfigModule.cs
@@ -36,8 +36,9 @@ internal sealed class ApplyNetworkConfigModule(ILogger<ApplyNetworkConfigModule>
         }
 
         var adapters = await context.Os.GetNetworkAdaptersAsync(cancellationToken).ConfigureAwait(false);
+        // The enumeration only returns MAC-bearing NICs; match by exact MAC.
         var byMac = adapters
-            .Where(a => a.IsPhysical && !string.IsNullOrEmpty(a.MacAddress))
+            .Where(a => !string.IsNullOrEmpty(a.MacAddress))
             .ToDictionary(a => a.MacAddress, StringComparer.OrdinalIgnoreCase);
 
         foreach (var (key, ethernet) in network.Ethernets)

--- a/src/Eryph.GuestServices.Provisioning/Windows/IWindowsOs.cs
+++ b/src/Eryph.GuestServices.Provisioning/Windows/IWindowsOs.cs
@@ -220,11 +220,9 @@ public interface IWindowsOs
     // Networking — used by ApplyNetworkConfigModule. See RFC 0002.
 
     /// <summary>
-    /// Enumerates the network adapters on this guest. The result is intended
-    /// for MAC-matching against cloud-init network-config and includes both
-    /// physical and virtual adapters; callers should filter on
-    /// <see cref="NetworkAdapterInfo.IsPhysical"/> when only hardware NICs
-    /// are relevant.
+    /// Enumerates the MAC-bearing network adapters on this guest, for
+    /// MAC-matching against cloud-init network-config. Loopback/tunnel
+    /// interfaces and adapters without a usable hardware address are excluded.
     /// </summary>
     Task<IReadOnlyList<NetworkAdapterInfo>> GetNetworkAdaptersAsync(CancellationToken cancellationToken);
 

--- a/src/Eryph.GuestServices.Provisioning/Windows/NetworkAdapterInfo.cs
+++ b/src/Eryph.GuestServices.Provisioning/Windows/NetworkAdapterInfo.cs
@@ -19,8 +19,9 @@ public sealed record NetworkAdapterInfo
 
     /// <summary>
     /// Canonical MAC: 12 lowercase hex digits separated by single colons.
-    /// Adapters without a usable link-layer address are not enumerated, so this
-    /// is always populated.
+    /// <see cref="IWindowsOs.GetNetworkAdaptersAsync"/> only yields adapters
+    /// with a usable hardware address, so values it returns are populated; a
+    /// hand-constructed instance may carry anything.
     /// </summary>
     public required string MacAddress { get; init; }
 }

--- a/src/Eryph.GuestServices.Provisioning/Windows/NetworkAdapterInfo.cs
+++ b/src/Eryph.GuestServices.Provisioning/Windows/NetworkAdapterInfo.cs
@@ -19,14 +19,8 @@ public sealed record NetworkAdapterInfo
 
     /// <summary>
     /// Canonical MAC: 12 lowercase hex digits separated by single colons.
-    /// Empty if the adapter has no link-layer address (loopback, tunnel).
+    /// Adapters without a usable link-layer address are not enumerated, so this
+    /// is always populated.
     /// </summary>
     public required string MacAddress { get; init; }
-
-    /// <summary>
-    /// True iff the adapter is "physical" in the MSFT_NetAdapter sense —
-    /// hardware NIC backed by a driver, not a loopback / tunnel / virtual
-    /// switch endpoint. The applier ignores non-physical adapters per RFC 0002.
-    /// </summary>
-    public required bool IsPhysical { get; init; }
 }

--- a/src/Eryph.GuestServices.Provisioning/Windows/NetworkAdapterInventory.cs
+++ b/src/Eryph.GuestServices.Provisioning/Windows/NetworkAdapterInventory.cs
@@ -1,4 +1,5 @@
 using System.Net.NetworkInformation;
+using System.Runtime.Versioning;
 
 namespace Eryph.GuestServices.Provisioning.Windows;
 
@@ -12,6 +13,7 @@ namespace Eryph.GuestServices.Provisioning.Windows;
 /// lives in <c>PermanentAddress</c>). CIM is still used to <em>set</em>
 /// addresses/DNS/routes, keyed by the interface index resolved here.
 /// </summary>
+[SupportedOSPlatform("windows")]
 internal static class NetworkAdapterInventory
 {
     public static IReadOnlyList<NetworkAdapterInfo> Enumerate()
@@ -19,38 +21,55 @@ internal static class NetworkAdapterInventory
         var results = new List<NetworkAdapterInfo>();
         foreach (var adapter in NetworkInterface.GetAllNetworkInterfaces())
         {
-            // Only adapters that can carry a network-config MAC. Loopback and
-            // tunnel/teredo interfaces never match a delivered Ethernet entry.
-            if (adapter.NetworkInterfaceType is NetworkInterfaceType.Loopback
-                or NetworkInterfaceType.Tunnel)
-                continue;
-
-            var macBytes = adapter.GetPhysicalAddress().GetAddressBytes();
-            if (macBytes.Length != 6)
-                continue;
-
-            var index = TryGetInterfaceIndex(adapter);
-            if (index == 0)
-                continue;
-
-            results.Add(new NetworkAdapterInfo
+            // One transitional/odd adapter must not abort the whole enumeration
+            // (GetIPProperties and the family lookups can throw); skip it.
+            try
             {
-                InterfaceAlias = adapter.Name,
-                InterfaceIndex = index,
-                MacAddress = FormatMac(macBytes),
-                // Everything that survived the filter above is a real,
-                // MAC-bearing NIC the config can target. Matching is by exact
-                // MAC, so any extra virtual adapter simply never matches.
-                IsPhysical = true,
-            });
+                var info = TryDescribe(adapter);
+                if (info is not null)
+                    results.Add(info);
+            }
+            catch (NetworkInformationException)
+            {
+                // Adapter in a transitional state (being removed / not yet
+                // registered) — skip it rather than fail the whole inventory.
+            }
         }
 
         return results;
     }
 
+    private static NetworkAdapterInfo? TryDescribe(NetworkInterface adapter)
+    {
+        // Only adapters that can carry a network-config MAC. Loopback and
+        // tunnel/teredo interfaces never match a delivered Ethernet entry.
+        if (adapter.NetworkInterfaceType is NetworkInterfaceType.Loopback
+            or NetworkInterfaceType.Tunnel)
+            return null;
+
+        var macBytes = adapter.GetPhysicalAddress().GetAddressBytes();
+        // Require a real 6-byte, non-zero MAC. An all-zero address (some
+        // not-yet-up virtual adapters report it) must not become a match key.
+        if (macBytes.Length != 6 || macBytes.All(b => b == 0))
+            return null;
+
+        var index = TryGetInterfaceIndex(adapter);
+        if (index == 0)
+            return null;
+
+        return new NetworkAdapterInfo
+        {
+            InterfaceAlias = adapter.Name,
+            InterfaceIndex = index,
+            MacAddress = FormatMac(macBytes),
+        };
+    }
+
     // The Windows interface index (IfIndex) the CIM set-methods key on. It is
-    // exposed via the IP-family properties; a freshly-booted NIC has at least an
-    // IPv6 link-local, so the IPv4 -> IPv6 fallback covers DHCP and static.
+    // exposed via the IP-family properties; for a dual-stack NIC the IPv4 and
+    // IPv6 indices are the same adapter IfIndex, and the verified path uses the
+    // IPv4 index. A freshly-booted NIC has at least an IPv6 link-local, so the
+    // fallback still yields the index for an otherwise IPv4-less adapter.
     private static int TryGetInterfaceIndex(NetworkInterface adapter)
     {
         var properties = adapter.GetIPProperties();
@@ -60,6 +79,7 @@ internal static class NetworkAdapterInventory
         }
         catch (NetworkInformationException)
         {
+            // IPv4 not configured on this adapter yet — try IPv6 below.
         }
 
         try
@@ -68,6 +88,7 @@ internal static class NetworkAdapterInventory
         }
         catch (NetworkInformationException)
         {
+            // Neither family is configured — no index to drive CIM with.
         }
 
         return 0;

--- a/src/Eryph.GuestServices.Provisioning/Windows/NetworkAdapterInventory.cs
+++ b/src/Eryph.GuestServices.Provisioning/Windows/NetworkAdapterInventory.cs
@@ -13,9 +13,12 @@ namespace Eryph.GuestServices.Provisioning.Windows;
 /// lives in <c>PermanentAddress</c>). CIM is still used to <em>set</em>
 /// addresses/DNS/routes, keyed by the interface index resolved here.
 /// </summary>
-[SupportedOSPlatform("windows")]
 internal static class NetworkAdapterInventory
 {
+    // The IfIndex resolution (GetIPv4Properties().Index) is a Windows concern;
+    // FormatMac below is platform-agnostic, so the attribute sits here, not on
+    // the class.
+    [SupportedOSPlatform("windows")]
     public static IReadOnlyList<NetworkAdapterInfo> Enumerate()
     {
         var results = new List<NetworkAdapterInfo>();

--- a/src/Eryph.GuestServices.Provisioning/Windows/NetworkAdapterInventory.cs
+++ b/src/Eryph.GuestServices.Provisioning/Windows/NetworkAdapterInventory.cs
@@ -1,0 +1,79 @@
+using System.Net.NetworkInformation;
+
+namespace Eryph.GuestServices.Provisioning.Windows;
+
+/// <summary>
+/// Enumerates the guest's network adapters and their MAC addresses with the
+/// built-in <see cref="NetworkInterface"/> APIs. The MAC comes from
+/// <see cref="NetworkInterface.GetPhysicalAddress"/> (the hardware address),
+/// which is reliable across NIC types and platforms — unlike the
+/// <c>MSFT_NetAdapter.MacAddress</c> CIM property, which is empty unless the OS
+/// overrides the MAC (so a Hyper-V vNIC reports it blank and the address only
+/// lives in <c>PermanentAddress</c>). CIM is still used to <em>set</em>
+/// addresses/DNS/routes, keyed by the interface index resolved here.
+/// </summary>
+internal static class NetworkAdapterInventory
+{
+    public static IReadOnlyList<NetworkAdapterInfo> Enumerate()
+    {
+        var results = new List<NetworkAdapterInfo>();
+        foreach (var adapter in NetworkInterface.GetAllNetworkInterfaces())
+        {
+            // Only adapters that can carry a network-config MAC. Loopback and
+            // tunnel/teredo interfaces never match a delivered Ethernet entry.
+            if (adapter.NetworkInterfaceType is NetworkInterfaceType.Loopback
+                or NetworkInterfaceType.Tunnel)
+                continue;
+
+            var macBytes = adapter.GetPhysicalAddress().GetAddressBytes();
+            if (macBytes.Length != 6)
+                continue;
+
+            var index = TryGetInterfaceIndex(adapter);
+            if (index == 0)
+                continue;
+
+            results.Add(new NetworkAdapterInfo
+            {
+                InterfaceAlias = adapter.Name,
+                InterfaceIndex = index,
+                MacAddress = FormatMac(macBytes),
+                // Everything that survived the filter above is a real,
+                // MAC-bearing NIC the config can target. Matching is by exact
+                // MAC, so any extra virtual adapter simply never matches.
+                IsPhysical = true,
+            });
+        }
+
+        return results;
+    }
+
+    // The Windows interface index (IfIndex) the CIM set-methods key on. It is
+    // exposed via the IP-family properties; a freshly-booted NIC has at least an
+    // IPv6 link-local, so the IPv4 -> IPv6 fallback covers DHCP and static.
+    private static int TryGetInterfaceIndex(NetworkInterface adapter)
+    {
+        var properties = adapter.GetIPProperties();
+        try
+        {
+            return properties.GetIPv4Properties().Index;
+        }
+        catch (NetworkInformationException)
+        {
+        }
+
+        try
+        {
+            return properties.GetIPv6Properties().Index;
+        }
+        catch (NetworkInformationException)
+        {
+        }
+
+        return 0;
+    }
+
+    // Lowercase, colon-separated — the cloud-init form the matcher normalises to.
+    internal static string FormatMac(byte[] mac) =>
+        string.Join(':', mac.Select(b => b.ToString("x2")));
+}

--- a/src/Eryph.GuestServices.Provisioning/Windows/Win32/CimNetworking.cs
+++ b/src/Eryph.GuestServices.Provisioning/Windows/Win32/CimNetworking.cs
@@ -25,52 +25,6 @@ internal static class CimNetworking
 {
     private const string StandardCimNamespace = @"root\StandardCimv2";
 
-    public static IReadOnlyList<NetworkAdapterInfo> EnumerateAdapters()
-    {
-        using var session = CimSession.Create(null);
-
-        var results = new List<NetworkAdapterInfo>();
-        // MSFT_NetAdapter surfaces both physical and virtual NICs; the
-        // ConnectorPresent boolean is the most reliable "this is a hardware
-        // NIC" indicator (it's set for real NDIS adapters and false for
-        // loopback / tunnel / virtual switch endpoints).
-        foreach (var instance in session.EnumerateInstances(StandardCimNamespace, "MSFT_NetAdapter"))
-        {
-            using (instance)
-            {
-                var ifIndex = GetUInt32(instance, "InterfaceIndex");
-                if (ifIndex == 0)
-                    continue;
-
-                var alias = GetString(instance, "Name")
-                    ?? GetString(instance, "InterfaceAlias")
-                    ?? $"Interface {ifIndex}";
-
-                // MacAddress as MSFT_NetAdapter reports it is uppercase with
-                // hyphens ("AA-BB-CC-DD-EE-FF"). Cloud-init style is lowercase
-                // colon-separated; normalise so callers can compare directly.
-                var mac = NormaliseMac(GetString(instance, "MacAddress"));
-
-                // Physical NICs report ConnectorPresent=true. Falling back to
-                // the "Virtual" flag (when present) handles older hosts that
-                // don't expose ConnectorPresent uniformly.
-                var connectorPresent = GetBoolean(instance, "ConnectorPresent");
-                var isVirtual = GetBoolean(instance, "Virtual");
-                var isPhysical = (connectorPresent ?? false) && !(isVirtual ?? false);
-
-                results.Add(new NetworkAdapterInfo
-                {
-                    InterfaceAlias = alias,
-                    InterfaceIndex = (int)ifIndex,
-                    MacAddress = mac,
-                    IsPhysical = isPhysical,
-                });
-            }
-        }
-
-        return results;
-    }
-
     public static void SetDhcp(int interfaceIndex, bool enabled)
     {
         using var session = CimSession.Create(null);
@@ -560,54 +514,8 @@ internal static class CimNetworking
                 $"{operation} failed with CIM return code {rc}.");
     }
 
-    private static uint GetUInt32(CimInstance instance, string property)
-    {
-        var value = instance.CimInstanceProperties[property]?.Value;
-        return value switch
-        {
-            uint u => u,
-            int i => (uint)i,
-            ushort s => s,
-            _ => 0u,
-        };
-    }
-
     private static string? GetString(CimInstance instance, string property) =>
         instance.CimInstanceProperties[property]?.Value as string;
-
-    private static bool? GetBoolean(CimInstance instance, string property) =>
-        instance.CimInstanceProperties[property]?.Value as bool?;
-
-    private static string NormaliseMac(string? raw)
-    {
-        if (string.IsNullOrWhiteSpace(raw))
-            return string.Empty;
-
-        var hex = new char[12];
-        var n = 0;
-        foreach (var ch in raw)
-        {
-            if (n == 12) break;
-            if (IsHexDigit(ch))
-                hex[n++] = char.ToLowerInvariant(ch);
-        }
-        if (n != 12)
-            return string.Empty;
-
-        return string.Create(17, hex, (span, src) =>
-        {
-            for (var i = 0; i < 6; i++)
-            {
-                span[i * 3] = src[i * 2];
-                span[i * 3 + 1] = src[i * 2 + 1];
-                if (i < 5)
-                    span[i * 3 + 2] = ':';
-            }
-        });
-    }
-
-    private static bool IsHexDigit(char c) =>
-        (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
 
     private static (string Address, int Prefix) ParseCidr(string cidr)
     {

--- a/src/Eryph.GuestServices.Provisioning/Windows/WindowsOs.cs
+++ b/src/Eryph.GuestServices.Provisioning/Windows/WindowsOs.cs
@@ -452,7 +452,7 @@ internal sealed class WindowsOs : IWindowsOs
     }
 
     public Task<IReadOnlyList<NetworkAdapterInfo>> GetNetworkAdaptersAsync(CancellationToken cancellationToken) =>
-        Task.Run(() => CimNetworking.EnumerateAdapters(), cancellationToken);
+        Task.Run(() => NetworkAdapterInventory.Enumerate(), cancellationToken);
 
     public Task EnableDhcpAsync(int interfaceIndex, CancellationToken cancellationToken) =>
         Task.Run(() => CimNetworking.SetDhcp(interfaceIndex, enabled: true), cancellationToken);

--- a/test/Eryph.GuestServices.Provisioning.Tests/Modules/ApplyNetworkConfigModuleTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Modules/ApplyNetworkConfigModuleTests.cs
@@ -34,7 +34,7 @@ public sealed class ApplyNetworkConfigModuleTests
         return new TestModuleContext(os, dataSource);
     }
 
-    private static NetworkAdapterInfo Physical(string alias, int ifIndex, string mac) =>
+    private static NetworkAdapterInfo Adapter(string alias, int ifIndex, string mac) =>
         new()
         {
             InterfaceAlias = alias,
@@ -82,7 +82,7 @@ public sealed class ApplyNetworkConfigModuleTests
         os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
             .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
             {
-                [Physical("Ethernet", 12, "d2:ab:04:5a:29:47")],
+                [Adapter("Ethernet", 12, "d2:ab:04:5a:29:47")],
             }[0]);
 
         var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
@@ -116,7 +116,7 @@ public sealed class ApplyNetworkConfigModuleTests
         os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
             .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
             {
-                [Physical("Ethernet", 7, "00:11:22:33:44:55")],
+                [Adapter("Ethernet", 7, "00:11:22:33:44:55")],
             }[0]);
 
         var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
@@ -159,7 +159,7 @@ public sealed class ApplyNetworkConfigModuleTests
         os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
             .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
             {
-                [Physical("Ethernet", 9, "00:11:22:33:44:55")],
+                [Adapter("Ethernet", 9, "00:11:22:33:44:55")],
             }[0]);
 
         var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
@@ -202,7 +202,7 @@ public sealed class ApplyNetworkConfigModuleTests
         os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
             .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
             {
-                [Physical("Ethernet", 1, "00:11:22:33:44:55")],
+                [Adapter("Ethernet", 1, "00:11:22:33:44:55")],
             }[0]);
 
         var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
@@ -238,7 +238,7 @@ public sealed class ApplyNetworkConfigModuleTests
         os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
             .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
             {
-                [Physical("Ethernet", 1, "00:11:22:33:44:55")],
+                [Adapter("Ethernet", 1, "00:11:22:33:44:55")],
             }[0]);
 
         var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
@@ -267,7 +267,7 @@ public sealed class ApplyNetworkConfigModuleTests
         os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
             .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
             {
-                [Physical("Ethernet", 7, "00:11:22:33:44:55")],
+                [Adapter("Ethernet", 7, "00:11:22:33:44:55")],
             }[0]);
 
         var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
@@ -310,7 +310,7 @@ public sealed class ApplyNetworkConfigModuleTests
         os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
             .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
             {
-                [Physical("Ethernet", 11, "00:11:22:33:44:55")],
+                [Adapter("Ethernet", 11, "00:11:22:33:44:55")],
             }[0]);
 
         var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
@@ -360,7 +360,7 @@ public sealed class ApplyNetworkConfigModuleTests
         os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
             .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
             {
-                [Physical("Ethernet", 13, "00:11:22:33:44:55")],
+                [Adapter("Ethernet", 13, "00:11:22:33:44:55")],
             }[0]);
 
         var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
@@ -411,7 +411,7 @@ public sealed class ApplyNetworkConfigModuleTests
         os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
             .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
             {
-                [Physical("Ethernet", 15, "00:11:22:33:44:55")],
+                [Adapter("Ethernet", 15, "00:11:22:33:44:55")],
             }[0]);
 
         var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
@@ -458,7 +458,7 @@ public sealed class ApplyNetworkConfigModuleTests
         os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
             .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
             {
-                [Physical("Ethernet", 17, "00:11:22:33:44:55")],
+                [Adapter("Ethernet", 17, "00:11:22:33:44:55")],
             }[0]);
 
         var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
@@ -505,7 +505,7 @@ public sealed class ApplyNetworkConfigModuleTests
         os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
             .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
             {
-                [Physical("Ethernet", 19, "00:11:22:33:44:55")],
+                [Adapter("Ethernet", 19, "00:11:22:33:44:55")],
             }[0]);
 
         var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
@@ -548,7 +548,7 @@ public sealed class ApplyNetworkConfigModuleTests
         os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
             .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
             {
-                [Physical("Ethernet", 21, "00:11:22:33:44:55")],
+                [Adapter("Ethernet", 21, "00:11:22:33:44:55")],
             }[0]);
 
         var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
@@ -603,7 +603,7 @@ public sealed class ApplyNetworkConfigModuleTests
         os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
             .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
             {
-                [Physical("Ethernet", 5, "aa:bb:cc:dd:ee:ff")],
+                [Adapter("Ethernet", 5, "aa:bb:cc:dd:ee:ff")],
             }[0]);
 
         var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
@@ -615,5 +615,46 @@ public sealed class ApplyNetworkConfigModuleTests
 
         result.Should().BeOfType<ModuleOutcome.Completed>();
         await os.Received(1).EnableDhcpAsync(5, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Duplicate_MAC_does_not_throw_and_lowest_index_wins()
+    {
+        // Two adapters can legitimately report the same MAC (a NIC team and a
+        // member, a bridged pair). The matcher must not throw on the duplicate
+        // and must pick deterministically: the lowest interface index.
+        var network = new NetworkConfig
+        {
+            Version = 2,
+            Ethernets = new Dictionary<string, NetworkEthernetConfig>
+            {
+                ["eth0"] = new()
+                {
+                    MacAddress = "00:11:22:33:44:55",
+                    Dhcp4 = true,
+                },
+            },
+        };
+
+        var os = Substitute.For<IWindowsOs>();
+        os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
+            .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
+            {
+                [
+                    Adapter("Ethernet 2", 23, "00:11:22:33:44:55"),
+                    Adapter("Ethernet", 12, "00:11:22:33:44:55"),
+                ],
+            }[0]);
+
+        var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
+
+        var result = await module.ApplyAsync(
+            ResolvedUserData.Empty(new CloudConfigModel()),
+            BuildContext(os, network),
+            CancellationToken.None);
+
+        result.Should().BeOfType<ModuleOutcome.Completed>();
+        await os.Received(1).EnableDhcpAsync(12, Arg.Any<CancellationToken>());
+        await os.DidNotReceive().EnableDhcpAsync(23, Arg.Any<CancellationToken>());
     }
 }

--- a/test/Eryph.GuestServices.Provisioning.Tests/Modules/ApplyNetworkConfigModuleTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Modules/ApplyNetworkConfigModuleTests.cs
@@ -40,7 +40,6 @@ public sealed class ApplyNetworkConfigModuleTests
             InterfaceAlias = alias,
             InterfaceIndex = ifIndex,
             MacAddress = mac,
-            IsPhysical = true,
         };
 
     [Fact]

--- a/test/Eryph.GuestServices.Provisioning.Tests/Windows/NetworkAdapterInventoryTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Windows/NetworkAdapterInventoryTests.cs
@@ -1,0 +1,32 @@
+using System.Text.RegularExpressions;
+using AwesomeAssertions;
+using Eryph.GuestServices.Provisioning.Windows;
+
+namespace Eryph.GuestServices.Provisioning.Tests.Windows;
+
+public class NetworkAdapterInventoryTests
+{
+    [Fact]
+    public void FormatMac_produces_lowercase_colon_separated()
+    {
+        var bytes = new byte[] { 0xD2, 0xAB, 0x1C, 0x28, 0x5F, 0xB2 };
+
+        NetworkAdapterInventory.FormatMac(bytes).Should().Be("d2:ab:1c:28:5f:b2");
+    }
+
+    [Fact]
+    public void Enumerate_returns_adapters_with_a_real_mac_and_index()
+    {
+        // Regression for the empty-MAC bug: the .NET enumeration must surface a
+        // usable hardware MAC (GetPhysicalAddress), not the blank
+        // MSFT_NetAdapter.MacAddress. Tolerant of a NIC-less environment: it
+        // only asserts the shape of whatever adapters are present.
+        var adapters = NetworkAdapterInventory.Enumerate();
+
+        adapters.Should().OnlyContain(a =>
+            Regex.IsMatch(a.MacAddress, "^[0-9a-f]{2}(:[0-9a-f]{2}){5}$")
+            && a.InterfaceIndex > 0
+            && a.IsPhysical
+            && !string.IsNullOrEmpty(a.InterfaceAlias));
+    }
+}

--- a/test/Eryph.GuestServices.Provisioning.Tests/Windows/NetworkAdapterInventoryTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Windows/NetworkAdapterInventoryTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
 using AwesomeAssertions;
 using Eryph.GuestServices.Provisioning.Windows;
@@ -6,27 +7,29 @@ namespace Eryph.GuestServices.Provisioning.Tests.Windows;
 
 public class NetworkAdapterInventoryTests
 {
-    [Fact]
-    public void FormatMac_produces_lowercase_colon_separated()
+    [Theory]
+    [InlineData(new byte[] { 0xD2, 0xAB, 0x1C, 0x28, 0x5F, 0xB2 }, "d2:ab:1c:28:5f:b2")]
+    [InlineData(new byte[] { 0x00, 0x0E, 0x1C, 0x00, 0x5F, 0x00 }, "00:0e:1c:00:5f:00")] // leading-zero nibbles
+    [InlineData(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, "ff:ff:ff:ff:ff:ff")]
+    public void FormatMac_produces_lowercase_colon_separated_with_leading_zeros(byte[] bytes, string expected)
     {
-        var bytes = new byte[] { 0xD2, 0xAB, 0x1C, 0x28, 0x5F, 0xB2 };
-
-        NetworkAdapterInventory.FormatMac(bytes).Should().Be("d2:ab:1c:28:5f:b2");
+        NetworkAdapterInventory.FormatMac(bytes).Should().Be(expected);
     }
 
     [Fact]
+    [SupportedOSPlatform("windows")]
     public void Enumerate_returns_adapters_with_a_real_mac_and_index()
     {
         // Regression for the empty-MAC bug: the .NET enumeration must surface a
         // usable hardware MAC (GetPhysicalAddress), not the blank
-        // MSFT_NetAdapter.MacAddress. Tolerant of a NIC-less environment: it
-        // only asserts the shape of whatever adapters are present.
+        // MSFT_NetAdapter.MacAddress. Asserts the build host has at least one
+        // MAC-bearing NIC and every entry is well-formed (non-vacuous).
         var adapters = NetworkAdapterInventory.Enumerate();
 
+        adapters.Should().NotBeEmpty();
         adapters.Should().OnlyContain(a =>
             Regex.IsMatch(a.MacAddress, "^[0-9a-f]{2}(:[0-9a-f]{2}){5}$")
             && a.InterfaceIndex > 0
-            && a.IsPhysical
             && !string.IsNullOrEmpty(a.InterfaceAlias));
     }
 }

--- a/test/Eryph.GuestServices.Provisioning.Tests/Windows/NetworkAdapterInventoryTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Windows/NetworkAdapterInventoryTests.cs
@@ -1,4 +1,3 @@
-using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
 using AwesomeAssertions;
 using Eryph.GuestServices.Provisioning.Windows;
@@ -17,9 +16,13 @@ public class NetworkAdapterInventoryTests
     }
 
     [Fact]
-    [SupportedOSPlatform("windows")]
     public void Enumerate_returns_adapters_with_a_real_mac_and_index()
     {
+        // Touches the host's real adapters, so gate to Windows per the repo
+        // convention (the inventory is Windows-only and a Linux runner has no
+        // CIM/IfIndex semantics to assert against).
+        if (!OperatingSystem.IsWindows()) return;
+
         // Regression for the empty-MAC bug: the .NET enumeration must surface a
         // usable hardware MAC (GetPhysicalAddress), not the blank
         // MSFT_NetAdapter.MacAddress. Asserts the build host has at least one

--- a/test/e2e/Provisioning.E2E.Tests.ps1
+++ b/test/e2e/Provisioning.E2E.Tests.ps1
@@ -442,10 +442,10 @@ Add-Type -AssemblyName System.IO.Compression.FileSystem; $z=[System.IO.Compressi
       # Regression for issue #53: the module enumerates adapters via .NET
       # NetworkInterface.GetPhysicalAddress, so it finds the eth0 NIC by MAC and
       # applies the eryph (DHCP) network-config instead of logging "no matching
-      # physical adapter; skipping" — which is what the empty
-      # MSFT_NetAdapter.MacAddress used to cause. Asserted from the agent log,
-      # pulled host-side via download-file and matched as booleans so no log
-      # content is echoed on failure.
+      # adapter; skipping" — which is what the empty MSFT_NetAdapter.MacAddress
+      # used to cause. Asserted from the agent log, pulled host-side via
+      # download-file and matched as booleans so no log content is echoed on
+      # failure.
       $localLog = Join-Path ([System.IO.Path]::GetTempPath()) "egs-net-$($catlet.VmId).log"
       Remove-Item $localLog -ErrorAction SilentlyContinue
       egs-tool download-file $catlet.VmId 'C:\ProgramData\eryph\guest-services\logs\agent.log' $localLog
@@ -454,7 +454,7 @@ Add-Type -AssemblyName System.IO.Compression.FileSystem; $z=[System.IO.Compressi
       # The DHCP apply path logs "DHCP requested — leaving IPv4 alone" only after
       # the adapter is matched.
       $matched = [bool](Select-String -LiteralPath $localLog -Pattern 'DHCP requested' -Quiet)
-      $skipped = [bool](Select-String -LiteralPath $localLog -Pattern 'no matching physical adapter' -Quiet)
+      $skipped = [bool](Select-String -LiteralPath $localLog -Pattern 'no matching adapter' -Quiet)
       $matched | Should -BeTrue
       $skipped | Should -BeFalse
     }

--- a/test/e2e/Provisioning.E2E.Tests.ps1
+++ b/test/e2e/Provisioning.E2E.Tests.ps1
@@ -435,4 +435,28 @@ Add-Type -AssemblyName System.IO.Compression.FileSystem; $z=[System.IO.Compressi
       [int]($r.Output.Trim() -replace 'agent\.log=', '') | Should -BeGreaterThan 0
     }
   }
+
+  Context 'network-config' {
+
+    It 'matched the NIC by MAC and applied the network-config (not skipped)' {
+      # Regression for issue #53: the module enumerates adapters via .NET
+      # NetworkInterface.GetPhysicalAddress, so it finds the eth0 NIC by MAC and
+      # applies the eryph (DHCP) network-config instead of logging "no matching
+      # physical adapter; skipping" — which is what the empty
+      # MSFT_NetAdapter.MacAddress used to cause. Asserted from the agent log,
+      # pulled host-side via download-file and matched as booleans so no log
+      # content is echoed on failure.
+      $localLog = Join-Path ([System.IO.Path]::GetTempPath()) "egs-net-$($catlet.VmId).log"
+      Remove-Item $localLog -ErrorAction SilentlyContinue
+      egs-tool download-file $catlet.VmId 'C:\ProgramData\eryph\guest-services\logs\agent.log' $localLog
+      Test-Path $localLog | Should -BeTrue
+
+      # The DHCP apply path logs "DHCP requested — leaving IPv4 alone" only after
+      # the adapter is matched.
+      $matched = [bool](Select-String -LiteralPath $localLog -Pattern 'DHCP requested' -Quiet)
+      $skipped = [bool](Select-String -LiteralPath $localLog -Pattern 'no matching physical adapter' -Quiet)
+      $matched | Should -BeTrue
+      $skipped | Should -BeFalse
+    }
+  }
 }


### PR DESCRIPTION
`ApplyNetworkConfigModule` matched the cloud-init network-config to guest NICs by MAC, but read the MAC from `MSFT_NetAdapter.MacAddress` — which is empty unless the OS overrides the MAC (a Hyper-V vNIC reports it blank; the address only lives in `PermanentAddress`). The empty MAC dropped every adapter from the match map, so each config entry hit "no matching physical adapter; skipping" and the network-config was never applied. This affects Windows guests generally, not just Hyper-V.

Fix: enumerate adapters and read MACs with the built-in `NetworkInterface.GetPhysicalAddress()` (the hardware address) plus the IP-family interface index. CIM is still used to *set* addresses/DNS/routes, keyed by that index. Removes the dead `CimNetworking.EnumerateAdapters` and its helpers.

Tested: unit tests for the MAC formatter and the inventory shape; an e2e assertion that the module matches the NIC and applies the config (rather than logging the skip warning), validated on a winsrv2022 catlet.

Fixes #53.