### PR TITLE
Add opt-in SSH port forwarding (PortForwardingEnabled)

### DIFF
--- a/docs/user/reference/modules.md
+++ b/docs/user/reference/modules.md
@@ -126,6 +126,7 @@ egs:
     remote_access: true     # the SSH transport egs-tool connects to
     provisioning: false     # disable further first-boot provisioning
     kvp_auth: true          # honor client keys pushed via Hyper-V KVP
+    port_forwarding: true   # opt-in; allow SSH tunneling (-L/-R) through the guest
   update:
     enabled: true           # opt-in; no update unless true
     channel: stable         # stable (default) | unstable
@@ -135,9 +136,10 @@ egs:
 ### settings
 
 Each switch maps to a service-control flag (see [settings](settings.md#service-control)).
-All three are three-state: omit a switch to leave it untouched. The flags are
-read at the next service start, so a change made during provisioning takes
-effect after the agent restarts.
+All are three-state: omit a switch to leave it untouched. `port_forwarding` is
+opt-in (off unless set to `true`); the others are opt-out (on unless set to
+`false`). The flags are read at the next service start, so a change made during
+provisioning takes effect after the agent restarts.
 
 ### update
 

--- a/docs/user/reference/settings.md
+++ b/docs/user/reference/settings.md
@@ -130,10 +130,21 @@ provisioning tunables above.
 | `RemoteAccessEnabled` | The remote-access transport `egs-tool` connects to. | on |
 | `KvpAuthEnabled` | Honoring of authorized client keys delivered via Hyper-V data exchange. When off, only the locally provisioned key in `id_egs.pub` authorizes — pushes via `egs-tool add-ssh-config` and other KVP writers are ignored. | on |
 | `AutoUpdateEnabled` | The background auto-patch loop that keeps the agent updated over the machine's lifetime (Windows). When off, the agent never self-updates on its own. | on |
+| `PortForwardingEnabled` | SSH port forwarding / tunneling (`ssh -L` / `-R`) over the remote-access transport. **Opt-in** — see below. | off |
 
-All are opt-out: a capability is on unless the value is set to `0`. A missing
-value, a read error, or an unknown OS all leave it on. The flags are read at
-service start, so restart `eryph-guest-services` after changing them.
+All but `PortForwardingEnabled` are opt-out: a capability is on unless the value
+is set to `0`. A missing value, a read error, or an unknown OS all leave it on.
+
+`PortForwardingEnabled` is the lone **opt-in** switch: it is off unless the value
+is explicitly set (`1` on Windows, `1`/`true` on Linux). A missing value or a
+read error leaves it **off**, so tunneling is never silently open. Turn it on
+where the guest is meant to act as a jump host — when on, a connected client can
+reach arbitrary `host:port` endpoints through the guest, so leave it off
+otherwise. The service advertises a `port-forwarding` entry in its feature list
+(`eryph:guest-services:features`) when forwarding is enabled.
+
+The flags are read at service start, so restart `eryph-guest-services` after
+changing them.
 
 `AutoUpdateEnabled` runs on every long-running guest — remote-access-only AND
 provisioned — so provisioned machines keep getting patched too. It checks the
@@ -156,6 +167,8 @@ Set-ItemProperty -Path 'HKLM:\SOFTWARE\eryph\guest-services' -Name 'Provisioning
 Set-ItemProperty -Path 'HKLM:\SOFTWARE\eryph\guest-services' -Name 'RemoteAccessEnabled' -Type DWord -Value 0
 Set-ItemProperty -Path 'HKLM:\SOFTWARE\eryph\guest-services' -Name 'KvpAuthEnabled' -Type DWord -Value 0
 Set-ItemProperty -Path 'HKLM:\SOFTWARE\eryph\guest-services' -Name 'AutoUpdateEnabled' -Type DWord -Value 0
+# Opt-in: set to 1 to allow SSH tunneling (ssh -L / -R) through the guest.
+Set-ItemProperty -Path 'HKLM:\SOFTWARE\eryph\guest-services' -Name 'PortForwardingEnabled' -Type DWord -Value 1
 Restart-Service -Name eryph-guest-services
 ```
 
@@ -171,8 +184,11 @@ sudo tee /etc/opt/eryph/guest-services/service-control.conf <<EOF
 ProvisioningEnabled=0
 RemoteAccessEnabled=0
 KvpAuthEnabled=0
+PortForwardingEnabled=1
 EOF
 sudo systemctl restart eryph-guest-services
 ```
 
-Set values back to `1` (or delete the value / file) and restart to re-enable.
+`PortForwardingEnabled` is opt-in, so the line above *enables* tunneling; omit it
+(or set it to `0`) to keep forwarding closed. For the opt-out flags, set values
+back to `1` (or delete the value / file) and restart to re-enable.

--- a/src/Eryph.GuestServices.CloudConfig/Configs/EgsConfig.cs
+++ b/src/Eryph.GuestServices.CloudConfig/Configs/EgsConfig.cs
@@ -15,7 +15,7 @@ public sealed record EgsConfig
     /// surface the service reads at start (Windows registry
     /// <c>HKLM\SOFTWARE\eryph\guest-services</c>).
     /// </summary>
-    [CloudInitField(Platforms = CloudInitPlatforms.Windows, Description = "eryph guest-services capability switches (remote access / provisioning / kvp auth)")]
+    [CloudInitField(Platforms = CloudInitPlatforms.Windows, Description = "eryph guest-services capability switches (remote access / provisioning / kvp auth / port forwarding)")]
     public EgsSettingsConfig? Settings { get; init; }
 
     /// <summary>
@@ -27,11 +27,11 @@ public sealed record EgsConfig
 }
 
 /// <summary>
-/// The three opt-out capability switches, mirroring
-/// <c>IServiceControlFlags</c>. Each is three-state: <c>null</c> leaves the
-/// flag untouched, <c>true</c>/<c>false</c> writes the switch. The values are
-/// read at the next service start, so a change made during provisioning takes
-/// effect after the agent restarts — not mid-run.
+/// The operator capability switches, mirroring <c>IServiceControlFlags</c>.
+/// Each is three-state: <c>null</c> leaves the flag untouched,
+/// <c>true</c>/<c>false</c> writes the switch. The values are read at the next
+/// service start, so a change made during provisioning takes effect after the
+/// agent restarts — not mid-run.
 /// </summary>
 [CloudInitRecord]
 public sealed record EgsSettingsConfig
@@ -54,4 +54,11 @@ public sealed record EgsSettingsConfig
     /// authority over guest access.
     /// </summary>
     public bool? KvpAuth { get; init; }
+
+    /// <summary>
+    /// Gates SSH port forwarding / tunneling (<c>ssh -L</c> / <c>-R</c>) over the
+    /// remote-access transport. <b>Opt-in</b>: it is off unless set to
+    /// <c>true</c>, so leaving this unset keeps tunneling closed.
+    /// </summary>
+    public bool? PortForwarding { get; init; }
 }

--- a/src/Eryph.GuestServices.Core/Constants.cs
+++ b/src/Eryph.GuestServices.Core/Constants.cs
@@ -43,6 +43,14 @@ public static class Constants
     /// </summary>
     public static readonly string ShellOverrideFeature = "shell-override";
 
+    /// <summary>
+    /// Feature flag advertised by services that have SSH port forwarding /
+    /// tunneling enabled (the opt-in <c>PortForwardingEnabled</c> switch). Absent
+    /// when forwarding is off, so a client can tell whether <c>-L</c>/<c>-R</c>
+    /// will be honored before attempting it.
+    /// </summary>
+    public static readonly string PortForwardingFeature = "port-forwarding";
+
     public static readonly string ClientAuthKey = "eryph:guest-services:client-public-key";
 
     /// <summary>

--- a/src/Eryph.GuestServices.Core/ServiceControlFlags.cs
+++ b/src/Eryph.GuestServices.Core/ServiceControlFlags.cs
@@ -22,14 +22,20 @@ public enum ServiceControlFlag
 
     /// <summary>The standalone background auto-patch loop (<c>AutoUpdateEnabled</c>).</summary>
     AutoUpdate,
+
+    /// <summary>SSH port forwarding / tunneling (<c>PortForwardingEnabled</c>).</summary>
+    PortForwarding,
 }
 
 /// <summary>
 /// Operator on/off switches for the top-level guest-services capabilities.
-/// All flags are <b>opt-out</b>: a capability is ON unless an operator has
-/// explicitly turned it off. This is an injectable seam so the gated services
-/// (provisioning agent, remote-access transport, KVP-auth honoring) can be
-/// unit-tested without touching the real config sources.
+/// Most flags are <b>opt-out</b>: a capability is ON unless an operator has
+/// explicitly turned it off. The exception is <see cref="IsPortForwardingEnabled"/>,
+/// which is <b>opt-in</b> (OFF unless explicitly turned on) because tunneling
+/// widens the guest's exposure and should never be open by default. This is an
+/// injectable seam so the gated services (provisioning agent, remote-access
+/// transport, KVP-auth honoring, port forwarding) can be unit-tested without
+/// touching the real config sources.
 /// </summary>
 public interface IServiceControlFlags
 {
@@ -67,6 +73,17 @@ public interface IServiceControlFlags
     /// updates centrally set it to <c>0</c>.
     /// </summary>
     bool IsAutoUpdateEnabled();
+
+    /// <summary>
+    /// Gates SSH port forwarding / tunneling over the remote-access transport
+    /// (<c>direct-tcpip</c> for <c>ssh -L</c> and <c>tcpip-forward</c> for
+    /// <c>ssh -R</c>). Unlike the other switches this is <b>opt-in</b>:
+    /// <c>false</c> unless an operator turned it on. Tunneling lets a connected
+    /// client reach arbitrary host:port endpoints through the guest, so it stays
+    /// closed by default and is opened deliberately where the guest is meant to
+    /// act as a jump host.
+    /// </summary>
+    bool IsPortForwardingEnabled();
 }
 
 /// <summary>
@@ -81,11 +98,13 @@ public interface IServiceControlFlags
 /// </list>
 /// </summary>
 /// <remarks>
-/// These are <b>fail-open</b> flags: a missing key/value, missing file, or any
-/// I/O / permission error yields <c>true</c>. We never disable a capability
-/// because of a read error — only an explicit <c>0</c> (or <c>false</c> on
-/// Linux) turns a capability off. The value→bool interpretation lives in two
-/// pure helpers — <see cref="InterpretWindowsRegistryValue"/> for the
+/// Each flag fails to its own default: a missing key/value, missing file, or any
+/// I/O / permission error yields the flag's <c>defaultWhenUnset</c>. The opt-out
+/// flags default <c>true</c> (fail-open — we never disable a capability because
+/// of a read error; only an explicit <c>0</c> / <c>false</c> turns them off);
+/// the opt-in port-forwarding flag defaults <c>false</c>, so an unreadable
+/// config never silently opens tunneling. The value→bool interpretation lives in
+/// two pure helpers — <see cref="InterpretWindowsRegistryValue"/> for the
 /// REG_DWORD path and <see cref="InterpretLinuxConfigValue"/> for the
 /// KEY=VALUE path — kept separate so a mistyped REG_SZ on Windows cannot
 /// accidentally exercise the Linux string-parsing rules. Platform-gated reads
@@ -105,6 +124,7 @@ public sealed class PlatformServiceControlFlags : IServiceControlFlags
     internal const string RemoteAccessEnabledValue = "RemoteAccessEnabled";
     internal const string KvpAuthEnabledValue = "KvpAuthEnabled";
     internal const string AutoUpdateEnabledValue = "AutoUpdateEnabled";
+    internal const string PortForwardingEnabledValue = "PortForwardingEnabled";
 
     /// <summary>
     /// Persisted value name for a flag — the REG_DWORD value name on Windows
@@ -117,6 +137,7 @@ public sealed class PlatformServiceControlFlags : IServiceControlFlags
         ServiceControlFlag.RemoteAccess => RemoteAccessEnabledValue,
         ServiceControlFlag.KvpAuth => KvpAuthEnabledValue,
         ServiceControlFlag.AutoUpdate => AutoUpdateEnabledValue,
+        ServiceControlFlag.PortForwarding => PortForwardingEnabledValue,
         _ => throw new ArgumentOutOfRangeException(nameof(flag), flag, "Unknown service-control flag."),
     };
 
@@ -128,63 +149,72 @@ public sealed class PlatformServiceControlFlags : IServiceControlFlags
 
     public bool IsAutoUpdateEnabled() => ReadFlag(AutoUpdateEnabledValue);
 
-    /// <summary>
-    /// Pure value→bool interpretation for a Windows REG_DWORD opt-out flag.
-    /// Off iff the registry value is the integer <c>0</c>. Anything else —
-    /// <see langword="null"/>, a REG_SZ string (even <c>"0"</c>), an
-    /// unrecognised kind — yields <c>true</c> (default ON / fail-open).
-    /// The documented Windows control surface is REG_DWORD only; honouring
-    /// strings would silently change long-standing behaviour.
-    /// </summary>
-    internal static bool InterpretWindowsRegistryValue(object? regValue) =>
-        regValue is int i ? i != 0 : true;
+    // Opt-in (default OFF): port forwarding stays closed unless an operator
+    // explicitly turns it on. A missing value / read error therefore yields
+    // false, so an unreadable config can never silently open tunneling.
+    public bool IsPortForwardingEnabled() => ReadFlag(PortForwardingEnabledValue, defaultWhenUnset: false);
 
     /// <summary>
-    /// Pure value→bool interpretation for a Linux config-file opt-out flag.
-    /// Off iff the value is the literal string <c>"0"</c> or <c>"false"</c>
-    /// (case-insensitive, whitespace tolerated). Anything else — including
-    /// <see langword="null"/>, empty, or unparseable strings — yields
-    /// <c>true</c> (default ON / fail-open).
+    /// Pure value→bool interpretation for a Windows REG_DWORD flag.
+    /// On iff the registry value is a non-zero integer, off iff it is the
+    /// integer <c>0</c>. Anything else — <see langword="null"/>, a REG_SZ string
+    /// (even <c>"0"</c>), an unrecognised kind — yields
+    /// <paramref name="defaultWhenUnset"/> (the flag's default: <c>true</c> for
+    /// opt-out flags / fail-open, <c>false</c> for opt-in flags). The documented
+    /// Windows control surface is REG_DWORD only; honouring strings would
+    /// silently change long-standing behaviour.
     /// </summary>
-    internal static bool InterpretLinuxConfigValue(string? rawValue) => rawValue switch
+    internal static bool InterpretWindowsRegistryValue(object? regValue, bool defaultWhenUnset = true) =>
+        regValue is int i ? i != 0 : defaultWhenUnset;
+
+    /// <summary>
+    /// Pure value→bool interpretation for a Linux config-file flag.
+    /// Off iff the value is the literal string <c>"0"</c> or <c>"false"</c>
+    /// (case-insensitive, whitespace tolerated), on for a truthy int/bool.
+    /// Anything else — including <see langword="null"/>, empty, or unparseable
+    /// strings — yields <paramref name="defaultWhenUnset"/> (the flag's default:
+    /// <c>true</c> for opt-out flags, <c>false</c> for opt-in flags).
+    /// </summary>
+    internal static bool InterpretLinuxConfigValue(string? rawValue, bool defaultWhenUnset = true) => rawValue switch
     {
-        null => true,
+        null => defaultWhenUnset,
         var s when int.TryParse(s.Trim(), out var n) => n != 0,
         var s when bool.TryParse(s.Trim(), out var b) => b,
-        _ => true,
+        _ => defaultWhenUnset,
     };
 
-    private static bool ReadFlag(string valueName)
+    private static bool ReadFlag(string valueName, bool defaultWhenUnset = true)
     {
         try
         {
             if (OperatingSystem.IsWindows())
-                return ReadWindowsFlag(valueName);
+                return ReadWindowsFlag(valueName, defaultWhenUnset);
             if (OperatingSystem.IsLinux())
-                return ReadLinuxFlag(valueName);
-            return true;
+                return ReadLinuxFlag(valueName, defaultWhenUnset);
+            return defaultWhenUnset;
         }
         catch
         {
-            // Fail-open: any I/O / permission error must never disable a
-            // capability. These are opt-out flags; only an explicit "0" /
-            // "false" turns them off.
-            return true;
+            // Fail to the flag's default: any I/O / permission error must leave a
+            // capability at its safe default. Opt-out flags default ON (only an
+            // explicit "0" / "false" turns them off); the opt-in port-forwarding
+            // flag defaults OFF, so a read error never silently opens tunneling.
+            return defaultWhenUnset;
         }
     }
 
     [SupportedOSPlatform("windows")]
-    private static bool ReadWindowsFlag(string valueName)
+    private static bool ReadWindowsFlag(string valueName, bool defaultWhenUnset)
     {
         using var key = Registry.LocalMachine.OpenSubKey(WindowsServiceControlKey);
-        return InterpretWindowsRegistryValue(key?.GetValue(valueName));
+        return InterpretWindowsRegistryValue(key?.GetValue(valueName), defaultWhenUnset);
     }
 
     [SupportedOSPlatform("linux")]
-    private static bool ReadLinuxFlag(string valueName)
+    private static bool ReadLinuxFlag(string valueName, bool defaultWhenUnset)
     {
         if (!File.Exists(LinuxServiceControlConfigPath))
-            return true;
+            return defaultWhenUnset;
 
         foreach (var line in File.ReadAllLines(LinuxServiceControlConfigPath))
         {
@@ -193,10 +223,10 @@ public sealed class PlatformServiceControlFlags : IServiceControlFlags
                 continue;
             if (!string.Equals(entry.Value.key, valueName, StringComparison.OrdinalIgnoreCase))
                 continue;
-            return InterpretLinuxConfigValue(entry.Value.value);
+            return InterpretLinuxConfigValue(entry.Value.value, defaultWhenUnset);
         }
 
-        return true;
+        return defaultWhenUnset;
     }
 
     /// <summary>

--- a/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Eryph.GuestServices.DevTunnels.Ssh.Extensions.csproj
+++ b/src/Eryph.GuestServices.DevTunnels.Ssh.Extensions/Eryph.GuestServices.DevTunnels.Ssh.Extensions.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DevTunnels.Ssh" Version="3.12.29" />
+    <PackageReference Include="Microsoft.DevTunnels.Ssh.Tcp" Version="3.12.29" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Eryph.GuestServices.Provisioning/Modules/EgsModule.cs
+++ b/src/Eryph.GuestServices.Provisioning/Modules/EgsModule.cs
@@ -10,7 +10,8 @@ namespace Eryph.GuestServices.Provisioning.Modules;
 /// <summary>
 /// eryph extension (not cloud-init): applies the <c>egs:</c> block, which
 /// configures the guest-services agent itself — its operator capability
-/// switches (remote access / provisioning / KVP auth) and, later, self-update.
+/// switches (remote access / provisioning / KVP auth / port forwarding) and,
+/// later, self-update.
 /// </summary>
 /// <remarks>
 /// Runs last in the Network stage (after network-config, NTP, timezone and
@@ -80,6 +81,8 @@ internal sealed class EgsModule(ILogger<EgsModule> logger, IEgsUpdater updater) 
         await WriteFlagIfSetAsync(ServiceControlFlag.Provisioning, settings.Provisioning, context, cancellationToken)
             .ConfigureAwait(false);
         await WriteFlagIfSetAsync(ServiceControlFlag.KvpAuth, settings.KvpAuth, context, cancellationToken)
+            .ConfigureAwait(false);
+        await WriteFlagIfSetAsync(ServiceControlFlag.PortForwarding, settings.PortForwarding, context, cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/src/Eryph.GuestServices.Service/Services/SshServerService.cs
+++ b/src/Eryph.GuestServices.Service/Services/SshServerService.cs
@@ -10,6 +10,7 @@ using Eryph.GuestServices.Sockets;
 using Microsoft.DevTunnels.Ssh;
 using Microsoft.DevTunnels.Ssh.Algorithms;
 using Microsoft.DevTunnels.Ssh.Events;
+using Microsoft.DevTunnels.Ssh.Tcp;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -28,6 +29,7 @@ internal sealed class SshServerService(
     private SocketSshServer? _server;
     private Task? _listenTask;
     private bool _started;
+    private bool _portForwardingEnabled;
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
@@ -41,6 +43,7 @@ internal sealed class SshServerService(
         }
 
         _started = true;
+        _portForwardingEnabled = controlFlags.IsPortForwardingEnabled();
 
         var hostKey = await keyStorage.GetHostKeyAsync();
         if (hostKey is null)
@@ -50,18 +53,10 @@ internal sealed class SshServerService(
             await keyStorage.SetHostKeyAsync(hostKey);
         }
 
-        var config = new SshSessionConfiguration(useSecurity: true);
-
-        config.Services.Add(typeof(SubsystemService), null);
-        // The shell selector is passed as the service activation config object.
-        // DevTunnels.Ssh activates the matching 2-arg ctor. Both the interactive
-        // ShellService and the exec CommandService run the client request through
-        // the selected shell, so they share the selector.
-        config.Services.Add(typeof(CommandService), shellSelector);
-        config.Services.Add(typeof(ShellService), shellSelector);
-        config.Services.Add(typeof(UploadFileService), null);
-        config.Services.Add(typeof(DownloadFileService), null);
-        config.Services.Add(typeof(ListDirectoryService), null);
+        var config = BuildConfiguration(shellSelector, _portForwardingEnabled);
+        if (_portForwardingEnabled)
+            logger.LogInformation(
+                "Port forwarding enabled (PortForwardingEnabled); SSH tunneling (-L/-R) is available.");
 
         _server = new SocketSshServer(config, new TraceSource("SshServer"));
         _server.Credentials = new SshServerCredentials(hostKey);
@@ -153,6 +148,47 @@ internal sealed class SshServerService(
         _socket?.Dispose();
     }
 
+    /// <summary>
+    /// Builds the SSH session configuration: the fixed set of egs services
+    /// (subsystem / shell / exec / file transfer / directory listing) plus,
+    /// only when <paramref name="portForwardingEnabled"/> is set, the
+    /// <see cref="PortForwardingService"/> that handles <c>direct-tcpip</c>
+    /// (<c>ssh -L</c>) and <c>tcpip-forward</c> (<c>ssh -R</c>) requests. Leaving
+    /// the service unregistered means the server rejects every forwarding
+    /// request, so forwarding is off unless an operator opts in.
+    /// </summary>
+    internal static SshSessionConfiguration BuildConfiguration(
+        IShellSelector shellSelector, bool portForwardingEnabled)
+    {
+        var config = new SshSessionConfiguration(useSecurity: true);
+
+        config.Services.Add(typeof(SubsystemService), null);
+        // The shell selector is passed as the service activation config object.
+        // DevTunnels.Ssh activates the matching 2-arg ctor. Both the interactive
+        // ShellService and the exec CommandService run the client request through
+        // the selected shell, so they share the selector.
+        config.Services.Add(typeof(CommandService), shellSelector);
+        config.Services.Add(typeof(ShellService), shellSelector);
+        config.Services.Add(typeof(UploadFileService), null);
+        config.Services.Add(typeof(DownloadFileService), null);
+        config.Services.Add(typeof(ListDirectoryService), null);
+
+        if (portForwardingEnabled)
+            config.Services.Add(typeof(PortForwardingService), null);
+
+        return config;
+    }
+
+    /// <summary>
+    /// The optional features advertised to the host via <see cref="Constants.FeaturesKey"/>.
+    /// Port forwarding is only listed when it is actually enabled, so a client
+    /// can tell whether <c>-L</c>/<c>-R</c> will be honored.
+    /// </summary>
+    internal static string[] GetSupportedFeatures(bool portForwardingEnabled) =>
+        portForwardingEnabled
+            ? [Constants.ShellOverrideFeature, Constants.PortForwardingFeature]
+            : [Constants.ShellOverrideFeature];
+
     private async Task SetStatusAsync(string? status)
     {
         // FeaturesKey is cleared on shutdown so capability discovery stays
@@ -165,13 +201,10 @@ internal sealed class SshServerService(
             [Constants.StatusKey] = status,
             [Constants.VersionKey] = GitVersionInformation.SemVer,
             [Constants.OperatingSystemKey] = RuntimeInformation.OSDescription,
-            [Constants.FeaturesKey] = status is null ? null : string.Join(' ', SupportedFeatures),
+            [Constants.FeaturesKey] = status is null
+                ? null
+                : string.Join(' ', GetSupportedFeatures(_portForwardingEnabled)),
         };
         await guestDataExchange.SetGuestValuesAsync(values);
     }
-
-    private static readonly string[] SupportedFeatures =
-    [
-        Constants.ShellOverrideFeature,
-    ];
 }

--- a/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/CloudConfigYamlSerializerTests.cs
+++ b/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/CloudConfigYamlSerializerTests.cs
@@ -54,6 +54,7 @@ public class CloudConfigYamlSerializerTests
                                 remote_access: false
                                 provisioning: true
                                 kvp_auth: false
+                                port_forwarding: true
                               update:
                                 enabled: true
                                 version: "0.4.0"
@@ -67,6 +68,7 @@ public class CloudConfigYamlSerializerTests
         config.Egs.Settings!.RemoteAccess.Should().BeFalse();
         config.Egs.Settings.Provisioning.Should().BeTrue();
         config.Egs.Settings.KvpAuth.Should().BeFalse();
+        config.Egs.Settings.PortForwarding.Should().BeTrue();
         config.Egs.Update.Should().NotBeNull();
         config.Egs.Update!.Enabled.Should().BeTrue();
         config.Egs.Update.Version.Should().Be("0.4.0");
@@ -89,6 +91,7 @@ public class CloudConfigYamlSerializerTests
         config.Egs!.Settings!.RemoteAccess.Should().BeFalse();
         config.Egs.Settings.Provisioning.Should().BeNull();
         config.Egs.Settings.KvpAuth.Should().BeNull();
+        config.Egs.Settings.PortForwarding.Should().BeNull();
     }
 
     [Fact]

--- a/test/Eryph.GuestServices.Provisioning.Tests/Hosting/ProvisioningHostedServiceGateTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Hosting/ProvisioningHostedServiceGateTests.cs
@@ -130,5 +130,6 @@ public class ProvisioningHostedServiceGateTests
         public bool IsRemoteAccessEnabled() => true;
         public bool IsKvpAuthEnabled() => true;
         public bool IsAutoUpdateEnabled() => false;
+        public bool IsPortForwardingEnabled() => false;
     }
 }

--- a/test/Eryph.GuestServices.Provisioning.Tests/Modules/EgsModuleTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Modules/EgsModuleTests.cs
@@ -97,6 +97,46 @@ public sealed class EgsModuleTests
             ServiceControlFlag.Provisioning, false, Arg.Any<CancellationToken>());
         await os.Received(1).SetServiceControlFlagAsync(
             ServiceControlFlag.KvpAuth, true, Arg.Any<CancellationToken>());
+        // The opt-in PortForwarding switch was not in the block, so it must not
+        // be written (a regression that wrote it would silently open tunneling).
+        await os.DidNotReceive().SetServiceControlFlagAsync(
+            ServiceControlFlag.PortForwarding, Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Writes_port_forwarding_switch_when_set()
+    {
+        // Port forwarding is opt-in; provisioning must still be able to turn it
+        // on (and only when explicitly set, like every other switch).
+        var (os, outcome) = await RunAsync(new EgsConfig
+        {
+            Settings = new EgsSettingsConfig { PortForwarding = true },
+        });
+
+        outcome.Should().BeOfType<ModuleOutcome.Completed>();
+        await os.Received(1).SetServiceControlFlagAsync(
+            ServiceControlFlag.PortForwarding, true, Arg.Any<CancellationToken>());
+        await os.DidNotReceive().SetServiceControlFlagAsync(
+            ServiceControlFlag.RemoteAccess, Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await os.DidNotReceive().SetServiceControlFlagAsync(
+            ServiceControlFlag.Provisioning, Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await os.DidNotReceive().SetServiceControlFlagAsync(
+            ServiceControlFlag.KvpAuth, Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Writes_port_forwarding_false_when_explicitly_disabled()
+    {
+        // The opt-in switch can also be explicitly turned back off; the
+        // three-state write must carry the false through verbatim.
+        var (os, outcome) = await RunAsync(new EgsConfig
+        {
+            Settings = new EgsSettingsConfig { PortForwarding = false },
+        });
+
+        outcome.Should().BeOfType<ModuleOutcome.Completed>();
+        await os.Received(1).SetServiceControlFlagAsync(
+            ServiceControlFlag.PortForwarding, false, Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/test/Eryph.GuestServices.Provisioning.Tests/UserData/CloudConfigMergeTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/UserData/CloudConfigMergeTests.cs
@@ -370,7 +370,7 @@ public sealed class CloudConfigMergeTests
         License = new LicenseConfig { ProductKey = "k" },
         Egs = new EgsConfig
         {
-            Settings = new EgsSettingsConfig { RemoteAccess = false, Provisioning = true, KvpAuth = false },
+            Settings = new EgsSettingsConfig { RemoteAccess = false, Provisioning = true, KvpAuth = false, PortForwarding = true },
             Update = new EgsUpdateConfig { Enabled = true, Version = "0.4.0", Channel = "stable" },
         },
         Apt = new AptConfig { Proxy = "http://proxy:8080" },

--- a/test/Eryph.GuestServices.Service.Tests/AutoUpdateServiceTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/AutoUpdateServiceTests.cs
@@ -99,6 +99,7 @@ public sealed class AutoUpdateServiceTests
         public bool IsRemoteAccessEnabled() => true;
         public bool IsKvpAuthEnabled() => true;
         public bool IsAutoUpdateEnabled() => autoUpdate;
+        public bool IsPortForwardingEnabled() => false;
     }
 
     private sealed class FakeUpdater(Func<EgsUpdateConfig?, UpdatePlan?> behavior) : IEgsUpdater

--- a/test/Eryph.GuestServices.Service.Tests/ClientKeyProviderTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/ClientKeyProviderTests.cs
@@ -594,5 +594,6 @@ public class ClientKeyProviderTests
         public bool IsRemoteAccessEnabled() => true;
         public bool IsKvpAuthEnabled() => kvpAuthEnabled;
         public bool IsAutoUpdateEnabled() => false;
+        public bool IsPortForwardingEnabled() => false;
     }
 }

--- a/test/Eryph.GuestServices.Service.Tests/ServiceControlFlagsTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/ServiceControlFlagsTests.cs
@@ -141,4 +141,97 @@ public class ServiceControlFlagsTests
         PlatformServiceControlFlags.GetValueName(ServiceControlFlag.AutoUpdate)
             .Should().Be("AutoUpdateEnabled");
     }
+
+    [Fact]
+    public void PortForwarding_GetValueName_MapsToPortForwardingEnabled()
+    {
+        PlatformServiceControlFlags.GetValueName(ServiceControlFlag.PortForwarding)
+            .Should().Be("PortForwardingEnabled");
+    }
+
+    // ---- Opt-in (default OFF) flag interpretation ----
+    // Port forwarding is the lone opt-in switch: with no value present it must
+    // read OFF, and only an explicit truthy value opens it. The interpreters
+    // take the flag's default; passing false models the opt-in path.
+
+    [Fact]
+    public void InterpretWindowsRegistryValue_OptIn_NullValue_IsOff()
+    {
+        PlatformServiceControlFlags.InterpretWindowsRegistryValue(null, defaultWhenUnset: false)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void InterpretWindowsRegistryValue_OptIn_DwordOne_IsOn()
+    {
+        PlatformServiceControlFlags.InterpretWindowsRegistryValue(1, defaultWhenUnset: false)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void InterpretWindowsRegistryValue_OptIn_DwordZero_IsOff()
+    {
+        PlatformServiceControlFlags.InterpretWindowsRegistryValue(0, defaultWhenUnset: false)
+            .Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("1")]   // REG_SZ is not the documented surface -> falls to default OFF
+    [InlineData("true")]
+    public void InterpretWindowsRegistryValue_OptIn_RegSzTruthy_IsStillOff(string regSzValue)
+    {
+        PlatformServiceControlFlags.InterpretWindowsRegistryValue(regSzValue, defaultWhenUnset: false)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void InterpretLinuxConfigValue_OptIn_NullValue_IsOff()
+    {
+        PlatformServiceControlFlags.InterpretLinuxConfigValue(null, defaultWhenUnset: false)
+            .Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("true")]
+    [InlineData(" True ")]
+    public void InterpretLinuxConfigValue_OptIn_TruthyValue_IsOn(string value)
+    {
+        PlatformServiceControlFlags.InterpretLinuxConfigValue(value, defaultWhenUnset: false)
+            .Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("false")]
+    [InlineData("")]          // empty -> default OFF
+    [InlineData("garbage")]   // unparseable -> default OFF
+    [InlineData("yes")]       // operator gotcha: "yes" is NOT truthy here -> stays OFF
+    public void InterpretLinuxConfigValue_OptIn_FalsyOrUnknown_IsOff(string value)
+    {
+        PlatformServiceControlFlags.InterpretLinuxConfigValue(value, defaultWhenUnset: false)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void InterpretWindowsRegistryValue_OptIn_NonDwordKind_IsOff()
+    {
+        // Only REG_DWORD is honored. A REG_QWORD (long) or any other kind — even
+        // a truthy-looking 1L — falls to the opt-in default OFF, so a mistyped
+        // value can never silently open tunneling.
+        PlatformServiceControlFlags.InterpretWindowsRegistryValue(1L, defaultWhenUnset: false)
+            .Should().BeFalse();
+        PlatformServiceControlFlags.InterpretWindowsRegistryValue(new object(), defaultWhenUnset: false)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void Default_PortForwarding_IsOff()
+    {
+        // The lone opt-in switch: with no value set on the machine it reads OFF
+        // (fail-closed) so an unreadable config can never silently open tunneling.
+        var flags = new PlatformServiceControlFlags();
+
+        flags.IsPortForwardingEnabled().Should().BeFalse();
+    }
 }

--- a/test/Eryph.GuestServices.Service.Tests/SshServerServiceAuthWiringTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/SshServerServiceAuthWiringTests.cs
@@ -97,5 +97,6 @@ public class SshServerServiceAuthWiringTests
         public bool IsRemoteAccessEnabled() => true;
         public bool IsKvpAuthEnabled() => true;
         public bool IsAutoUpdateEnabled() => false;
+        public bool IsPortForwardingEnabled() => false;
     }
 }

--- a/test/Eryph.GuestServices.Service.Tests/SshServerServicePortForwardingTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/SshServerServicePortForwardingTests.cs
@@ -1,0 +1,56 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.Core;
+using Eryph.GuestServices.DevTunnels.Ssh.Extensions;
+using Eryph.GuestServices.Service.Services;
+using Microsoft.DevTunnels.Ssh.Tcp;
+
+namespace Eryph.GuestServices.Service.Tests;
+
+/// <summary>
+/// Guards the opt-in port-forwarding wiring in <see cref="SshServerService"/>:
+/// the <see cref="PortForwardingService"/> is registered (and the feature
+/// advertised) only when the flag is on, so the server rejects every
+/// <c>-L</c>/<c>-R</c> request by default.
+/// </summary>
+public class SshServerServicePortForwardingTests
+{
+    [Fact]
+    public void BuildConfiguration_Disabled_DoesNotRegisterPortForwardingService()
+    {
+        var config = SshServerService.BuildConfiguration(new StubShellSelector(), portForwardingEnabled: false);
+
+        config.Services.Should().NotContainKey(typeof(PortForwardingService));
+    }
+
+    [Fact]
+    public void BuildConfiguration_Enabled_RegistersPortForwardingService()
+    {
+        var config = SshServerService.BuildConfiguration(new StubShellSelector(), portForwardingEnabled: true);
+
+        config.Services.Should().ContainKey(typeof(PortForwardingService));
+    }
+
+    [Fact]
+    public void GetSupportedFeatures_Disabled_OmitsPortForwardingFeature()
+    {
+        var features = SshServerService.GetSupportedFeatures(portForwardingEnabled: false);
+
+        features.Should().Contain(Constants.ShellOverrideFeature);
+        features.Should().NotContain(Constants.PortForwardingFeature);
+    }
+
+    [Fact]
+    public void GetSupportedFeatures_Enabled_AdvertisesPortForwardingFeature()
+    {
+        var features = SshServerService.GetSupportedFeatures(portForwardingEnabled: true);
+
+        features.Should().Contain(Constants.ShellOverrideFeature);
+        features.Should().Contain(Constants.PortForwardingFeature);
+    }
+
+    private sealed class StubShellSelector : IShellSelector
+    {
+        public Task<ShellSelection> SelectAsync(ShellOverride sshOverride, CancellationToken cancellation)
+            => Task.FromResult(new ShellSelection("/bin/sh", string.Empty));
+    }
+}

--- a/test/Eryph.GuestServices.Service.Tests/SshServerServiceRemoteAccessGateTests.cs
+++ b/test/Eryph.GuestServices.Service.Tests/SshServerServiceRemoteAccessGateTests.cs
@@ -59,6 +59,7 @@ public class SshServerServiceRemoteAccessGateTests
         public bool IsRemoteAccessEnabled() => remoteAccessEnabled;
         public bool IsKvpAuthEnabled() => true;
         public bool IsAutoUpdateEnabled() => false;
+        public bool IsPortForwardingEnabled() => false;
     }
 
     private sealed class ThrowingKeyStorage : IKeyStorage

--- a/test/e2e/Helpers.ps1
+++ b/test/e2e/Helpers.ps1
@@ -1074,14 +1074,14 @@ function Test-CatletSshWithKey {
   }
 }
 
-function Set-CatletKvpAuthEnabled {
+function Set-CatletServiceControlFlag {
   <#
   .SYNOPSIS
-    Writes (or clears) the HKLM\SOFTWARE\eryph\guest-services\KvpAuthEnabled
-    DWORD inside a running catlet AND restarts eryph-guest-services so the
-    new flag value is in force. The service caches the flag at startup
-    (matches IsRemoteAccessEnabled semantics), so a registry change alone
-    is invisible to the running service until restart.
+    Writes (or clears) a HKLM\SOFTWARE\eryph\guest-services\<Name> REG_DWORD
+    inside a running catlet AND restarts eryph-guest-services so the new flag
+    value is in force. The service caches its control flags at startup
+    (matches IsRemoteAccessEnabled semantics), so a registry change alone is
+    invisible to the running service until restart.
 
     Uses PowerShell Direct (Hyper-V VMBus) for BOTH the registry write and
     the service restart — no networking, no SSH, no firewall. The caller
@@ -1092,6 +1092,7 @@ function Set-CatletKvpAuthEnabled {
   [CmdletBinding()]
   param(
     [Parameter(Mandatory = $true)] $Catlet,
+    [Parameter(Mandatory = $true)] [string] $Name,
     [Parameter()] [Nullable[int]] $Value,  # null = delete, otherwise REG_DWORD
     [Parameter(Mandatory = $true)] [pscredential] $Credential
   )
@@ -1099,31 +1100,31 @@ function Set-CatletKvpAuthEnabled {
   # All registry I/O + the restart go through PowerShell Direct. Same
   # channel for write, verify, and restart — survives the service stop.
   Invoke-Command -VMId $Catlet.VmId -Credential $Credential -ScriptBlock {
-    param([Nullable[int]] $TargetValue)
+    param([string] $FlagName, [Nullable[int]] $TargetValue)
     $key = 'HKLM:\SOFTWARE\eryph\guest-services'
     if ($null -eq $TargetValue) {
       if (Test-Path -LiteralPath $key) {
-        Remove-ItemProperty -LiteralPath $key -Name 'KvpAuthEnabled' -ErrorAction SilentlyContinue
+        Remove-ItemProperty -LiteralPath $key -Name $FlagName -ErrorAction SilentlyContinue
       }
     } else {
       if (-not (Test-Path -LiteralPath $key)) {
         New-Item -Path $key -Force | Out-Null
       }
-      Set-ItemProperty -LiteralPath $key -Name 'KvpAuthEnabled' -Type DWord -Value $TargetValue
+      Set-ItemProperty -LiteralPath $key -Name $FlagName -Type DWord -Value $TargetValue
     }
     # Read back so the caller can fail fast if the write didn't land
     # where egs-service reads from.
-    $kvp = Get-ItemProperty -LiteralPath $key -Name 'KvpAuthEnabled' -ErrorAction SilentlyContinue
-    if ($null -ne $kvp) { $kvp.KvpAuthEnabled } else { $null }
-  } -ArgumentList $Value -OutVariable readBack | Out-Null
+    $reg = Get-ItemProperty -LiteralPath $key -Name $FlagName -ErrorAction SilentlyContinue
+    if ($null -ne $reg) { $reg.$FlagName } else { $null }
+  } -ArgumentList $Name, $Value -OutVariable readBack | Out-Null
 
   if ($null -eq $Value) {
     if ($null -ne $readBack[0]) {
-      throw "KvpAuthEnabled clear did not take effect on $($Catlet.Name); still reads $($readBack[0])."
+      throw "$Name clear did not take effect on $($Catlet.Name); still reads $($readBack[0])."
     }
   } else {
     if ($readBack[0] -ne $Value) {
-      throw "KvpAuthEnabled=$Value not visible on $($Catlet.Name) (read back $($readBack[0]))."
+      throw "$Name=$Value not visible on $($Catlet.Name) (read back $($readBack[0]))."
     }
   }
 
@@ -1146,6 +1147,22 @@ function Set-CatletKvpAuthEnabled {
   if ($status -ne 'available') {
     throw "egs-service did not return to 'available' within 2 minutes after restart (status=$status)"
   }
+}
+
+function Set-CatletKvpAuthEnabled {
+  <#
+  .SYNOPSIS
+    Convenience wrapper over Set-CatletServiceControlFlag for the
+    KvpAuthEnabled flag (Windows).
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] $Catlet,
+    [Parameter()] [Nullable[int]] $Value,
+    [Parameter(Mandatory = $true)] [pscredential] $Credential
+  )
+  Set-CatletServiceControlFlag -Catlet $Catlet -Name 'KvpAuthEnabled' `
+    -Value $Value -Credential $Credential
 }
 
 function New-EphemeralSshKey {
@@ -1480,13 +1497,17 @@ function Write-LinuxEgsClientKey {
   }
 }
 
-function Set-CatletKvpAuthEnabledLinux {
+function Set-CatletServiceControlFlagLinux {
   <#
   .SYNOPSIS
-    Writes / clears the KvpAuthEnabled flag in
+    Writes / clears a single control flag in
     /etc/opt/eryph/guest-services/service-control.conf on a running
     Linux catlet, then restarts eryph-guest-services so the new value
     is in force (PlatformServiceControlFlags caches at startup).
+
+    The conf is written with just the one KEY=VALUE line (clearing
+    removes the file entirely → all flags back to default). That single-
+    flag-per-file shape is fine for the isolated e2e contexts here.
 
     Channel: direct sshd as the admin user — independent of
     eryph-guest-services lifecycle.
@@ -1495,17 +1516,18 @@ function Set-CatletKvpAuthEnabledLinux {
   param(
     [Parameter(Mandatory = $true)] $Catlet,
     [Parameter(Mandatory = $true)] [string] $Username,
+    [Parameter(Mandatory = $true)] [string] $Name,
     [Parameter()] [Nullable[int]] $Value
   )
 
   $confPath = '/etc/opt/eryph/guest-services/service-control.conf'
 
   if ($null -eq $Value) {
-    # Clear: just remove the file (no flags = all default ON). Tolerate
+    # Clear: just remove the file (no flags = all defaults). Tolerate
     # "file already absent" — rm -f is idempotent.
     $writeCmd = "sudo rm -f $confPath"
   } else {
-    $content = "KvpAuthEnabled=$Value`n"
+    $content = "$Name=$Value`n"
     $b64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($content))
     $writeCmd = "echo $b64 | base64 -d | sudo tee $confPath > /dev/null"
   }
@@ -1519,17 +1541,17 @@ function Set-CatletKvpAuthEnabledLinux {
       throw "service-control.conf write on $($Catlet.Name) returned $LASTEXITCODE."
     }
 
-    # Read back so a hive/path mismatch surfaces immediately.
+    # Read back so a path mismatch surfaces immediately.
     $verifyCmd = "test -f $confPath && cat $confPath || echo MISSING"
     $readBack = (Invoke-CatletAdminSshLinux -Catlet $Catlet -Username $Username `
       -Command $verifyCmd) | Out-String
     if ($null -eq $Value) {
       if ($readBack -notmatch 'MISSING') {
-        throw "KvpAuthEnabled clear did not take effect on $($Catlet.Name); conf still:`n$readBack"
+        throw "$Name clear did not take effect on $($Catlet.Name); conf still:`n$readBack"
       }
     } else {
-      if ($readBack -notmatch "KvpAuthEnabled\s*=\s*$Value") {
-        throw "KvpAuthEnabled=$Value not visible in conf on $($Catlet.Name). Got:`n$readBack"
+      if ($readBack -notmatch "$Name\s*=\s*$Value") {
+        throw "$Name=$Value not visible in conf on $($Catlet.Name). Got:`n$readBack"
       }
     }
 
@@ -1557,5 +1579,282 @@ function Set-CatletKvpAuthEnabledLinux {
   }
   finally {
     $PSNativeCommandUseErrorActionPreference = $savedPref
+  }
+}
+
+function Set-CatletKvpAuthEnabledLinux {
+  <#
+  .SYNOPSIS
+    Convenience wrapper over Set-CatletServiceControlFlagLinux for the
+    KvpAuthEnabled flag.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] $Catlet,
+    [Parameter(Mandatory = $true)] [string] $Username,
+    [Parameter()] [Nullable[int]] $Value
+  )
+  Set-CatletServiceControlFlagLinux -Catlet $Catlet -Username $Username `
+    -Name 'KvpAuthEnabled' -Value $Value
+}
+
+# ---------------------------------------------------------------------------
+# Port-forwarding e2e helpers (shared host side + per-OS guest listeners)
+# ---------------------------------------------------------------------------
+#
+# The port-forwarding gate is proven by a real `ssh -L` tunnel through the egs
+# proxy: a tiny TCP listener inside the guest answers a fixed token on
+# 127.0.0.1:<guestPort>, and the host opens
+#   ssh -L 127.0.0.1:<localPort>:127.0.0.1:<guestPort>
+# then reads the token back through the tunnel. This exercises the same
+# `direct-tcpip` path a jump host uses (the guest dials the target); a loopback
+# target keeps the test self-contained while proving the channel is honored.
+#
+# When PortForwardingEnabled is off the egs SSH server never registers the
+# DevTunnels PortForwardingService, so it refuses the direct-tcpip channel: the
+# client's local listener still accepts the TCP connect, but no data flows and
+# the token read comes back empty.
+
+function Get-FreeLocalTcpPort {
+  <#
+  .SYNOPSIS
+    Returns a currently-free TCP port on the host loopback (bind-to-0 trick).
+    Small TOCTOU window, acceptable for a single test process.
+  #>
+  $l = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+  $l.Start()
+  try { return [int]($l.LocalEndpoint).Port }
+  finally { $l.Stop() }
+}
+
+function Start-CatletLoopbackTcpProbe {
+  <#
+  .SYNOPSIS
+    Starts a loopback TCP listener inside a WINDOWS catlet (via PowerShell
+    Direct) that writes a fixed token to every client and closes. Runs as a
+    detached SYSTEM scheduled task so it survives the Invoke-Command session
+    and the eryph-guest-services restarts the gate test triggers.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] $Catlet,
+    [Parameter(Mandatory = $true)] [int] $Port,
+    [Parameter(Mandatory = $true)] [string] $Token,
+    [Parameter(Mandatory = $true)] [pscredential] $Credential,
+    [Parameter()] [string] $TaskName = 'EgsFwdProbe'
+  )
+
+  # Built host-side ("@...@" is expandable: $Port/$Token interpolate here;
+  # backtick-escaped $vars stay literal for the guest-side runtime).
+  $listenerScript = @"
+`$ErrorActionPreference = 'Stop'
+`$listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, $Port)
+`$listener.Start()
+while (`$true) {
+  `$client = `$listener.AcceptTcpClient()
+  try {
+    `$stream = `$client.GetStream()
+    `$bytes = [System.Text.Encoding]::ASCII.GetBytes('$Token')
+    `$stream.Write(`$bytes, 0, `$bytes.Length)
+    `$stream.Flush()
+    Start-Sleep -Milliseconds 150
+  } finally { `$client.Close() }
+}
+"@
+
+  Invoke-Command -VMId $Catlet.VmId -Credential $Credential -ScriptBlock {
+    param($scriptText, $tn)
+    $path = 'C:\Windows\Temp\egs-fwdprobe.ps1'
+    Set-Content -LiteralPath $path -Value $scriptText -Encoding utf8
+    schtasks.exe /create /tn $tn `
+      /tr "powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File $path" `
+      /sc once /st 23:59:59 /ru SYSTEM /rl HIGHEST /f | Out-Null
+    schtasks.exe /run /tn $tn | Out-Null
+  } -ArgumentList $listenerScript, $TaskName | Out-Null
+
+  # Give the task a moment to bind before the first probe.
+  Start-Sleep -Seconds 2
+}
+
+function Stop-CatletLoopbackTcpProbe {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] $Catlet,
+    [Parameter(Mandatory = $true)] [pscredential] $Credential,
+    [Parameter()] [string] $TaskName = 'EgsFwdProbe'
+  )
+  Invoke-Command -VMId $Catlet.VmId -Credential $Credential -ScriptBlock {
+    param($tn)
+    schtasks.exe /end /tn $tn 2>$null | Out-Null
+    schtasks.exe /delete /tn $tn /f 2>$null | Out-Null
+    Get-CimInstance Win32_Process -Filter "Name = 'powershell.exe'" -ErrorAction SilentlyContinue |
+      Where-Object { $_.CommandLine -like '*egs-fwdprobe.ps1*' } |
+      ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+  } -ArgumentList $TaskName | Out-Null
+}
+
+function Start-CatletLoopbackTcpProbeLinux {
+  <#
+  .SYNOPSIS
+    Starts a loopback TCP listener inside a LINUX catlet (via direct sshd)
+    that writes a fixed token to every client and closes. Detached with
+    setsid+nohup so it survives the admin ssh session and service restarts.
+    Uses python3 (present on the Ubuntu starter).
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] $Catlet,
+    [Parameter(Mandatory = $true)] [string] $Username,
+    [Parameter(Mandatory = $true)] [int] $Port,
+    [Parameter(Mandatory = $true)] [string] $Token
+  )
+
+  $py = @"
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('127.0.0.1', $Port))
+s.listen(5)
+while True:
+    c, _ = s.accept()
+    try:
+        c.sendall(b'$Token')
+    finally:
+        c.close()
+"@
+  $b64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($py))
+  $cmd = "echo $b64 | base64 -d > /tmp/egs-fwdprobe.py && " +
+         "setsid nohup python3 /tmp/egs-fwdprobe.py >/tmp/egs-fwdprobe.log 2>&1 & echo started"
+  $savedPref = $PSNativeCommandUseErrorActionPreference
+  $PSNativeCommandUseErrorActionPreference = $false
+  try {
+    Invoke-CatletAdminSshLinux -Catlet $Catlet -Username $Username -Command $cmd 2>&1 | Out-Null
+    Start-Sleep -Seconds 2
+  }
+  finally {
+    $PSNativeCommandUseErrorActionPreference = $savedPref
+  }
+}
+
+function Stop-CatletLoopbackTcpProbeLinux {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] $Catlet,
+    [Parameter(Mandatory = $true)] [string] $Username
+  )
+  $savedPref = $PSNativeCommandUseErrorActionPreference
+  $PSNativeCommandUseErrorActionPreference = $false
+  try {
+    Invoke-CatletAdminSshLinux -Catlet $Catlet -Username $Username `
+      -Command 'pkill -f egs-fwdprobe.py; rm -f /tmp/egs-fwdprobe.py' 2>&1 | Out-Null
+  }
+  finally {
+    $PSNativeCommandUseErrorActionPreference = $savedPref
+  }
+}
+
+function Test-CatletPortForward {
+  <#
+  .SYNOPSIS
+    Opens `ssh -L 127.0.0.1:<local>:127.0.0.1:<GuestPort>` through the egs
+    proxy with the supplied identity, reads from the local end, and returns
+    $true iff the guest-side token came back over the tunnel. $false means
+    the forward was refused (server didn't register PortForwardingService) or
+    no data flowed before timeout.
+
+    The actual data round-trip — not just "did ssh connect" — is the signal:
+    with forwarding off the client's local listener still accepts the connect,
+    so only reading the token distinguishes enabled from disabled.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)] [Guid] $VmId,
+    [Parameter(Mandatory = $true)] [string] $IdentityFile,
+    [Parameter(Mandatory = $true)] [int] $GuestPort,
+    [Parameter(Mandatory = $true)] [string] $ExpectedToken,
+    [Parameter()] [int] $TimeoutSeconds = 12,
+    # Remote command that just holds the session open while we drive the
+    # forward. We deliberately do NOT use `ssh -N`: a channel-less session over
+    # the egs proxy is torn down immediately (the local -L listener never even
+    # comes up), so we keep an exec channel alive — the proven path — and run
+    # the forward alongside it. Default is the Windows guest shell; the Linux
+    # suite passes 'sleep 30'.
+    [Parameter()] [string] $KeepAliveCommand = 'powershell -NoProfile -Command "Start-Sleep -Seconds 30"'
+  )
+
+  $localPort = Get-FreeLocalTcpPort
+  $proxy = "egs-tool.exe proxy $VmId"
+  $knownHosts = "$env:TEMP\egs-portfwd-known_hosts-$([guid]::NewGuid().ToString('N')).tmp"
+
+  $sshArgs = @(
+    '-F', 'NUL',
+    '-i', $IdentityFile,
+    '-o', 'IdentitiesOnly=yes',
+    '-o', 'StrictHostKeyChecking=no',
+    '-o', "UserKnownHostsFile=$knownHosts",
+    '-o', 'BatchMode=yes',
+    '-o', "ConnectTimeout=$TimeoutSeconds",
+    '-o', "ProxyCommand=$proxy",
+    '-L', "127.0.0.1:${localPort}:127.0.0.1:${GuestPort}",
+    "egs@$($VmId).hyper-v.alt",
+    $KeepAliveCommand
+  )
+
+  # Launch ssh in a background JOB, not Start-Process: a Start-Process child has
+  # no console, and the egs-tool ProxyCommand it spawns then dies immediately
+  # ("Connection closed by UNKNOWN port 65535"), so the -L listener never comes
+  # up. A job runs in a child pwsh with proper stdio, exactly like the working
+  # interactive `& ssh` path.
+  $job = Start-Job -ScriptBlock {
+    param($sshExe, $sshArgs)
+    & $sshExe @sshArgs 2>&1
+  } -ArgumentList $script:WinSshExe, $sshArgs
+
+  try {
+    # Wait for ssh's local listener to come up (it accepts regardless of the
+    # server's forwarding policy — this is just readiness, not the verdict).
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $ready = $false
+    while ((Get-Date) -lt $deadline) {
+      if ($job.State -ne 'Running') { break }
+      try {
+        $t = [System.Net.Sockets.TcpClient]::new()
+        $t.Connect('127.0.0.1', $localPort)
+        $t.Close()
+        $ready = $true
+        break
+      } catch { Start-Sleep -Milliseconds 300 }
+    }
+    if (-not $ready) {
+      Write-Host "port-forward probe: local listener never came up (job state=$($job.State)). ssh output:"
+      Receive-Job $job -ErrorAction SilentlyContinue | Select-Object -Last 5 | ForEach-Object { Write-Host "  ssh: $_" }
+      return $false
+    }
+
+    # The real test: read the token through the tunnel. With forwarding off the
+    # local listener still accepts, so only the data round-trip is the verdict.
+    $received = ''
+    $client = [System.Net.Sockets.TcpClient]::new()
+    try {
+      $iar = $client.BeginConnect('127.0.0.1', $localPort, $null, $null)
+      if ($iar.AsyncWaitHandle.WaitOne([TimeSpan]::FromSeconds($TimeoutSeconds))) {
+        $client.EndConnect($iar)
+        $client.ReceiveTimeout = $TimeoutSeconds * 1000
+        $stream = $client.GetStream()
+        $buf = [byte[]]::new(256)
+        try {
+          $n = $stream.Read($buf, 0, $buf.Length)
+          if ($n -gt 0) { $received = [System.Text.Encoding]::ASCII.GetString($buf, 0, $n) }
+        } catch { }
+      }
+    } catch { }
+    finally { $client.Close() }
+
+    return ($received.Trim() -eq $ExpectedToken)
+  }
+  finally {
+    Stop-Job $job -ErrorAction SilentlyContinue
+    Remove-Job $job -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $knownHosts -Force -ErrorAction SilentlyContinue
   }
 }

--- a/test/e2e/RemoteAccess.E2E.Tests.ps1
+++ b/test/e2e/RemoteAccess.E2E.Tests.ps1
@@ -238,4 +238,62 @@ Describe 'Remote-access client auth' {
       $exit | Should -Be 0
     }
   }
+
+  Context 'PortForwardingEnabled gate' {
+
+    # Port forwarding is the lone OPT-IN switch: off unless explicitly turned
+    # on. The guest runs a loopback TCP probe; the host opens `ssh -L` through
+    # the egs proxy to 127.0.0.1:<probe> inside the guest and reads the token.
+    # That exercises the same direct-tcpip path a jump host uses.
+
+    BeforeAll {
+      $script:FwdGuestPort = 28080
+      $script:FwdToken = "egs-portfwd-$([guid]::NewGuid().ToString('N').Substring(0, 8))"
+      Start-CatletLoopbackTcpProbe -Catlet $catlet -Port $script:FwdGuestPort `
+        -Token $script:FwdToken -Credential $script:CatletAdminCredential
+    }
+
+    AfterAll {
+      # When keeping the VM for inspection, leave forwarding ON and the probe
+      # running so `ssh -L` can be debugged by hand against the kept catlet.
+      if ($env:EGS_E2E_KEEP_VM) { return }
+      try {
+        Set-CatletServiceControlFlag -Catlet $catlet -Name 'PortForwardingEnabled' `
+          -Value $null -Credential $script:CatletAdminCredential
+      } catch { }
+      try {
+        Stop-CatletLoopbackTcpProbe -Catlet $catlet -Credential $script:CatletAdminCredential
+      } catch { }
+    }
+
+    It 'does not advertise the feature and refuses -L when unset (default OFF)' {
+      Set-CatletServiceControlFlag -Catlet $catlet -Name 'PortForwardingEnabled' `
+        -Value $null -Credential $script:CatletAdminCredential
+
+      $data = egs-tool get-data --json $catlet.VmId | ConvertFrom-Json -AsHashtable
+      ($data.guest['eryph:guest-services:features'] -split ' ') | Should -Not -Contain 'port-forwarding'
+
+      (Test-CatletPortForward -VmId $catlet.VmId -IdentityFile $provisionedKey `
+        -GuestPort $script:FwdGuestPort -ExpectedToken $script:FwdToken) | Should -BeFalse
+    }
+
+    It 'advertises the feature and forwards -L when PortForwardingEnabled=1' {
+      Set-CatletServiceControlFlag -Catlet $catlet -Name 'PortForwardingEnabled' `
+        -Value 1 -Credential $script:CatletAdminCredential
+
+      $data = egs-tool get-data --json $catlet.VmId | ConvertFrom-Json -AsHashtable
+      ($data.guest['eryph:guest-services:features'] -split ' ') | Should -Contain 'port-forwarding'
+
+      (Test-CatletPortForward -VmId $catlet.VmId -IdentityFile $provisionedKey `
+        -GuestPort $script:FwdGuestPort -ExpectedToken $script:FwdToken) | Should -BeTrue
+    }
+
+    It 'refuses -L again when set back to 0' {
+      Set-CatletServiceControlFlag -Catlet $catlet -Name 'PortForwardingEnabled' `
+        -Value 0 -Credential $script:CatletAdminCredential
+
+      (Test-CatletPortForward -VmId $catlet.VmId -IdentityFile $provisionedKey `
+        -GuestPort $script:FwdGuestPort -ExpectedToken $script:FwdToken) | Should -BeFalse
+    }
+  }
 }

--- a/test/e2e/RemoteAccess.Linux.E2E.Tests.ps1
+++ b/test/e2e/RemoteAccess.Linux.E2E.Tests.ps1
@@ -235,4 +235,61 @@ Describe 'Remote-access client auth (Linux)' {
       $exit | Should -Be 0
     }
   }
+
+  Context 'PortForwardingEnabled gate (Linux service-control.conf)' {
+
+    # Opt-in switch (off by default). A loopback python TCP probe answers a
+    # token on 127.0.0.1:<port> inside the guest; the host opens `ssh -L`
+    # through the egs proxy and reads it back — the direct-tcpip jump-host path.
+
+    BeforeAll {
+      $script:FwdGuestPortLinux = 28081
+      $script:FwdTokenLinux = "egs-portfwd-$([guid]::NewGuid().ToString('N').Substring(0, 8))"
+      Start-CatletLoopbackTcpProbeLinux -Catlet $catlet -Username $adminUsername `
+        -Port $script:FwdGuestPortLinux -Token $script:FwdTokenLinux
+    }
+
+    AfterAll {
+      try {
+        Set-CatletServiceControlFlagLinux -Catlet $catlet -Username $adminUsername `
+          -Name 'PortForwardingEnabled' -Value $null
+      } catch { }
+      try {
+        Stop-CatletLoopbackTcpProbeLinux -Catlet $catlet -Username $adminUsername
+      } catch { }
+    }
+
+    It 'does not advertise the feature and refuses -L when unset (default OFF)' {
+      Set-CatletServiceControlFlagLinux -Catlet $catlet -Username $adminUsername `
+        -Name 'PortForwardingEnabled' -Value $null
+
+      $data = egs-tool get-data --json $catlet.VmId | ConvertFrom-Json -AsHashtable
+      ($data.guest['eryph:guest-services:features'] -split ' ') | Should -Not -Contain 'port-forwarding'
+
+      (Test-CatletPortForward -VmId $catlet.VmId -IdentityFile $provisionedKey `
+        -GuestPort $script:FwdGuestPortLinux -ExpectedToken $script:FwdTokenLinux `
+        -KeepAliveCommand 'sleep 30') | Should -BeFalse
+    }
+
+    It 'advertises the feature and forwards -L when PortForwardingEnabled=1' {
+      Set-CatletServiceControlFlagLinux -Catlet $catlet -Username $adminUsername `
+        -Name 'PortForwardingEnabled' -Value 1
+
+      $data = egs-tool get-data --json $catlet.VmId | ConvertFrom-Json -AsHashtable
+      ($data.guest['eryph:guest-services:features'] -split ' ') | Should -Contain 'port-forwarding'
+
+      (Test-CatletPortForward -VmId $catlet.VmId -IdentityFile $provisionedKey `
+        -GuestPort $script:FwdGuestPortLinux -ExpectedToken $script:FwdTokenLinux `
+        -KeepAliveCommand 'sleep 30') | Should -BeTrue
+    }
+
+    It 'refuses -L again when set back to 0' {
+      Set-CatletServiceControlFlagLinux -Catlet $catlet -Username $adminUsername `
+        -Name 'PortForwardingEnabled' -Value 0
+
+      (Test-CatletPortForward -VmId $catlet.VmId -IdentityFile $provisionedKey `
+        -GuestPort $script:FwdGuestPortLinux -ExpectedToken $script:FwdTokenLinux `
+        -KeepAliveCommand 'sleep 30') | Should -BeFalse
+    }
+  }
 }


### PR DESCRIPTION
Adds an opt-in `PortForwardingEnabled` control flag that gates SSH tunneling (`ssh -L` / `-R`) on the guest's remote-access transport.

- **Opt-in / fail-closed:** unlike the other control flags (which are opt-out, default ON), this one defaults OFF and a missing value, malformed value, I/O error, or unknown OS all yield OFF — tunneling never opens silently.
- When enabled, the SSH server registers the DevTunnels `PortForwardingService` and advertises a `port-forwarding` entry in the `eryph:guest-services:features` KVP; when disabled, neither happens.
- Configurable per-VM via `egs.settings.port_forwarding` (three-state, like the other egs settings) and operator-side via the Windows registry / Linux `service-control.conf`.
- Both `-L` (jump host) and `-R` are enabled when on; `-R` listeners bind where the client requests (no separate gateway-ports control).

Coverage: unit tests for the opt-in/fail-closed read path, the `BuildConfiguration`/`GetSupportedFeatures` seam, and the provisioning write; a new e2e gate context (Windows + Linux) that drives a real `ssh -L` tunnel and checks the feature advertisement. Validated end-to-end on a live Windows guest. Docs updated (settings + modules).