### PR TITLE
fix(network-config): apply v2 `match` selector and harden v2 parsing (#59)

### DIFF
--- a/docs/user/explanation/coexistence.md
+++ b/docs/user/explanation/coexistence.md
@@ -43,8 +43,8 @@ datasource reads the `config-2` ISO that OpenStack produces.
 
 ## Hyper-V (eryph)
 
-No native agent — the agent is it. eryph-zero attaches a `config-2` drive and
-the agent reports back over Hyper-V KVP.
+No native agent — the agent is it. eryph-zero attaches a NoCloud `cidata` seed
+disk and the agent reports back over Hyper-V KVP.
 
 ## An existing cloudbase-init
 

--- a/docs/user/explanation/differences-from-cloud-init.md
+++ b/docs/user/explanation/differences-from-cloud-init.md
@@ -20,6 +20,7 @@ expect. The differences that matter:
 | Linux-only keys (`apt`, `snap`, `chef`, …) | Accepted and logged at Info; they do nothing on Windows. `egs-service validate --target windows` flags them. |
 | Reporting | Log and Hyper-V KVP only. No webhook or cloud-native backend. |
 | Vendor-data | Read and discarded; not merged into cloud-config. |
+| network-config coverage | Only the per-interface IP subset is applied — addresses, gateways, routes, DNS servers and search, MTU (IPv4 + IPv6 for v2, IPv4 only for v1). Bonds, bridges, VLANs, and per-interface options (`dhcp4`/`dhcp6-overrides`, `routing-policy`, `set-name`, `wakeonlan`, `accept-ra`) are parsed but **not applied** — logged as warnings. cloud-init applies the full schema via netplan. See the [coverage matrix](../howto/configure-networking.md#coverage-matrix). |
 
 Random passwords are rejected rather than generated because cloud-init returns
 the generated value over the system console (`/dev/console`), and Windows guests
@@ -47,7 +48,9 @@ and `version: 1.10` into `"1.1"`. The agent keeps what you wrote.
   per-boot / per-once frequencies.
 - `reset` matches `cloud-init clean`; `collect-logs` matches
   `cloud-init collect-logs`.
-- network-config v1 and v2, including IPv6, routes, DNS search domains, and MTU.
+- Reading network-config v1 and v2 and matching adapters by MAC (the *applied*
+  subset is narrower than cloud-init — see the network-config row above and the
+  [coverage matrix](../howto/configure-networking.md#coverage-matrix)).
 - `chpasswd.expire`, `write_files.defer`, `prefer_fqdn_over_hostname`, and
   `users[].gecos` (mapped to the Windows full name).
 - Per-stage module selection (`enabledModules` / `disabledModules`) and

--- a/docs/user/explanation/differences-from-cloudbase-init.md
+++ b/docs/user/explanation/differences-from-cloudbase-init.md
@@ -11,7 +11,7 @@ full cloud-init compatibility.
 | Locale, keyboard, timezone, NTP, licensing | First-class cloud-config keys (`locale`, `keyboard`, `timezone`, `ntp`, `license`). On cbi you script these or drive them from cbi's own config file. |
 | SSH | `SshModule` configures the OS OpenSSH daemon — merges `authorized_keys`, manages host keys, writes an `sshd_config` drop-in. |
 | Stages | cloud-init's `Local` / `Network` / `Config` / `Final`, not cbi's plugin phases. |
-| network-config | v1 and v2 both accepted. cbi takes only the older OpenStack shape. |
+| network-config | v1 and v2 schemas both accepted; egs applies the per-interface IP subset and warns on the rest (see the [coverage matrix](../howto/configure-networking.md#coverage-matrix)). cbi takes only the older OpenStack shape. |
 | Frequencies | per-instance, per-boot, and per-once, with semaphores. cbi has per-instance only. |
 | Script dispatch | By filename extension, with a shebang fallback when there's no extension. cbi goes by filename only. |
 | Parts without a filename | Logged and run as PowerShell. cbi drops them. |

--- a/docs/user/explanation/windows-cloud-init-status.md
+++ b/docs/user/explanation/windows-cloud-init-status.md
@@ -10,7 +10,7 @@ Don't treat the non-eryph path as production-ready yet.
 
 Implemented and exercised by the eryph e2e suite:
 
-- Network-config v1/v2: MAC-matched IPv4 + IPv6, static and DHCP, per-interface routes, DNS servers and search suffixes, MTU.
+- Network-config v1/v2: MAC-matched static and DHCP addressing, per-interface routes, DNS servers and search suffixes, MTU (IPv4 + IPv6 for v2, IPv4 only for v1). Constructs outside that subset — bonds/bridges/VLANs, per-interface options — are warned, not applied. See the [coverage matrix](../howto/configure-networking.md#coverage-matrix).
 - Module frequencies: per-instance, per-boot, per-once with semaphores.
 - Datasource readiness: probe loop with exponential backoff and a shared budget.
 - Cleanup hook: fires once on full success.

--- a/docs/user/howto/configure-networking.md
+++ b/docs/user/howto/configure-networking.md
@@ -67,15 +67,63 @@ disables DHCP for that family and sets the listed addresses and the gateway.
 Per-interface routes, DNS servers, DNS search suffixes, and MTU are applied when
 present. A family with no directive is left as-is.
 
-An entry with no MAC address is skipped with a warning — Windows needs a MAC to
-bind to an adapter — as is an entry whose MAC matches no adapter.
+Adapters are bound by MAC. An entry with no MAC is skipped with a warning —
+Windows needs a MAC to bind to an adapter — as is an entry whose MAC matches no
+adapter.
 
-Bonds, bridges, VLANs, and wifi aren't applied, even though the schemas allow
-them — when present they're logged with a warning rather than dropped silently.
-The same goes for per-interface options the agent doesn't honour on Windows
-(`dhcp4-overrides`/`dhcp6-overrides`, `routing-policy`, `set-name`, `wakeonlan`,
-`accept-ra`) and for a top-level `macaddress` that asks to change an adapter's
-MAC: the rest of the entry is still applied, and the ignored parts are warned.
+## Coverage matrix
+
+The Windows applier implements the per-interface IP subset of each schema.
+Anything outside that subset is **not** configured on the guest; where the
+schema lets you express it, the agent makes the omission visible rather than
+dropping it silently.
+
+Legend: **Applied** — configured on the guest · **Warned** — parsed but not
+applied, logged with a warning · **Not applied** — accepted but neither applied
+nor warned.
+
+### v2 (netplan-style)
+
+| Construct | Status | Notes |
+| --- | --- | --- |
+| `match.macaddress` | Applied | the key used to bind the entry to an adapter |
+| `match.name`, `match.driver` | Warned | Windows binds by MAC; an entry with no MAC is skipped |
+| `dhcp4`, `dhcp6` | Applied | |
+| `addresses` (IPv4 + IPv6) | Applied | static addresses; per-address `lifetime`/`label` options are ignored |
+| `gateway4`, `gateway6` | Applied | |
+| `routes` (`to`, `via`, `metric`) | Applied | includes `to: default`; `table`/`scope`/`type`/`on-link` are ignored |
+| `nameservers.addresses`, `nameservers.search` | Applied | |
+| `mtu` | Applied | |
+| `macaddress` (set/spoof adapter MAC) | Warned | the adapter MAC is never changed |
+| `dhcp4-overrides`, `dhcp6-overrides` | Warned | |
+| `routing-policy` | Warned | |
+| `set-name`, `wakeonlan`, `accept-ra` | Warned | |
+| `optional` | Not applied | benign; no effect on Windows |
+| `bonds`, `bridges`, `vlans` | Warned | the link is not created |
+| `wifis`, `tunnels`, `vrfs`, … | Not applied | not modelled |
+| `renderer` | Not applied | informational only |
+
+### v1 (cloud-init networking config v1)
+
+v1 is projected onto the same applier; only **IPv4 physical interfaces** are
+projected.
+
+| Construct | Status | Notes |
+| --- | --- | --- |
+| `type: physical` + `mac_address` | Applied | the key used to bind the entry to an adapter |
+| `type: physical` without `mac_address` | Warned | skipped — needs a MAC to bind |
+| `mtu` | Applied | |
+| subnet `type: dhcp` / `dhcp4` | Applied | DHCPv4 (a physical entry with no subnets defaults to DHCP) |
+| subnet `type: static` / `static4` (`address`, `gateway`) | Applied | IPv4 |
+| `dns_nameservers`, `dns_search` | Applied | per-subnet, or inherited from a global `type: nameserver` entry |
+| subnet `routes` (`network`, `gateway`, `metric`) | Applied | |
+| `type: nameserver` (global DNS) | Applied | inherited by physical interfaces without their own DNS |
+| subnet `type: static6` / `dhcp6` / `manual` | Not applied | v1 projects IPv4 only |
+| `type: bond` / `bridge` / `vlan` / `route` | Not applied | only `physical` and `nameserver` entries are projected |
+
+> v1 IPv6 subnets and the non-physical link types are currently dropped without
+> a warning (unlike their v2 counterparts). If you need IPv6 or those link
+> types on a v1 datasource, prefer the v2 schema.
 
 `ApplyNetworkConfig` runs after `SetHostname`, so a hostname change isn't
 disrupted by an address change in the same run. It's per-instance; to re-apply on

--- a/docs/user/howto/configure-networking.md
+++ b/docs/user/howto/configure-networking.md
@@ -2,9 +2,9 @@
 
 Network configuration travels in a separate cloud-init document, network-config,
 not in `#cloud-config`. The datasource supplies it and the `ApplyNetworkConfig`
-module applies it during the Network stage. On eryph it's written into the
-`config-2` ConfigDrive; on a NoCloud setup, put a `network-config` file next to
-`meta-data` and `user-data`.
+module applies it during the Network stage. eryph supplies it as a **v1**
+network-config on the NoCloud seed disk — a `cidata` volume holding `meta-data`,
+`user-data`, and `network-config`.
 
 Both the v1 and v2 schemas are accepted, and adapters are matched to the config
 by MAC address.

--- a/docs/user/howto/configure-networking.md
+++ b/docs/user/howto/configure-networking.md
@@ -71,7 +71,11 @@ An entry with no MAC address is skipped with a warning — Windows needs a MAC t
 bind to an adapter — as is an entry whose MAC matches no adapter.
 
 Bonds, bridges, VLANs, and wifi aren't applied, even though the schemas allow
-them.
+them — when present they're logged with a warning rather than dropped silently.
+The same goes for per-interface options the agent doesn't honour on Windows
+(`dhcp4-overrides`/`dhcp6-overrides`, `routing-policy`, `set-name`, `wakeonlan`,
+`accept-ra`) and for a top-level `macaddress` that asks to change an adapter's
+MAC: the rest of the entry is still applied, and the ignored parts are warned.
 
 `ApplyNetworkConfig` runs after `SetHostname`, so a hostname change isn't
 disrupted by an address change in the same run. It's per-instance; to re-apply on

--- a/docs/user/howto/reset-and-rerun.md
+++ b/docs/user/howto/reset-and-rerun.md
@@ -72,8 +72,9 @@ egs-service run --state-dir C:\Temp\state --user-data sample.yaml
 
 - It does not roll back OS state. If a user account was created, the
   account stays. If `write_files` wrote a file, the file stays.
-- It does not delete the cloud-init datasource. The cidata / config-2
-  ISO is owned by the host; the agent never ejects it on its own.
+- It does not delete the cloud-init datasource. The seed disk — a `cidata`
+  volume for eryph, or a `config-2` ISO for ConfigDrive datasources — is owned
+  by the host; the agent never ejects it on its own.
 
 ## When `state.json` is corrupted
 

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -20,8 +20,8 @@ module names, frequencies, and semaphore layout — adapted to Windows.
   plain Hyper-V VM. Provisioning is in the same binary but optional: no
   datasource means the agent logs *No data source available* once and
   exits. Remote access keeps working.
-- **eryph.** Every catlet boots with `egs-service`. It finds the
-  `config-2` ConfigDrive eryph-zero attaches and applies the cloud-config
+- **eryph.** Every catlet boots with `egs-service`. It finds the NoCloud
+  `cidata` seed disk eryph-zero attaches and applies the cloud-config
   fodder. State and reporting flow through Hyper-V KVP.
 - **Other clouds (work in progress).** A cloudbase-init replacement for
   Hyper-V / OpenStack / Azure guests outside eryph. The Azure datasource

--- a/docs/user/reference/modules.md
+++ b/docs/user/reference/modules.md
@@ -64,9 +64,13 @@ from the datasource — for example inside a `config-2` ConfigDrive — not from
 cloud-config. See [Configure networking](../howto/configure-networking.md).
 
 Adapters are matched by MAC address. For each match the module applies the
-addresses (IPv4 and IPv6, static or DHCP), gateways, routes, DNS servers and
-search suffixes, and MTU. An entry whose MAC matches no adapter is skipped with
-a warning; an absent network-config is a no-op.
+addresses, gateways, routes, DNS servers and search suffixes, and MTU — IPv4 and
+IPv6 for v2, IPv4 only for v1. An entry whose MAC matches no adapter is skipped
+with a warning; an absent network-config is a no-op. Constructs outside that
+subset (bonds, bridges, VLANs, and per-interface options the agent doesn't
+honour) are logged with a warning rather than applied. See
+[Configure networking](../howto/configure-networking.md) for the full coverage
+matrix.
 
 ## NtpClient
 

--- a/docs/user/reference/modules.md
+++ b/docs/user/reference/modules.md
@@ -60,8 +60,9 @@ resumes afterward.
 ## ApplyNetworkConfig
 
 Applies a network-config document (v1 or v2) to the guest. The document comes
-from the datasource — for example inside a `config-2` ConfigDrive — not from
-cloud-config. See [Configure networking](../howto/configure-networking.md).
+from the datasource — for eryph, a v1 network-config on the NoCloud seed disk
+(a `cidata` volume) — not from cloud-config. See
+[Configure networking](../howto/configure-networking.md).
 
 Adapters are matched by MAC address. For each match the module applies the
 addresses, gateways, routes, DNS servers and search suffixes, and MTU — IPv4 and

--- a/docs/user/tutorial/first-catlet-with-cloud-config.md
+++ b/docs/user/tutorial/first-catlet-with-cloud-config.md
@@ -44,7 +44,7 @@ fodder:
 gc demo-catlet.yaml | New-Catlet
 ```
 
-eryph-zero attaches a `config-2` ConfigDrive to the VM with the fodder
+eryph-zero attaches a NoCloud `cidata` seed disk to the VM with the fodder
 serialised as cloud-init user-data. On first boot the agent picks it up.
 
 ## Step 3 — watch the provisioning state

--- a/src/Eryph.GuestServices.CloudConfig.Yaml/Converters/NetworkAddressListYamlConverter.cs
+++ b/src/Eryph.GuestServices.CloudConfig.Yaml/Converters/NetworkAddressListYamlConverter.cs
@@ -1,0 +1,81 @@
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace Eryph.GuestServices.CloudConfig.Yaml.Converters;
+
+/// <summary>
+/// Parses a network-config v2 <c>addresses:</c> list. cloud-init / netplan
+/// allow each entry to be either a plain <c>"ip/prefix"</c> scalar or the
+/// advanced single-key map form (<c>"ip/prefix": {lifetime: .., label: ..}</c>);
+/// we keep the address (the map key) and drop the per-address options the
+/// Windows applier does not honour.
+/// </summary>
+/// <remarks>
+/// Critically this must never throw on a structurally valid document. The
+/// default <c>List&lt;string&gt;</c> deserializer raises on the map form, and
+/// that exception — swallowed upstream — is exactly the failure mode that hid
+/// issue #59 (one unexpected sub-shape nulling the entire network-config).
+/// Unknown values are drained via <c>rootDeserializer(typeof(object))</c>, the
+/// same resilient idiom <c>UserConfigYamlTypeConverter</c> uses.
+/// </remarks>
+internal sealed class NetworkAddressListYamlConverter : IYamlTypeConverter
+{
+    // Attached via WithAttributeOverride; must not claim any type by default.
+    public bool Accepts(Type type) => false;
+
+    public object? ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
+    {
+        var result = new List<string>();
+
+        // A lone scalar (or an explicit null) where a list was expected: be
+        // tolerant — treat it as a single address, or nothing.
+        if (parser.TryConsume<Scalar>(out var lone))
+        {
+            if (!string.IsNullOrWhiteSpace(lone.Value))
+                result.Add(lone.Value);
+            return result;
+        }
+
+        if (!parser.TryConsume<SequenceStart>(out _))
+        {
+            // Unexpected shape (e.g. a bare mapping): drain it rather than throw.
+            _ = rootDeserializer(typeof(object));
+            return result;
+        }
+
+        while (!parser.TryConsume<SequenceEnd>(out _))
+        {
+            if (parser.TryConsume<Scalar>(out var item))
+            {
+                if (!string.IsNullOrWhiteSpace(item.Value))
+                    result.Add(item.Value);
+            }
+            else if (parser.TryConsume<MappingStart>(out _))
+            {
+                // Advanced form: { "10.0.0.1/24": {lifetime: 0, label: ..} }.
+                // The first key is the address; the value(s) are options we
+                // don't apply on Windows, so drain them.
+                var first = true;
+                while (!parser.TryConsume<MappingEnd>(out _))
+                {
+                    var key = parser.Consume<Scalar>();
+                    if (first && !string.IsNullOrWhiteSpace(key.Value))
+                        result.Add(key.Value);
+                    first = false;
+                    _ = rootDeserializer(typeof(object));
+                }
+            }
+            else
+            {
+                // Nested sequence or other unexpected node: drain and move on.
+                _ = rootDeserializer(typeof(object));
+            }
+        }
+
+        return result;
+    }
+
+    public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer) =>
+        serializer(value, type);
+}

--- a/src/Eryph.GuestServices.CloudConfig.Yaml/Converters/NetworkAddressListYamlConverter.cs
+++ b/src/Eryph.GuestServices.CloudConfig.Yaml/Converters/NetworkAddressListYamlConverter.cs
@@ -61,9 +61,18 @@ internal sealed class NetworkAddressListYamlConverter : IYamlTypeConverter
                 var first = true;
                 while (!parser.TryConsume<MappingEnd>(out _))
                 {
-                    var key = parser.Consume<Scalar>();
-                    if (first && !IsNullOrEmptyAddress(key.Value))
-                        result.Add(key.Value);
+                    // Keys are normally scalar IP strings, but YAML permits
+                    // complex (non-scalar) keys; drain those instead of
+                    // throwing, keeping the "never throw on valid YAML" goal.
+                    if (parser.TryConsume<Scalar>(out var key))
+                    {
+                        if (first && !IsNullOrEmptyAddress(key.Value))
+                            result.Add(key.Value);
+                    }
+                    else
+                    {
+                        _ = rootDeserializer(typeof(object));
+                    }
                     first = false;
                     _ = rootDeserializer(typeof(object));
                 }

--- a/src/Eryph.GuestServices.CloudConfig.Yaml/Converters/NetworkAddressListYamlConverter.cs
+++ b/src/Eryph.GuestServices.CloudConfig.Yaml/Converters/NetworkAddressListYamlConverter.cs
@@ -32,7 +32,7 @@ internal sealed class NetworkAddressListYamlConverter : IYamlTypeConverter
         // tolerant — treat it as a single address, or nothing.
         if (parser.TryConsume<Scalar>(out var lone))
         {
-            if (!string.IsNullOrWhiteSpace(lone.Value))
+            if (!IsNullOrEmptyAddress(lone.Value))
                 result.Add(lone.Value);
             return result;
         }
@@ -48,7 +48,9 @@ internal sealed class NetworkAddressListYamlConverter : IYamlTypeConverter
         {
             if (parser.TryConsume<Scalar>(out var item))
             {
-                if (!string.IsNullOrWhiteSpace(item.Value))
+                // A null/empty list entry (`- ~`, `- null`, `-`) is dropped
+                // rather than kept as a junk address.
+                if (!IsNullOrEmptyAddress(item.Value))
                     result.Add(item.Value);
             }
             else if (parser.TryConsume<MappingStart>(out _))
@@ -60,7 +62,7 @@ internal sealed class NetworkAddressListYamlConverter : IYamlTypeConverter
                 while (!parser.TryConsume<MappingEnd>(out _))
                 {
                     var key = parser.Consume<Scalar>();
-                    if (first && !string.IsNullOrWhiteSpace(key.Value))
+                    if (first && !IsNullOrEmptyAddress(key.Value))
                         result.Add(key.Value);
                     first = false;
                     _ = rootDeserializer(typeof(object));
@@ -78,4 +80,9 @@ internal sealed class NetworkAddressListYamlConverter : IYamlTypeConverter
 
     public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer) =>
         serializer(value, type);
+
+    // YAML 1.1 null tokens (and empty/whitespace) are not addresses. A plain
+    // `~`/`null` entry is a placeholder, not an address literal, so we drop it.
+    private static bool IsNullOrEmptyAddress(string? value) =>
+        string.IsNullOrWhiteSpace(value) || value is "~" or "null" or "Null" or "NULL";
 }

--- a/src/Eryph.GuestServices.CloudConfig.Yaml/NetworkConfigYamlSerializer.cs
+++ b/src/Eryph.GuestServices.CloudConfig.Yaml/NetworkConfigYamlSerializer.cs
@@ -222,7 +222,23 @@ public static class NetworkConfigYamlSerializer
             Mtu = raw.Mtu,
             MacAddress = raw.MacAddress,
             Routes = raw.Routes?.Select(ConvertRoute).ToList(),
+            UnsupportedOptions = CollectUnsupportedOptions(raw),
         };
+    }
+
+    // Surface v2 keys that are present but not honoured on Windows so the
+    // applier can warn. Order matches the document's logical grouping; only
+    // non-null (present) keys are listed.
+    private static IReadOnlyList<string>? CollectUnsupportedOptions(RawEthernetConfig raw)
+    {
+        var options = new List<string>();
+        if (raw.Dhcp4Overrides is not null) options.Add("dhcp4-overrides");
+        if (raw.Dhcp6Overrides is not null) options.Add("dhcp6-overrides");
+        if (raw.RoutingPolicy is not null) options.Add("routing-policy");
+        if (raw.SetName is not null) options.Add("set-name");
+        if (raw.WakeOnLan is not null) options.Add("wakeonlan");
+        if (raw.AcceptRa is not null) options.Add("accept-ra");
+        return options.Count == 0 ? null : options;
     }
 
     private static NetworkBondConfig ConvertBond(RawBondConfig? raw)
@@ -377,6 +393,23 @@ public static class NetworkConfigYamlSerializer
         [YamlMember(Alias = "macaddress", ApplyNamingConventions = false)]
         public string? MacAddress { get; set; }
         public List<RawRoute>? Routes { get; set; }
+
+        // v2 keys we parse only to detect their PRESENCE so the applier can
+        // warn that they are not applied on Windows (rather than dropping them
+        // silently via IgnoreUnmatchedProperties). Typed loosely (object) so an
+        // arbitrary sub-shape can never throw. See CollectUnsupportedOptions.
+        [YamlMember(Alias = "dhcp4-overrides", ApplyNamingConventions = false)]
+        public object? Dhcp4Overrides { get; set; }
+        [YamlMember(Alias = "dhcp6-overrides", ApplyNamingConventions = false)]
+        public object? Dhcp6Overrides { get; set; }
+        [YamlMember(Alias = "routing-policy", ApplyNamingConventions = false)]
+        public object? RoutingPolicy { get; set; }
+        [YamlMember(Alias = "set-name", ApplyNamingConventions = false)]
+        public string? SetName { get; set; }
+        [YamlMember(Alias = "wakeonlan", ApplyNamingConventions = false)]
+        public bool? WakeOnLan { get; set; }
+        [YamlMember(Alias = "accept-ra", ApplyNamingConventions = false)]
+        public bool? AcceptRa { get; set; }
     }
 
     // cloud-init v2 'match' sub-map. Modelled as an object (not a string) so a

--- a/src/Eryph.GuestServices.CloudConfig.Yaml/NetworkConfigYamlSerializer.cs
+++ b/src/Eryph.GuestServices.CloudConfig.Yaml/NetworkConfigYamlSerializer.cs
@@ -188,7 +188,7 @@ public static class NetworkConfigYamlSerializer
 
         return new NetworkEthernetConfig
         {
-            Match = raw.Match,
+            Match = ConvertMatch(raw.Match),
             Dhcp4 = raw.Dhcp4,
             Dhcp6 = raw.Dhcp6,
             Addresses = raw.Addresses,
@@ -233,6 +233,21 @@ public static class NetworkConfigYamlSerializer
         {
             Link = raw.Link,
             Id = raw.Id,
+        };
+    }
+
+    private static NetworkMatch? ConvertMatch(RawMatch? raw)
+    {
+        // Drop an empty/all-null match block so downstream "has a selector?"
+        // checks stay a simple null test.
+        if (raw is null || (raw.Name is null && raw.MacAddress is null && raw.Driver is null))
+            return null;
+
+        return new NetworkMatch
+        {
+            Name = raw.Name,
+            MacAddress = raw.MacAddress,
+            Driver = raw.Driver,
         };
     }
 
@@ -313,7 +328,7 @@ public static class NetworkConfigYamlSerializer
 
     private sealed class RawEthernetConfig
     {
-        public string? Match { get; set; }
+        public RawMatch? Match { get; set; }
         public bool? Dhcp4 { get; set; }
         public bool? Dhcp6 { get; set; }
         public List<string>? Addresses { get; set; }
@@ -328,6 +343,21 @@ public static class NetworkConfigYamlSerializer
         [YamlMember(Alias = "macaddress", ApplyNamingConventions = false)]
         public string? MacAddress { get; set; }
         public List<RawRoute>? Routes { get; set; }
+    }
+
+    // cloud-init v2 'match' sub-map. Modelled as an object (not a string) so a
+    // `match: {macaddress: ..}` block parses instead of throwing — the bug
+    // behind issue #59, where the swallowed parse failure nulled the whole
+    // network-config.
+    private sealed class RawMatch
+    {
+        public string? Name { get; set; }
+        // netplan spells it 'macaddress' (no underscore), same as the
+        // top-level ethernet field; pin the alias so the underscored naming
+        // convention can't rewrite it to 'mac_address'.
+        [YamlMember(Alias = "macaddress", ApplyNamingConventions = false)]
+        public string? MacAddress { get; set; }
+        public string? Driver { get; set; }
     }
 
     private sealed class RawBondConfig

--- a/src/Eryph.GuestServices.CloudConfig.Yaml/NetworkConfigYamlSerializer.cs
+++ b/src/Eryph.GuestServices.CloudConfig.Yaml/NetworkConfigYamlSerializer.cs
@@ -21,6 +21,12 @@ public static class NetworkConfigYamlSerializer
             .WithEnumNamingConvention(UnderscoredNamingConvention.Instance)
             .WithNamingConvention(UnderscoredNamingConvention.Instance)
             .IgnoreUnmatchedProperties()
+            // The v2 `addresses:` list accepts both plain scalars and the
+            // advanced single-key map form; this converter keeps the address
+            // and never throws on the map shape (issue #59 failure class).
+            .WithAttributeOverride<RawEthernetConfig>(
+                e => e.Addresses!,
+                new YamlConverterAttribute(typeof(NetworkAddressListYamlConverter)))
             // PyYAML SafeLoader-equivalent YAML 1.1 scalar resolution. The
             // network-config schema has int? fields (mtu, vlan id, route
             // metric) where leading-zero octal / underscore forms must parse
@@ -28,6 +34,9 @@ public static class NetworkConfigYamlSerializer
             .WithNodeDeserializer(
                 new Yaml11ScalarResolver(),
                 s => s.Before<ScalarNodeDeserializer>())
+            // Registered so YamlDotNet can resolve the converter attached via
+            // WithAttributeOverride above (it reports Accepts(_) => false).
+            .WithTypeConverter(new NetworkAddressListYamlConverter())
             .Build());
 
     public static NetworkConfig Deserialize(string yaml)
@@ -39,7 +48,15 @@ public static class NetworkConfigYamlSerializer
         // expanded — netplan/network-config uses anchors to share common
         // interface settings, matching PyYAML SafeLoader.
         var parser = new MergingParser(new Parser(new StringReader(yaml)));
-        var raw = Deserializer.Value.Deserialize<RawNetworkConfig?>(parser) ?? new RawNetworkConfig();
+        var root = Deserializer.Value.Deserialize<RawNetworkRoot?>(parser) ?? new RawNetworkRoot();
+
+        // netplan and many cloud-init samples wrap the whole document under a
+        // top-level `network:` key (the form every /etc/netplan file uses);
+        // the bare form (version/ethernets at the root) is equally valid. When
+        // the wrapper is present it carries the real config — unwrap it so both
+        // forms parse identically instead of the wrapped one yielding an empty
+        // result (the issue #59 silent-failure class).
+        var raw = root.Network ?? root;
 
         // v1 carries a 'config' list rather than top-level ethernets/bonds/.. —
         // project the physical entries to the v2-shape Ethernets dictionary so
@@ -278,9 +295,19 @@ public static class NetworkConfigYamlSerializer
         _ => NetworkDhcpRenderer.Other,
     };
 
+    // Root shape that also accepts the `network:`-wrapped form. When the wrapper
+    // is present, YamlDotNet populates Network and leaves the inherited
+    // top-level fields at their defaults; the bare form populates the inherited
+    // fields and leaves Network null. Deserialize() picks whichever carries the
+    // config.
+    private sealed class RawNetworkRoot : RawNetworkConfig
+    {
+        public RawNetworkConfig? Network { get; set; }
+    }
+
     // Mutable raw shape so YamlDotNet can populate it; converted into the
     // immutable model above.
-    private sealed class RawNetworkConfig
+    private class RawNetworkConfig
     {
         public int Version { get; set; }
         public string? Renderer { get; set; }

--- a/src/Eryph.GuestServices.CloudConfig.Yaml/NetworkConfigYamlSerializer.cs
+++ b/src/Eryph.GuestServices.CloudConfig.Yaml/NetworkConfigYamlSerializer.cs
@@ -44,6 +44,13 @@ public static class NetworkConfigYamlSerializer
         if (string.IsNullOrWhiteSpace(yaml))
             return new NetworkConfig();
 
+        // Strip a leading UTF-8 BOM if a producer (often a Windows editor, and
+        // this is Windows-side tooling) emitted one. The StringReader path below
+        // does not skip it and the parser would choke on U+FEFF before the
+        // document. Mirrors NoCloudDataSource.DecodeUtf8.
+        if (yaml[0] == '\uFEFF')
+            yaml = yaml[1..];
+
         // Wrap in a MergingParser so YAML 1.1 merge keys (`<<: *anchor`) are
         // expanded — netplan/network-config uses anchors to share common
         // interface settings, matching PyYAML SafeLoader.

--- a/src/Eryph.GuestServices.CloudConfig/Configs/NetworkConfig.cs
+++ b/src/Eryph.GuestServices.CloudConfig/Configs/NetworkConfig.cs
@@ -21,9 +21,11 @@ public sealed record NetworkConfig
 
 public sealed record NetworkEthernetConfig
 {
-    // The cloud-init v2 'match' clause is a sub-object (name / macaddress / driver).
-    // For v1 we keep it as a free-form string. A richer model can land later if needed.
-    public string? Match { get; init; }
+    // The cloud-init v2 'match' clause is a sub-object (name / macaddress / driver)
+    // used to bind this entry to a physical NIC. On Windows we match by MAC, so
+    // Match.MacAddress is the selector the applier honours. v1 does not use it
+    // (v1 carries the MAC on the entry as mac_address -> MacAddress).
+    public NetworkMatch? Match { get; init; }
 
     public bool? Dhcp4 { get; init; }
 
@@ -61,6 +63,18 @@ public sealed record NetworkVlanConfig
     public string? Link { get; init; }
 
     public int? Id { get; init; }
+}
+
+// cloud-init v2 'match' selector. Any combination of name (glob), macaddress
+// and driver may be present; cloud-init applies the entry to NICs matching all
+// the given criteria. The Windows applier only resolves adapters by MAC today.
+public sealed record NetworkMatch
+{
+    public string? Name { get; init; }
+
+    public string? MacAddress { get; init; }
+
+    public string? Driver { get; init; }
 }
 
 public sealed record NetworkNameservers

--- a/src/Eryph.GuestServices.CloudConfig/Configs/NetworkConfig.cs
+++ b/src/Eryph.GuestServices.CloudConfig/Configs/NetworkConfig.cs
@@ -44,6 +44,12 @@ public sealed record NetworkEthernetConfig
     public string? MacAddress { get; init; }
 
     public IReadOnlyList<NetworkRoute>? Routes { get; init; }
+
+    // v2 keys that are present in the document but NOT applied on Windows
+    // (e.g. dhcp4-overrides, routing-policy, set-name). Captured at parse time
+    // purely so the applier can warn instead of silently dropping them — the
+    // names are the cloud-init/netplan spellings, for the log message.
+    public IReadOnlyList<string>? UnsupportedOptions { get; init; }
 }
 
 public sealed record NetworkBondConfig

--- a/src/Eryph.GuestServices.Provisioning/Modules/ApplyNetworkConfigModule.cs
+++ b/src/Eryph.GuestServices.Provisioning/Modules/ApplyNetworkConfigModule.cs
@@ -29,7 +29,18 @@ internal sealed class ApplyNetworkConfigModule(ILogger<ApplyNetworkConfigModule>
         // CloudConfig. ResolvedUserData carries the latter; the former is
         // surfaced via IModuleContext.DataSource.StructuredNetworkConfig.
         var network = context.DataSource.StructuredNetworkConfig;
-        if (network is null || network.Ethernets is null || network.Ethernets.Count == 0)
+        if (network is null)
+        {
+            logger.LogDebug("No network-config present; nothing to do.");
+            return ModuleOutcome.Ok();
+        }
+
+        // Surface constructs we parse but never apply on Windows so an operator
+        // isn't left guessing why their bond/VLAN/etc. did nothing — better a
+        // visible warning than a silent drop (the issue #59 lesson).
+        WarnUnappliedDeviceTypes(network);
+
+        if (network.Ethernets is null || network.Ethernets.Count == 0)
         {
             logger.LogDebug("No network-config ethernets to apply; nothing to do.");
             return ModuleOutcome.Ok();
@@ -78,10 +89,61 @@ internal sealed class ApplyNetworkConfigModule(ILogger<ApplyNetworkConfigModule>
                 continue;
             }
 
+            WarnUnappliedEthernetOptions(key, mac, ethernet);
+
             await ApplyToAdapter(context, adapter, ethernet, cancellationToken).ConfigureAwait(false);
         }
 
         return ModuleOutcome.Ok();
+    }
+
+    // Bonds, bridges and VLANs are modelled by the parser (so they don't break
+    // the document) but the Windows applier only configures ethernets. Warn for
+    // each group that is present rather than dropping it silently.
+    private void WarnUnappliedDeviceTypes(NetworkConfig network)
+    {
+        WarnDeviceGroup("bond", network.Bonds?.Keys);
+        WarnDeviceGroup("bridge", network.Bridges?.Keys);
+        WarnDeviceGroup("VLAN", network.Vlans?.Keys);
+    }
+
+    private void WarnDeviceGroup(string kind, IEnumerable<string>? names)
+    {
+        if (names is null)
+            return;
+        var list = names.ToList();
+        if (list.Count == 0)
+            return;
+        logger.LogWarning(
+            "Network-config defines {Count} {Kind}(s) ({Names}) which are not applied on Windows; ignoring.",
+            list.Count, kind, string.Join(", ", list));
+    }
+
+    // Per-interface v2 keys we parse but don't honour on Windows. They are
+    // surfaced (not applied) so an operator sees why e.g. a routing-policy or
+    // dhcp4-overrides had no effect.
+    private void WarnUnappliedEthernetOptions(string key, string mac, NetworkEthernetConfig ethernet)
+    {
+        if (ethernet.UnsupportedOptions is { Count: > 0 } options)
+        {
+            logger.LogWarning(
+                "Network-config entry '{Name}' ({Mac}): option(s) {Options} are not applied on Windows; ignoring.",
+                key, mac, string.Join(", ", options));
+        }
+
+        // A top-level `macaddress` that differs from the match selector is a
+        // request to SET/spoof the adapter MAC — we never change the MAC.
+        if (!string.IsNullOrEmpty(ethernet.Match?.MacAddress)
+            && !string.IsNullOrEmpty(ethernet.MacAddress)
+            && !string.Equals(
+                NormaliseMac(ethernet.MacAddress),
+                NormaliseMac(ethernet.Match!.MacAddress),
+                StringComparison.Ordinal))
+        {
+            logger.LogWarning(
+                "Network-config entry '{Name}': setting a new adapter MAC ({Mac}) is not supported on Windows; the adapter MAC is left unchanged.",
+                key, ethernet.MacAddress);
+        }
     }
 
     private async Task ApplyToAdapter(

--- a/src/Eryph.GuestServices.Provisioning/Modules/ApplyNetworkConfigModule.cs
+++ b/src/Eryph.GuestServices.Provisioning/Modules/ApplyNetworkConfigModule.cs
@@ -52,12 +52,18 @@ internal sealed class ApplyNetworkConfigModule(ILogger<ApplyNetworkConfigModule>
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var mac = NormaliseMac(ethernet.MacAddress);
+            // cloud-init/netplan binds an entry to a NIC via `match.macaddress`
+            // (the selector); the top-level `macaddress` instead SETS/spoofs the
+            // adapter MAC. Prefer the selector, then fall back to the top-level
+            // value so configs that (ab)use it as a key — like our synthetic
+            // fixtures — keep resolving. See issue #59.
+            var mac = NormaliseMac(ethernet.Match?.MacAddress ?? ethernet.MacAddress);
             if (string.IsNullOrEmpty(mac))
             {
-                // v1 sometimes omits mac_address; we have no way to bind that
-                // entry to a specific Windows adapter, so log and continue
-                // (matching cloud-init's "skip unmatched" semantics).
+                // No MAC selector at all (v1 may omit mac_address; a v2 match
+                // may carry only name/driver). We have no way to bind that entry
+                // to a specific Windows adapter, so log and continue (matching
+                // cloud-init's "skip unmatched" semantics).
                 logger.LogWarning(
                     "Network-config entry '{Name}' has no MAC address; skipping (Windows requires MAC matching).",
                     key);

--- a/src/Eryph.GuestServices.Provisioning/Windows/Win32/CimNetworking.cs
+++ b/src/Eryph.GuestServices.Provisioning/Windows/Win32/CimNetworking.cs
@@ -346,42 +346,12 @@ internal static class CimNetworking
         }
     }
 
-    public static void SetDnsServers(int interfaceIndex, IReadOnlyList<string> dnsServers)
-    {
-        using var session = CimSession.Create(null);
-
-        // Group addresses by family so we can call SetDnsClientServerAddress
-        // once per family — passing a mixed list confuses the provider.
-        // Empty arrays reset that family back to DHCP-driven discovery.
-        var byFamily = dnsServers
-            .Select(s => (s, family: GetAddressFamily(s)))
-            .Where(t => t.family is 2 or 23)
-            .GroupBy(t => t.family);
-
-        var familiesWritten = new HashSet<ushort>();
-        foreach (var group in byFamily)
-        {
-            var family = (ushort)group.Key;
-            familiesWritten.Add(family);
-            InvokeSetDns(session, interfaceIndex, family, group.Select(t => t.s).ToArray());
-        }
-
-        // When the caller passes an empty desired list, we still need to
-        // reset both families explicitly so previously-applied DNS doesn't
-        // linger.
-        if (dnsServers.Count == 0)
-        {
-            InvokeSetDns(session, interfaceIndex, 2, Array.Empty<string>());
-            InvokeSetDns(session, interfaceIndex, 23, Array.Empty<string>());
-        }
-        else
-        {
-            // If the caller listed only IPv4 addresses, leave IPv6 alone
-            // (and vice versa). We do NOT clear families the caller didn't
-            // mention — that would surprise dual-stack guests.
-            _ = familiesWritten;
-        }
-    }
+    // NOTE: DNS server configuration intentionally does NOT live here. The
+    // MSFT_DNSClientServerAddress provider exposes no settable property
+    // (ServerAddresses is ReadOnly) and no static set method, and a raw MI
+    // ModifyInstance with the cmdlet's operation options is rejected with
+    // "Invalid parameter". DNS is therefore applied via the
+    // Set-DnsClientServerAddress cmdlet in WindowsOs.SetDnsServersAsync.
 
     public static void SetInterfaceMtu(int interfaceIndex, int mtu)
     {
@@ -406,31 +376,6 @@ internal static class CimNetworking
     }
 
     // ---- helpers ----
-
-    private static void InvokeSetDns(CimSession session, int interfaceIndex, ushort family, string[] servers)
-    {
-        using var parameters = new CimMethodParametersCollection
-        {
-            CimMethodParameter.Create("InterfaceIndex", (uint)interfaceIndex, CimType.UInt32, CimFlags.None),
-            CimMethodParameter.Create("AddressFamily", family, CimType.UInt16, CimFlags.None),
-            CimMethodParameter.Create(
-                "ServerAddresses",
-                servers,
-                CimType.StringArray,
-                servers.Length == 0 ? CimFlags.NullValue : CimFlags.None),
-            CimMethodParameter.Create("ResetServerAddresses", servers.Length == 0, CimType.Boolean, CimFlags.None),
-        };
-
-        // MSFT_DNSClientServerAddress lives at the class level; the static
-        // method SetServerAddress is the standard write path used by
-        // Set-DnsClientServerAddress under the hood.
-        using var result = session.InvokeMethod(
-            StandardCimNamespace,
-            "MSFT_DNSClientServerAddress",
-            "SetServerAddress",
-            parameters);
-        CheckReturn(result, $"MSFT_DNSClientServerAddress.SetServerAddress(family={family})");
-    }
 
     private static CimInstance? FindIpInterface(CimSession session, int interfaceIndex, ushort addressFamily)
     {
@@ -533,17 +478,5 @@ internal static class CimNetworking
         // Round-trip via IPAddress so "10.0.0.05" -> "10.0.0.5" etc.
         var ip = IPAddress.Parse(address);
         return $"{ip}/{prefix}";
-    }
-
-    private static ushort GetAddressFamily(string address)
-    {
-        if (!IPAddress.TryParse(address, out var ip))
-            return 0;
-        return ip.AddressFamily switch
-        {
-            System.Net.Sockets.AddressFamily.InterNetwork => 2,
-            System.Net.Sockets.AddressFamily.InterNetworkV6 => 23,
-            _ => 0,
-        };
     }
 }

--- a/src/Eryph.GuestServices.Provisioning/Windows/WindowsOs.cs
+++ b/src/Eryph.GuestServices.Provisioning/Windows/WindowsOs.cs
@@ -495,15 +495,25 @@ internal sealed class WindowsOs : IWindowsOs
 
     // internal for unit testing — the -Command string is a composition root we
     // want exercised directly (a wrong cmdlet/parameter name or a quoting slip
-    // would otherwise only surface on a real guest). An empty list resets the
-    // interface back to DHCP-provided servers; otherwise the whole (possibly
-    // mixed IPv4+IPv6) list is handed to the cmdlet, which assigns each address
-    // to the correct family.
-    internal static string BuildSetDnsServersCommand(int interfaceIndex, IReadOnlyList<string> dnsServers) =>
-        dnsServers.Count == 0
+    // would otherwise only surface on a real guest). Null/blank entries are
+    // dropped first: the YAML 1.1 resolver turns a `~`/`null`/empty nameserver
+    // into a null/blank string, which would NRE in FormatPsStringList or emit an
+    // invalid -ServerAddresses. A list that is empty (or empties out after that)
+    // resets the interface back to DHCP-provided servers; otherwise the whole
+    // (possibly mixed IPv4+IPv6) list is handed to the cmdlet, which assigns each
+    // address to the correct family.
+    internal static string BuildSetDnsServersCommand(int interfaceIndex, IReadOnlyList<string> dnsServers)
+    {
+        var servers = dnsServers
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Select(s => s.Trim())
+            .ToList();
+
+        return servers.Count == 0
             ? $"Set-DnsClientServerAddress -InterfaceIndex {interfaceIndex} -ResetServerAddresses -ErrorAction Stop"
             : $"Set-DnsClientServerAddress -InterfaceIndex {interfaceIndex} "
-              + $"-ServerAddresses {FormatPsStringList(dnsServers)} -ErrorAction Stop";
+              + $"-ServerAddresses {FormatPsStringList(servers)} -ErrorAction Stop";
+    }
 
     // Render a PowerShell single-quoted, comma-separated string array literal
     // (e.g. 'a','b') for use inside a -Command script. Each value is escaped so

--- a/src/Eryph.GuestServices.Provisioning/Windows/WindowsOs.cs
+++ b/src/Eryph.GuestServices.Provisioning/Windows/WindowsOs.cs
@@ -473,11 +473,43 @@ internal sealed class WindowsOs : IWindowsOs
         CancellationToken cancellationToken) =>
         Task.Run(() => CimNetworking.SetIpv4DefaultGateway(interfaceIndex, gateway), cancellationToken);
 
-    public Task SetDnsServersAsync(
+    public async Task SetDnsServersAsync(
         int interfaceIndex,
         IReadOnlyList<string> dnsServers,
-        CancellationToken cancellationToken) =>
-        Task.Run(() => CimNetworking.SetDnsServers(interfaceIndex, dnsServers), cancellationToken);
+        CancellationToken cancellationToken)
+    {
+        // DNS servers are set via the Set-DnsClientServerAddress cmdlet, not CIM.
+        // MSFT_DNSClientServerAddress exposes no settable property (ServerAddresses
+        // is ReadOnly) and no static set method (only RequestStateChange); the
+        // cmdlet sets DNS through a parameterized ModifyInstance envelope that a
+        // raw MI ModifyInstance cannot reproduce — the DCOM provider rejects the
+        // custom options with "Invalid parameter". The cmdlet takes the interface
+        // index directly and assigns a mixed IPv4+IPv6 list to the correct family,
+        // so the whole list goes in one call. An empty list resets the interface
+        // back to DHCP-provided servers.
+        await RunOrThrowAsync(
+            "powershell.exe",
+            ["-NoProfile", "-NonInteractive", "-Command", BuildSetDnsServersCommand(interfaceIndex, dnsServers)],
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    // internal for unit testing — the -Command string is a composition root we
+    // want exercised directly (a wrong cmdlet/parameter name or a quoting slip
+    // would otherwise only surface on a real guest). An empty list resets the
+    // interface back to DHCP-provided servers; otherwise the whole (possibly
+    // mixed IPv4+IPv6) list is handed to the cmdlet, which assigns each address
+    // to the correct family.
+    internal static string BuildSetDnsServersCommand(int interfaceIndex, IReadOnlyList<string> dnsServers) =>
+        dnsServers.Count == 0
+            ? $"Set-DnsClientServerAddress -InterfaceIndex {interfaceIndex} -ResetServerAddresses -ErrorAction Stop"
+            : $"Set-DnsClientServerAddress -InterfaceIndex {interfaceIndex} "
+              + $"-ServerAddresses {FormatPsStringList(dnsServers)} -ErrorAction Stop";
+
+    // Render a PowerShell single-quoted, comma-separated string array literal
+    // (e.g. 'a','b') for use inside a -Command script. Each value is escaped so
+    // a stray single quote can't break out of the literal.
+    private static string FormatPsStringList(IReadOnlyList<string> values) =>
+        string.Join(",", values.Select(v => $"'{EscapePsSingleQuoted(v)}'"));
 
     public Task EnableDhcp6Async(int interfaceIndex, CancellationToken cancellationToken) =>
         Task.Run(() => CimNetworking.SetDhcp6(interfaceIndex, enabled: true), cancellationToken);

--- a/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/NetworkConfigYamlSerializerTests.cs
+++ b/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/NetworkConfigYamlSerializerTests.cs
@@ -250,13 +250,17 @@ public class NetworkConfigYamlSerializerTests
         eth0.Gateway4.Should().BeNull();
         eth0.Addresses.Should().BeNull();
         eth0.Routes.Should().BeNull();
+        // ...but their presence is surfaced so the applier can warn.
+        eth0.UnsupportedOptions.Should().BeEquivalentTo(["dhcp4-overrides", "dhcp6-overrides"]);
     }
 
     [Fact]
     public void Deserialize_v2_unmodelled_scalar_keys_are_tolerated()
     {
         // set-name / wakeonlan / optional / accept-ra are valid netplan keys
-        // the Windows applier does not act on. They must not break parsing.
+        // the Windows applier does not act on. They must not break parsing, and
+        // the noteworthy ones are surfaced via UnsupportedOptions so the applier
+        // can warn (optional is benign and intentionally not surfaced).
         const string yaml = """
                             version: 2
                             ethernets:
@@ -275,6 +279,7 @@ public class NetworkConfigYamlSerializerTests
         var eth0 = result.Ethernets!["eth0"];
         eth0.Match!.MacAddress.Should().Be("00:11:22:33:44:55");
         eth0.Dhcp4.Should().BeTrue();
+        eth0.UnsupportedOptions.Should().BeEquivalentTo(["set-name", "wakeonlan", "accept-ra"]);
     }
 
     [Fact]
@@ -515,8 +520,10 @@ public class NetworkConfigYamlSerializerTests
 
         var eth0 = result.Ethernets!["eth0"];
         eth0.Addresses.Should().BeEquivalentTo(["10.0.0.5/24"]);
-        // routing-policy is dropped, not misread into modelled routes.
+        // routing-policy is dropped, not misread into modelled routes...
         eth0.Routes.Should().BeNull();
+        // ...and surfaced so the applier can warn.
+        eth0.UnsupportedOptions.Should().BeEquivalentTo(["routing-policy"]);
     }
 
     [Fact]

--- a/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/NetworkConfigYamlSerializerTests.cs
+++ b/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/NetworkConfigYamlSerializerTests.cs
@@ -245,6 +245,11 @@ public class NetworkConfigYamlSerializerTests
         var eth0 = result.Ethernets!["eth0"];
         eth0.Dhcp4.Should().BeTrue();
         eth0.MacAddress.Should().Be("00:11:22:33:44:55");
+        // The drained override blocks must not leak into sibling fields.
+        eth0.Dhcp6.Should().BeNull();
+        eth0.Gateway4.Should().BeNull();
+        eth0.Addresses.Should().BeNull();
+        eth0.Routes.Should().BeNull();
     }
 
     [Fact]
@@ -508,7 +513,10 @@ public class NetworkConfigYamlSerializerTests
 
         var result = NetworkConfigYamlSerializer.Deserialize(yaml);
 
-        result.Ethernets!["eth0"].Addresses.Should().BeEquivalentTo(["10.0.0.5/24"]);
+        var eth0 = result.Ethernets!["eth0"];
+        eth0.Addresses.Should().BeEquivalentTo(["10.0.0.5/24"]);
+        // routing-policy is dropped, not misread into modelled routes.
+        eth0.Routes.Should().BeNull();
     }
 
     [Fact]
@@ -674,6 +682,326 @@ public class NetworkConfigYamlSerializerTests
         result.Bonds.Should().ContainKey("bond0");
         result.Bridges.Should().ContainKey("br0");
         result.Vlans.Should().ContainKey("vlan100");
+    }
+
+    // ----- YAML syntax robustness (cross-model review gaps) -----
+
+    [Fact]
+    public void Deserialize_v2_anchors_and_merge_keys_are_expanded()
+    {
+        // netplan factors shared interface settings out with a YAML anchor and
+        // pulls them in via a `<<:` merge key. The serializer wraps input in a
+        // MergingParser specifically for this; prove it for network-config.
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              _base: &base
+                                dhcp4: true
+                                mtu: 1500
+                                nameservers:
+                                  addresses: [1.1.1.1]
+                              eth0:
+                                <<: *base
+                                match:
+                                  macaddress: "00:11:22:33:44:55"
+                                addresses: [10.0.0.5/24]
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        var eth0 = result.Ethernets!["eth0"];
+        eth0.Dhcp4.Should().BeTrue();                 // merged from anchor
+        eth0.Mtu.Should().Be(1500);                   // merged from anchor
+        eth0.Nameservers!.Addresses.Should().BeEquivalentTo(["1.1.1.1"]); // merged
+        eth0.Match!.MacAddress.Should().Be("00:11:22:33:44:55");          // local
+        eth0.Addresses.Should().BeEquivalentTo(["10.0.0.5/24"]);          // local
+    }
+
+    [Fact]
+    public void Deserialize_v2_unquoted_mac_in_match_and_top_level()
+    {
+        // Hand-written netplan and several generators emit MACs WITHOUT quotes.
+        // A MAC is a plain scalar (no colon-space), and MAC/macaddress are
+        // string targets so the YAML 1.1 resolver never coerces them.
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                match:
+                                  macaddress: 02:00:00:ad:e2:71
+                                dhcp4: true
+                              eth1:
+                                macaddress: 00:00:00:00:00:12
+                                dhcp4: true
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Ethernets!["eth0"].Match!.MacAddress.Should().Be("02:00:00:ad:e2:71");
+        // An all-decimal-looking MAC must not be mangled into a number.
+        result.Ethernets!["eth1"].MacAddress.Should().Be("00:00:00:00:00:12");
+    }
+
+    [Fact]
+    public void Deserialize_v2_unquoted_ipv6_addresses_and_gateway()
+    {
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                addresses:
+                                  - fd00::5/64
+                                gateway6: fd00::1
+                                nameservers:
+                                  addresses:
+                                    - 2606:4700:4700::1111
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        var eth0 = result.Ethernets!["eth0"];
+        eth0.Addresses.Should().BeEquivalentTo(["fd00::5/64"]);
+        eth0.Gateway6.Should().Be("fd00::1");
+        eth0.Nameservers!.Addresses.Should().BeEquivalentTo(["2606:4700:4700::1111"]);
+    }
+
+    [Fact]
+    public void Deserialize_v2_quoted_bool_tokens_still_parse_as_bool()
+    {
+        // dhcp4/dhcp6 are bool? targets; the YAML 1.1 resolver accepts the bool
+        // token whether plain or quoted (cloud-init parity), so "no"/"yes" parse.
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                dhcp4: "no"
+                                dhcp6: "yes"
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Ethernets!["eth0"].Dhcp4.Should().BeFalse();
+        result.Ethernets!["eth0"].Dhcp6.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Deserialize_v2_addresses_empty_list_yields_empty()
+    {
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                addresses: []
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Ethernets!["eth0"].Addresses.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public void Deserialize_v2_addresses_explicit_null_yields_empty()
+    {
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                addresses: ~
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Ethernets!["eth0"].Addresses.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public void Deserialize_v2_addresses_lone_scalar_is_promoted_to_list()
+    {
+        // Some old generators emit a single address as a scalar, not a list.
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                addresses: 10.0.0.5/24
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Ethernets!["eth0"].Addresses.Should().BeEquivalentTo(["10.0.0.5/24"]);
+    }
+
+    [Fact]
+    public void Deserialize_v2_addresses_null_entry_in_list_is_dropped()
+    {
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                addresses:
+                                  - 10.0.0.5/24
+                                  - ~
+                                  - fd00::1/64
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Ethernets!["eth0"].Addresses
+            .Should().BeEquivalentTo(["10.0.0.5/24", "fd00::1/64"]);
+    }
+
+    [Fact]
+    public void Deserialize_v2_advanced_address_map_empty_and_null_values()
+    {
+        // The advanced map form with an empty `{}` or a null value still yields
+        // just the address (the map key); it must not throw.
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                addresses:
+                                  - "10.0.0.5/24": {}
+                                  - "10.0.0.6/24":
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Ethernets!["eth0"].Addresses
+            .Should().BeEquivalentTo(["10.0.0.5/24", "10.0.0.6/24"]);
+    }
+
+    [Fact]
+    public void Deserialize_v2_advanced_address_flow_map_item()
+    {
+        // Flow-form of the advanced map item, as MAAS/cloud-init tooling emits.
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                addresses:
+                                  - 10.0.0.5/24
+                                  - {"fd00::5/64": {lifetime: 0}}
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Ethernets!["eth0"].Addresses
+            .Should().BeEquivalentTo(["10.0.0.5/24", "fd00::5/64"]);
+    }
+
+    [Fact]
+    public void Deserialize_v2_advanced_address_multi_key_map_keeps_first_strict()
+    {
+        // A multi-key map item does not occur in netplan; we deliberately keep
+        // only the first key (strict). This pins that behavior so it can't
+        // change silently.
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                addresses:
+                                  - "10.0.0.5/24": {label: a}
+                                    "10.0.0.6/24": {label: b}
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Ethernets!["eth0"].Addresses.Should().BeEquivalentTo(["10.0.0.5/24"]);
+    }
+
+    [Fact]
+    public void Deserialize_v2_with_comments_and_crlf_line_endings()
+    {
+        // Windows-authored configs use CRLF and operators add comments.
+        var yaml =
+            "version: 2\r\n" +
+            "ethernets:\r\n" +
+            "  eth0:  # primary nic\r\n" +
+            "    macaddress: \"00:11:22:33:44:55\"\r\n" +
+            "    # static address follows\r\n" +
+            "    addresses: [10.0.0.5/24]\r\n";
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        var eth0 = result.Ethernets!["eth0"];
+        eth0.MacAddress.Should().Be("00:11:22:33:44:55");
+        eth0.Addresses.Should().BeEquivalentTo(["10.0.0.5/24"]);
+    }
+
+    [Fact]
+    public void Deserialize_v2_leading_utf8_bom_is_stripped()
+    {
+        // A UTF-8 BOM from a Windows editor must not break the parse.
+        var yaml =
+            "\uFEFF" +
+            "version: 2\n" +
+            "ethernets:\n" +
+            "  eth0:\n" +
+            "    macaddress: \"00:11:22:33:44:55\"\n" +
+            "    dhcp4: true\n";
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Version.Should().Be(2);
+        result.Ethernets!["eth0"].Dhcp4.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Deserialize_v2_mac_address_underscore_form_does_not_bind_strict()
+    {
+        // v2 spells the selector `macaddress` (no underscore); `mac_address`
+        // is the v1 spelling. In a v2 ethernet it is not bound — strict, matching
+        // netplan. Pinned so the alias behavior can't regress silently.
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                mac_address: "00:11:22:33:44:55"
+                                dhcp4: true
+                              eth1:
+                                match:
+                                  mac_address: "00:11:22:33:44:66"
+                                dhcp4: true
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Ethernets!["eth0"].MacAddress.Should().BeNull();
+        result.Ethernets!["eth1"].Match.Should().BeNull();
+    }
+
+    [Fact]
+    public void Deserialize_v2_wrapper_takes_precedence_over_root_keys_strict()
+    {
+        // A malformed doc carrying BOTH a top-level ethernet and a `network:`
+        // wrapper: the wrapper wins and the root-level entry is dropped. Pin
+        // this precedence (strict) so it's intentional, not accidental.
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              rootonly:
+                                macaddress: "00:11:22:33:44:01"
+                                dhcp4: true
+                            network:
+                              version: 2
+                              ethernets:
+                                wrapped:
+                                  macaddress: "00:11:22:33:44:02"
+                                  dhcp4: true
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Ethernets.Should().ContainKey("wrapped");
+        result.Ethernets.Should().NotContainKey("rootonly");
     }
 
     [Fact]

--- a/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/NetworkConfigYamlSerializerTests.cs
+++ b/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/NetworkConfigYamlSerializerTests.cs
@@ -332,6 +332,351 @@ public class NetworkConfigYamlSerializerTests
     }
 
     [Fact]
+    public void Deserialize_v2_match_combines_name_macaddress_and_driver()
+    {
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                match:
+                                  name: "eth*"
+                                  macaddress: "00:11:22:33:44:55"
+                                  driver: "virtio_net"
+                                dhcp4: true
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        var match = result.Ethernets!["eth0"].Match!;
+        match.Name.Should().Be("eth*");
+        match.MacAddress.Should().Be("00:11:22:33:44:55");
+        match.Driver.Should().Be("virtio_net");
+    }
+
+    [Fact]
+    public void Deserialize_v2_static_dualstack_with_both_gateways()
+    {
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                addresses:
+                                  - 10.0.0.5/24
+                                  - "fd00::5/64"
+                                gateway4: 10.0.0.1
+                                gateway6: "fd00::1"
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        var eth0 = result.Ethernets!["eth0"];
+        eth0.Addresses.Should().BeEquivalentTo(["10.0.0.5/24", "fd00::5/64"]);
+        eth0.Gateway4.Should().Be("10.0.0.1");
+        eth0.Gateway6.Should().Be("fd00::1");
+    }
+
+    [Fact]
+    public void Deserialize_v2_dhcp4_and_dhcp6_both_true()
+    {
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                dhcp4: true
+                                dhcp6: true
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        var eth0 = result.Ethernets!["eth0"];
+        eth0.Dhcp4.Should().BeTrue();
+        eth0.Dhcp6.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Deserialize_v2_multiple_ethernets_in_one_document()
+    {
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              primary:
+                                match:
+                                  macaddress: "00:11:22:33:44:01"
+                                addresses: [10.0.0.5/24]
+                              secondary:
+                                match:
+                                  macaddress: "00:11:22:33:44:02"
+                                dhcp4: true
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Ethernets.Should().HaveCount(2);
+        result.Ethernets!["primary"].Match!.MacAddress.Should().Be("00:11:22:33:44:01");
+        result.Ethernets!["primary"].Addresses.Should().BeEquivalentTo(["10.0.0.5/24"]);
+        result.Ethernets!["secondary"].Match!.MacAddress.Should().Be("00:11:22:33:44:02");
+        result.Ethernets!["secondary"].Dhcp4.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Deserialize_v2_network_wrapper_is_equivalent_to_bare_form()
+    {
+        // netplan / many cloud-init samples nest everything under a top-level
+        // `network:` key. It must parse identically to the bare form (which it
+        // previously did not — the wrapper produced an empty config).
+        const string wrapped = """
+                            network:
+                              version: 2
+                              ethernets:
+                                eth0:
+                                  match:
+                                    macaddress: "00:11:22:33:44:55"
+                                  addresses: [10.0.0.5/24]
+                                  gateway4: 10.0.0.1
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(wrapped);
+
+        result.Version.Should().Be(2);
+        var eth0 = result.Ethernets!["eth0"];
+        eth0.Match!.MacAddress.Should().Be("00:11:22:33:44:55");
+        eth0.Addresses.Should().BeEquivalentTo(["10.0.0.5/24"]);
+        eth0.Gateway4.Should().Be("10.0.0.1");
+    }
+
+    [Fact]
+    public void Deserialize_v1_network_wrapper_is_unwrapped()
+    {
+        const string yaml = """
+                            network:
+                              version: 1
+                              config:
+                                - type: physical
+                                  name: eth0
+                                  mac_address: 00:11:22:33:44:55
+                                  subnets:
+                                    - type: dhcp
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Version.Should().Be(1);
+        result.Ethernets!["eth0"].Dhcp4.Should().BeTrue();
+        result.Ethernets!["eth0"].MacAddress.Should().Be("00:11:22:33:44:55");
+    }
+
+    [Fact]
+    public void Deserialize_v2_advanced_address_map_form_keeps_the_address()
+    {
+        // netplan's advanced form attaches per-address options via a single-key
+        // map. We keep the address (the key) and drop label/lifetime. The map
+        // form previously threw and nulled the whole config.
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                addresses:
+                                  - 10.0.0.5/24
+                                  - "fd00::5/64":
+                                      lifetime: 0
+                                      label: "maas"
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Ethernets!["eth0"].Addresses
+            .Should().BeEquivalentTo(["10.0.0.5/24", "fd00::5/64"]);
+    }
+
+    [Fact]
+    public void Deserialize_v2_routing_policy_block_is_tolerated()
+    {
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                addresses: [10.0.0.5/24]
+                                routing-policy:
+                                  - from: 10.0.0.0/24
+                                    table: 101
+                                    priority: 100
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Ethernets!["eth0"].Addresses.Should().BeEquivalentTo(["10.0.0.5/24"]);
+    }
+
+    [Fact]
+    public void Deserialize_v2_bond_with_parameters_and_addressing_is_tolerated()
+    {
+        // Bonds aren't applied on Windows, but a bond carrying addressing keys
+        // and a parameters map must still parse (and be preserved as a bond).
+        const string yaml = """
+                            version: 2
+                            bonds:
+                              bond0:
+                                interfaces: [eth0, eth1]
+                                parameters:
+                                  mode: 802.3ad
+                                  mii-monitor-interval: 100
+                                addresses: [10.0.0.9/24]
+                                dhcp4: false
+                                nameservers:
+                                  addresses: [1.1.1.1]
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Bonds.Should().ContainKey("bond0");
+        result.Bonds!["bond0"].Interfaces.Should().BeEquivalentTo(["eth0", "eth1"]);
+        result.Bonds!["bond0"].Parameters.Should().ContainKey("mode");
+    }
+
+    [Fact]
+    public void Deserialize_v2_bridge_with_parameters_and_addressing_is_tolerated()
+    {
+        const string yaml = """
+                            version: 2
+                            bridges:
+                              br0:
+                                interfaces: [eth0]
+                                parameters:
+                                  stp: true
+                                  forward-delay: 12
+                                addresses: [10.0.0.2/24]
+                                dhcp4: true
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Bridges.Should().ContainKey("br0");
+        result.Bridges!["br0"].Interfaces.Should().BeEquivalentTo(["eth0"]);
+    }
+
+    [Fact]
+    public void Deserialize_v2_vlan_with_addressing_is_tolerated()
+    {
+        const string yaml = """
+                            version: 2
+                            vlans:
+                              vlan100:
+                                id: 100
+                                link: eth0
+                                addresses: [10.0.100.5/24]
+                                gateway4: 10.0.100.1
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Vlans.Should().ContainKey("vlan100");
+        result.Vlans!["vlan100"].Id.Should().Be(100);
+        result.Vlans!["vlan100"].Link.Should().Be("eth0");
+    }
+
+    [Fact]
+    public void Deserialize_v2_kitchen_sink_document_parses_all_modelled_fields()
+    {
+        // A single document exercising the full v2 surface at once: every
+        // device type, the renderer, match selectors, both IP families, DNS,
+        // routes, MTU, and a pile of keys we tolerate but don't apply
+        // (set-name, wakeonlan, optional, accept-ra, dhcp overrides,
+        // routing-policy). The whole thing must parse without throwing and
+        // populate every field the applier consumes.
+        const string yaml = """
+                            network:
+                              version: 2
+                              renderer: networkd
+                              ethernets:
+                                primary:
+                                  match:
+                                    name: "eth*"
+                                    macaddress: "00:11:22:33:44:55"
+                                    driver: "virtio_net"
+                                  set-name: primary
+                                  wakeonlan: true
+                                  optional: true
+                                  accept-ra: false
+                                  dhcp4: false
+                                  dhcp6: false
+                                  dhcp4-overrides:
+                                    route-metric: 200
+                                  addresses:
+                                    - 10.0.0.5/24
+                                    - "fd00::5/64":
+                                        lifetime: 0
+                                  gateway4: 10.0.0.1
+                                  gateway6: "fd00::1"
+                                  nameservers:
+                                    addresses: [1.1.1.1, "2606:4700:4700::1111"]
+                                    search: [corp.local, example.com]
+                                  routes:
+                                    - to: 10.10.0.0/16
+                                      via: 10.0.0.254
+                                      metric: 100
+                                      on-link: true
+                                    - to: default
+                                      via: 10.0.0.1
+                                  routing-policy:
+                                    - from: 10.0.0.0/24
+                                      table: 101
+                                  mtu: 9000
+                                  macaddress: "00:11:22:33:44:55"
+                                fallback:
+                                  match:
+                                    macaddress: "00:11:22:33:44:66"
+                                  dhcp4: true
+                              bonds:
+                                bond0:
+                                  interfaces: [eth2, eth3]
+                                  parameters:
+                                    mode: active-backup
+                              bridges:
+                                br0:
+                                  interfaces: [bond0]
+                                  parameters:
+                                    stp: true
+                              vlans:
+                                vlan100:
+                                  id: 100
+                                  link: br0
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Version.Should().Be(2);
+        result.Renderer.Should().Be(NetworkDhcpRenderer.Networkd);
+
+        var primary = result.Ethernets!["primary"];
+        primary.Match!.Name.Should().Be("eth*");
+        primary.Match.MacAddress.Should().Be("00:11:22:33:44:55");
+        primary.Match.Driver.Should().Be("virtio_net");
+        primary.Dhcp4.Should().BeFalse();
+        primary.Dhcp6.Should().BeFalse();
+        primary.Addresses.Should().BeEquivalentTo(["10.0.0.5/24", "fd00::5/64"]);
+        primary.Gateway4.Should().Be("10.0.0.1");
+        primary.Gateway6.Should().Be("fd00::1");
+        primary.Nameservers!.Addresses.Should().BeEquivalentTo(["1.1.1.1", "2606:4700:4700::1111"]);
+        primary.Nameservers!.Search.Should().BeEquivalentTo(["corp.local", "example.com"]);
+        primary.Routes.Should().HaveCount(2);
+        primary.Routes![0].To.Should().Be("10.10.0.0/16");
+        primary.Routes![0].Via.Should().Be("10.0.0.254");
+        primary.Routes![0].Metric.Should().Be(100);
+        primary.Routes![1].To.Should().Be("default");
+        primary.Mtu.Should().Be(9000);
+        primary.MacAddress.Should().Be("00:11:22:33:44:55");
+
+        result.Ethernets!["fallback"].Dhcp4.Should().BeTrue();
+        result.Bonds.Should().ContainKey("bond0");
+        result.Bridges.Should().ContainKey("br0");
+        result.Vlans.Should().ContainKey("vlan100");
+    }
+
+    [Fact]
     public void Deserialize_v1_physical_with_dhcp_subnet_projects_to_ethernets()
     {
         // v1 has a 'config' list rather than top-level ethernets/..; physical

--- a/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/NetworkConfigYamlSerializerTests.cs
+++ b/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/NetworkConfigYamlSerializerTests.cs
@@ -925,6 +925,27 @@ public class NetworkConfigYamlSerializerTests
     }
 
     [Fact]
+    public void Deserialize_v2_address_map_with_non_scalar_key_does_not_throw()
+    {
+        // YAML permits a non-scalar mapping key. The converter must drain it
+        // rather than throw (its "never throw on valid YAML" goal); such a key
+        // carries no address, and a normal entry alongside it still parses.
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                addresses:
+                                  - {[a, b]: 0}
+                                  - 10.0.0.5/24
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Ethernets!["eth0"].Addresses.Should().BeEquivalentTo(["10.0.0.5/24"]);
+    }
+
+    [Fact]
     public void Deserialize_v2_with_comments_and_crlf_line_endings()
     {
         // Windows-authored configs use CRLF and operators add comments.

--- a/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/NetworkConfigYamlSerializerTests.cs
+++ b/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/NetworkConfigYamlSerializerTests.cs
@@ -149,6 +149,189 @@ public class NetworkConfigYamlSerializerTests
     }
 
     [Fact]
+    public void Deserialize_v2_match_macaddress_block_is_parsed()
+    {
+        // Real cloud-init/netplan binds an interface to a NIC via a `match`
+        // sub-map, NOT the top-level `macaddress` (which SETS/spoofs a MAC).
+        // Regression for issue #59: a `match:` mapping previously threw because
+        // Match was modelled as a string, and the swallowed exception left the
+        // whole network-config null.
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                match:
+                                  macaddress: "02:00:00:ad:e2:71"
+                                addresses:
+                                  - 192.168.8.210/24
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        var eth0 = result.Ethernets!["eth0"];
+        eth0.Match.Should().NotBeNull();
+        eth0.Match!.MacAddress.Should().Be("02:00:00:ad:e2:71");
+        eth0.Addresses.Should().BeEquivalentTo(["192.168.8.210/24"]);
+    }
+
+    [Fact]
+    public void Deserialize_v2_match_name_and_driver_are_parsed()
+    {
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                match:
+                                  name: "en*"
+                                  driver: "e1000"
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        var match = result.Ethernets!["eth0"].Match;
+        match.Should().NotBeNull();
+        match!.Name.Should().Be("en*");
+        match.Driver.Should().Be("e1000");
+        match.MacAddress.Should().BeNull();
+    }
+
+    [Fact]
+    public void Deserialize_v2_flow_style_from_issue_59()
+    {
+        // Verbatim payload from issue #59 (flow mappings + flow sequences),
+        // exactly as the eryph/vagrant generator wrote it to the cidata disk.
+        const string yaml = """
+                            ethernets:
+                              eth0:
+                                addresses: [192.168.8.210/24]
+                                gateway4: 192.168.8.1
+                                match: {macaddress: '02:00:00:ad:e2:71'}
+                                nameservers:
+                                  addresses: [192.168.8.1]
+                            version: 2
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Version.Should().Be(2);
+        var eth0 = result.Ethernets!["eth0"];
+        eth0.Match!.MacAddress.Should().Be("02:00:00:ad:e2:71");
+        eth0.Addresses.Should().BeEquivalentTo(["192.168.8.210/24"]);
+        eth0.Gateway4.Should().Be("192.168.8.1");
+        eth0.Nameservers!.Addresses.Should().BeEquivalentTo(["192.168.8.1"]);
+    }
+
+    [Fact]
+    public void Deserialize_v2_dhcp_overrides_blocks_are_tolerated()
+    {
+        // dhcp4-overrides / dhcp6-overrides are sub-maps we don't model. They
+        // must be ignored without aborting the parse — the issue-59 failure
+        // mode was a known key with an unexpected shape killing the document.
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                dhcp4: true
+                                dhcp4-overrides:
+                                  route-metric: 200
+                                  use-dns: false
+                                dhcp6-overrides:
+                                  use-dns: false
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        var eth0 = result.Ethernets!["eth0"];
+        eth0.Dhcp4.Should().BeTrue();
+        eth0.MacAddress.Should().Be("00:11:22:33:44:55");
+    }
+
+    [Fact]
+    public void Deserialize_v2_unmodelled_scalar_keys_are_tolerated()
+    {
+        // set-name / wakeonlan / optional / accept-ra are valid netplan keys
+        // the Windows applier does not act on. They must not break parsing.
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                match:
+                                  macaddress: "00:11:22:33:44:55"
+                                set-name: eth0
+                                wakeonlan: true
+                                optional: true
+                                accept-ra: false
+                                dhcp4: true
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        var eth0 = result.Ethernets!["eth0"];
+        eth0.Match!.MacAddress.Should().Be("00:11:22:33:44:55");
+        eth0.Dhcp4.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Deserialize_v2_dhcp_bool_yes_no_forms()
+    {
+        // YAML 1.1 / PyYAML bool tokens: cloud-init accepts yes/no/on/off.
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                dhcp4: no
+                                dhcp6: yes
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        var eth0 = result.Ethernets!["eth0"];
+        eth0.Dhcp4.Should().BeFalse();
+        eth0.Dhcp6.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Deserialize_v2_route_with_unmodelled_fields_is_tolerated()
+    {
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                routes:
+                                  - to: 10.10.0.0/16
+                                    via: 10.0.0.1
+                                    metric: 100
+                                    on-link: true
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        var route = result.Ethernets!["eth0"].Routes!.Single();
+        route.To.Should().Be("10.10.0.0/16");
+        route.Via.Should().Be("10.0.0.1");
+        route.Metric.Should().Be(100);
+    }
+
+    [Fact]
+    public void Deserialize_v2_ethernet_without_match_leaves_match_null()
+    {
+        const string yaml = """
+                            version: 2
+                            ethernets:
+                              eth0:
+                                macaddress: "00:11:22:33:44:55"
+                                dhcp4: true
+                            """;
+
+        var result = NetworkConfigYamlSerializer.Deserialize(yaml);
+
+        result.Ethernets!["eth0"].Match.Should().BeNull();
+    }
+
+    [Fact]
     public void Deserialize_v1_physical_with_dhcp_subnet_projects_to_ethernets()
     {
         // v1 has a 'config' list rather than top-level ethernets/..; physical

--- a/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/NetworkConfigYamlSerializerTests.cs
+++ b/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/NetworkConfigYamlSerializerTests.cs
@@ -161,17 +161,17 @@ public class NetworkConfigYamlSerializerTests
                             ethernets:
                               eth0:
                                 match:
-                                  macaddress: "02:00:00:ad:e2:71"
+                                  macaddress: "00:11:22:aa:bb:cc"
                                 addresses:
-                                  - 192.168.8.210/24
+                                  - 10.0.0.5/24
                             """;
 
         var result = NetworkConfigYamlSerializer.Deserialize(yaml);
 
         var eth0 = result.Ethernets!["eth0"];
         eth0.Match.Should().NotBeNull();
-        eth0.Match!.MacAddress.Should().Be("02:00:00:ad:e2:71");
-        eth0.Addresses.Should().BeEquivalentTo(["192.168.8.210/24"]);
+        eth0.Match!.MacAddress.Should().Be("00:11:22:aa:bb:cc");
+        eth0.Addresses.Should().BeEquivalentTo(["10.0.0.5/24"]);
     }
 
     [Fact]
@@ -198,16 +198,16 @@ public class NetworkConfigYamlSerializerTests
     [Fact]
     public void Deserialize_v2_flow_style_from_issue_59()
     {
-        // Verbatim payload from issue #59 (flow mappings + flow sequences),
-        // exactly as the eryph/vagrant generator wrote it to the cidata disk.
+        // Flow-style mappings and sequences (as a generator may emit them),
+        // exercising the issue #59 match-block path end to end.
         const string yaml = """
                             ethernets:
                               eth0:
-                                addresses: [192.168.8.210/24]
-                                gateway4: 192.168.8.1
-                                match: {macaddress: '02:00:00:ad:e2:71'}
+                                addresses: [10.0.0.5/24]
+                                gateway4: 10.0.0.1
+                                match: {macaddress: '00:11:22:aa:bb:cc'}
                                 nameservers:
-                                  addresses: [192.168.8.1]
+                                  addresses: [10.0.0.1]
                             version: 2
                             """;
 
@@ -215,10 +215,10 @@ public class NetworkConfigYamlSerializerTests
 
         result.Version.Should().Be(2);
         var eth0 = result.Ethernets!["eth0"];
-        eth0.Match!.MacAddress.Should().Be("02:00:00:ad:e2:71");
-        eth0.Addresses.Should().BeEquivalentTo(["192.168.8.210/24"]);
-        eth0.Gateway4.Should().Be("192.168.8.1");
-        eth0.Nameservers!.Addresses.Should().BeEquivalentTo(["192.168.8.1"]);
+        eth0.Match!.MacAddress.Should().Be("00:11:22:aa:bb:cc");
+        eth0.Addresses.Should().BeEquivalentTo(["10.0.0.5/24"]);
+        eth0.Gateway4.Should().Be("10.0.0.1");
+        eth0.Nameservers!.Addresses.Should().BeEquivalentTo(["10.0.0.1"]);
     }
 
     [Fact]
@@ -735,7 +735,7 @@ public class NetworkConfigYamlSerializerTests
                             ethernets:
                               eth0:
                                 match:
-                                  macaddress: 02:00:00:ad:e2:71
+                                  macaddress: 00:11:22:aa:bb:cc
                                 dhcp4: true
                               eth1:
                                 macaddress: 00:00:00:00:00:12
@@ -744,7 +744,7 @@ public class NetworkConfigYamlSerializerTests
 
         var result = NetworkConfigYamlSerializer.Deserialize(yaml);
 
-        result.Ethernets!["eth0"].Match!.MacAddress.Should().Be("02:00:00:ad:e2:71");
+        result.Ethernets!["eth0"].Match!.MacAddress.Should().Be("00:11:22:aa:bb:cc");
         // An all-decimal-looking MAC must not be mangled into a number.
         result.Ethernets!["eth1"].MacAddress.Should().Be("00:00:00:00:00:12");
     }

--- a/test/Eryph.GuestServices.Provisioning.Tests/Modules/ApplyNetworkConfigModuleTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Modules/ApplyNetworkConfigModuleTests.cs
@@ -3,8 +3,10 @@ using Eryph.GuestServices.CloudConfig;
 using Eryph.GuestServices.CloudConfig.Yaml;
 using Eryph.GuestServices.Provisioning.DataSources;
 using Eryph.GuestServices.Provisioning.Modules;
+using Eryph.GuestServices.Provisioning.Tests.Reporting;
 using Eryph.GuestServices.Provisioning.UserData;
 using Eryph.GuestServices.Provisioning.Windows;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using CloudConfigModel = global::Eryph.GuestServices.CloudConfig.CloudConfig;
@@ -771,5 +773,128 @@ public sealed class ApplyNetworkConfigModuleTests
         result.Should().BeOfType<ModuleOutcome.Completed>();
         await os.Received(1).EnableDhcpAsync(12, Arg.Any<CancellationToken>());
         await os.DidNotReceive().EnableDhcpAsync(23, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Unapplied_device_types_are_warned_not_silently_dropped()
+    {
+        // bonds / bridges / VLANs are parsed but never applied on Windows. The
+        // operator must get a warning per group rather than a silent no-op.
+        var network = new NetworkConfig
+        {
+            Version = 2,
+            Bonds = new Dictionary<string, NetworkBondConfig>
+            {
+                ["bond0"] = new() { Interfaces = ["eth1", "eth2"] },
+            },
+            Bridges = new Dictionary<string, NetworkBridgeConfig>
+            {
+                ["br0"] = new() { Interfaces = ["eth3"] },
+            },
+            Vlans = new Dictionary<string, NetworkVlanConfig>
+            {
+                ["vlan100"] = new() { Id = 100, Link = "eth0" },
+            },
+            // deliberately no ethernets
+        };
+
+        var os = Substitute.For<IWindowsOs>();
+        var logger = new CapturingLogger<ApplyNetworkConfigModule>();
+        var module = new ApplyNetworkConfigModule(logger);
+
+        var result = await module.ApplyAsync(
+            ResolvedUserData.Empty(new CloudConfigModel()),
+            BuildContext(os, network),
+            CancellationToken.None);
+
+        result.Should().BeOfType<ModuleOutcome.Completed>();
+        logger.Entries.Should().Contain(e => e.Level == LogLevel.Warning && e.Message.Contains("bond"));
+        logger.Entries.Should().Contain(e => e.Level == LogLevel.Warning && e.Message.Contains("bridge"));
+        logger.Entries.Should().Contain(e => e.Level == LogLevel.Warning && e.Message.Contains("VLAN"));
+        // Nothing applicable: we never even enumerate adapters.
+        await os.DidNotReceiveWithAnyArgs().GetNetworkAdaptersAsync(default);
+    }
+
+    [Fact]
+    public async Task Unsupported_ethernet_options_are_warned_but_ip_is_still_applied()
+    {
+        // An ethernet carrying options we don't honour (dhcp4-overrides,
+        // routing-policy) must still get its DHCP/IP config applied, AND a
+        // warning that lists the ignored options.
+        var network = new NetworkConfig
+        {
+            Version = 2,
+            Ethernets = new Dictionary<string, NetworkEthernetConfig>
+            {
+                ["eth0"] = new()
+                {
+                    MacAddress = "00:11:22:33:44:55",
+                    Dhcp4 = true,
+                    UnsupportedOptions = ["dhcp4-overrides", "routing-policy"],
+                },
+            },
+        };
+
+        var os = Substitute.For<IWindowsOs>();
+        os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
+            .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
+            {
+                [Adapter("Ethernet", 6, "00:11:22:33:44:55")],
+            }[0]);
+
+        var logger = new CapturingLogger<ApplyNetworkConfigModule>();
+        var module = new ApplyNetworkConfigModule(logger);
+
+        var result = await module.ApplyAsync(
+            ResolvedUserData.Empty(new CloudConfigModel()),
+            BuildContext(os, network),
+            CancellationToken.None);
+
+        result.Should().BeOfType<ModuleOutcome.Completed>();
+        await os.Received(1).EnableDhcpAsync(6, Arg.Any<CancellationToken>());
+        logger.Entries.Should().Contain(e =>
+            e.Level == LogLevel.Warning
+            && e.Message.Contains("dhcp4-overrides")
+            && e.Message.Contains("routing-policy"));
+    }
+
+    [Fact]
+    public async Task Setting_a_new_adapter_mac_is_warned()
+    {
+        // A top-level macaddress that differs from the match selector is a
+        // request to SET the MAC, which Windows side does not do. Warn.
+        var network = new NetworkConfig
+        {
+            Version = 2,
+            Ethernets = new Dictionary<string, NetworkEthernetConfig>
+            {
+                ["eth0"] = new()
+                {
+                    Match = new NetworkMatch { MacAddress = "00:11:22:33:44:55" },
+                    MacAddress = "aa:bb:cc:dd:ee:ff",
+                    Dhcp4 = true,
+                },
+            },
+        };
+
+        var os = Substitute.For<IWindowsOs>();
+        os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
+            .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
+            {
+                [Adapter("Ethernet", 6, "00:11:22:33:44:55")],
+            }[0]);
+
+        var logger = new CapturingLogger<ApplyNetworkConfigModule>();
+        var module = new ApplyNetworkConfigModule(logger);
+
+        var result = await module.ApplyAsync(
+            ResolvedUserData.Empty(new CloudConfigModel()),
+            BuildContext(os, network),
+            CancellationToken.None);
+
+        result.Should().BeOfType<ModuleOutcome.Completed>();
+        await os.Received(1).EnableDhcpAsync(6, Arg.Any<CancellationToken>());
+        logger.Entries.Should().Contain(e =>
+            e.Level == LogLevel.Warning && e.Message.Contains("MAC"));
     }
 }

--- a/test/Eryph.GuestServices.Provisioning.Tests/Modules/ApplyNetworkConfigModuleTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Modules/ApplyNetworkConfigModuleTests.cs
@@ -201,7 +201,7 @@ public sealed class ApplyNetworkConfigModuleTests
         os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
             .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
             {
-                [Adapter("Ethernet", 8, "02:00:00:ad:e2:71")],
+                [Adapter("Ethernet", 8, "00:11:22:aa:bb:cc")],
             }[0]);
 
         var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
@@ -215,12 +215,12 @@ public sealed class ApplyNetworkConfigModuleTests
         await os.Received(1).DisableDhcpAsync(8, Arg.Any<CancellationToken>());
         await os.Received(1).SetStaticIpv4AddressesAsync(
             8,
-            Arg.Is<IReadOnlyList<string>>(a => a.Count == 1 && a[0] == "192.168.8.210/24"),
+            Arg.Is<IReadOnlyList<string>>(a => a.Count == 1 && a[0] == "10.0.0.5/24"),
             Arg.Any<CancellationToken>());
-        await os.Received(1).SetIpv4DefaultGatewayAsync(8, "192.168.8.1", Arg.Any<CancellationToken>());
+        await os.Received(1).SetIpv4DefaultGatewayAsync(8, "10.0.0.1", Arg.Any<CancellationToken>());
         await os.Received(1).SetDnsServersAsync(
             8,
-            Arg.Is<IReadOnlyList<string>>(d => d.Count == 1 && d[0] == "192.168.8.1"),
+            Arg.Is<IReadOnlyList<string>>(d => d.Count == 1 && d[0] == "10.0.0.1"),
             Arg.Any<CancellationToken>());
     }
 
@@ -237,7 +237,7 @@ public sealed class ApplyNetworkConfigModuleTests
             {
                 ["eth0"] = new()
                 {
-                    Match = new NetworkMatch { MacAddress = "02:00:00:ad:e2:71" },
+                    Match = new NetworkMatch { MacAddress = "00:11:22:aa:bb:cc" },
                     MacAddress = "aa:bb:cc:dd:ee:ff",
                     Dhcp4 = true,
                 },
@@ -248,7 +248,7 @@ public sealed class ApplyNetworkConfigModuleTests
         os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
             .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
             {
-                [Adapter("Ethernet", 4, "02:00:00:ad:e2:71")],
+                [Adapter("Ethernet", 4, "00:11:22:aa:bb:cc")],
             }[0]);
 
         var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);

--- a/test/Eryph.GuestServices.Provisioning.Tests/Modules/ApplyNetworkConfigModuleTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Modules/ApplyNetworkConfigModuleTests.cs
@@ -184,6 +184,121 @@ public sealed class ApplyNetworkConfigModuleTests
     }
 
     [Fact]
+    public async Task Match_macaddress_block_binds_adapter_and_applies_static()
+    {
+        // Regression for issue #59: the network-config binds the NIC via a v2
+        // `match: {macaddress}` block (the standard netplan selector), not the
+        // top-level `macaddress`. The applier must resolve the adapter from
+        // match.macaddress and apply the static IPv4 config + DNS.
+        var yaml = LoadFixtureText("issue-59-v2-match.yaml");
+        var network = NetworkConfigYamlSerializer.Deserialize(yaml);
+        network.Version.Should().Be(2);
+        network.Ethernets.Should().ContainKey("eth0");
+
+        var os = Substitute.For<IWindowsOs>();
+        os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
+            .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
+            {
+                [Adapter("Ethernet", 8, "02:00:00:ad:e2:71")],
+            }[0]);
+
+        var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
+
+        var result = await module.ApplyAsync(
+            ResolvedUserData.Empty(new CloudConfigModel()),
+            BuildContext(os, network),
+            CancellationToken.None);
+
+        result.Should().BeOfType<ModuleOutcome.Completed>();
+        await os.Received(1).DisableDhcpAsync(8, Arg.Any<CancellationToken>());
+        await os.Received(1).SetStaticIpv4AddressesAsync(
+            8,
+            Arg.Is<IReadOnlyList<string>>(a => a.Count == 1 && a[0] == "192.168.8.210/24"),
+            Arg.Any<CancellationToken>());
+        await os.Received(1).SetIpv4DefaultGatewayAsync(8, "192.168.8.1", Arg.Any<CancellationToken>());
+        await os.Received(1).SetDnsServersAsync(
+            8,
+            Arg.Is<IReadOnlyList<string>>(d => d.Count == 1 && d[0] == "192.168.8.1"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Match_macaddress_takes_precedence_over_top_level_for_binding()
+    {
+        // When both a match.macaddress (the selector) and a top-level
+        // macaddress (the MAC to set/spoof) are present, the adapter is
+        // selected by match — that is what netplan/cloud-init does.
+        var network = new NetworkConfig
+        {
+            Version = 2,
+            Ethernets = new Dictionary<string, NetworkEthernetConfig>
+            {
+                ["eth0"] = new()
+                {
+                    Match = new NetworkMatch { MacAddress = "02:00:00:ad:e2:71" },
+                    MacAddress = "aa:bb:cc:dd:ee:ff",
+                    Dhcp4 = true,
+                },
+            },
+        };
+
+        var os = Substitute.For<IWindowsOs>();
+        os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
+            .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
+            {
+                [Adapter("Ethernet", 4, "02:00:00:ad:e2:71")],
+            }[0]);
+
+        var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
+
+        var result = await module.ApplyAsync(
+            ResolvedUserData.Empty(new CloudConfigModel()),
+            BuildContext(os, network),
+            CancellationToken.None);
+
+        result.Should().BeOfType<ModuleOutcome.Completed>();
+        await os.Received(1).EnableDhcpAsync(4, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Match_with_only_name_and_no_mac_is_skipped()
+    {
+        // Windows binds by MAC only. A match block that carries only a name /
+        // driver gives us no MAC to resolve, so the entry is skipped (no
+        // writes, no failure) — same semantics as a missing macaddress.
+        var network = new NetworkConfig
+        {
+            Version = 2,
+            Ethernets = new Dictionary<string, NetworkEthernetConfig>
+            {
+                ["eth0"] = new()
+                {
+                    Match = new NetworkMatch { Name = "en*" },
+                    Addresses = ["10.0.0.5/24"],
+                },
+            },
+        };
+
+        var os = Substitute.For<IWindowsOs>();
+        os.GetNetworkAdaptersAsync(Arg.Any<CancellationToken>())
+            .Returns(new IReadOnlyList<NetworkAdapterInfo>[]
+            {
+                [Adapter("Ethernet", 1, "00:11:22:33:44:55")],
+            }[0]);
+
+        var module = new ApplyNetworkConfigModule(NullLogger<ApplyNetworkConfigModule>.Instance);
+
+        var result = await module.ApplyAsync(
+            ResolvedUserData.Empty(new CloudConfigModel()),
+            BuildContext(os, network),
+            CancellationToken.None);
+
+        result.Should().BeOfType<ModuleOutcome.Completed>();
+        await os.DidNotReceiveWithAnyArgs().DisableDhcpAsync(default, default);
+        await os.DidNotReceiveWithAnyArgs().SetStaticIpv4AddressesAsync(default, default!, default);
+    }
+
+    [Fact]
     public async Task Adapter_unmatched_by_mac_is_skipped_without_writes()
     {
         // The cloud-init entry references a MAC that doesn't exist on the

--- a/test/Eryph.GuestServices.Provisioning.Tests/State/FileDataSourceCacheTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/State/FileDataSourceCacheTests.cs
@@ -71,18 +71,18 @@ public sealed class FileDataSourceCacheTests : IDisposable
     {
         // End-to-end regression for issue #59: `run --stage network` does not
         // re-read the cidata disk — it loads datasource.json and re-parses the
-        // raw NetworkConfig text. The reporter's config selects the NIC via a
-        // v2 `match: {macaddress}` block; that mapping must survive the reload
-        // as a populated StructuredNetworkConfig (it previously came back null
-        // because the parse threw and was swallowed).
+        // raw NetworkConfig text. A v2 config that selects the NIC via a
+        // `match: {macaddress}` block must survive the reload as a populated
+        // StructuredNetworkConfig (it previously came back null because the
+        // parse threw and was swallowed).
         const string rawNetworkConfig =
             "ethernets:\n" +
             "  eth0:\n" +
-            "    addresses: [192.168.8.210/24]\n" +
-            "    gateway4: 192.168.8.1\n" +
-            "    match: {macaddress: '02:00:00:ad:e2:71'}\n" +
+            "    addresses: [10.0.0.5/24]\n" +
+            "    gateway4: 10.0.0.1\n" +
+            "    match: {macaddress: '00:11:22:aa:bb:cc'}\n" +
             "    nameservers:\n" +
-            "      addresses: [192.168.8.1]\n" +
+            "      addresses: [10.0.0.1]\n" +
             "version: 2\n";
 
         var cache = NewCache();
@@ -101,10 +101,10 @@ public sealed class FileDataSourceCacheTests : IDisposable
         restored!.StructuredNetworkConfig.Should().NotBeNull();
         restored.StructuredNetworkConfig!.Ethernets.Should().NotBeNull().And.ContainKey("eth0");
         var eth0 = restored.StructuredNetworkConfig.Ethernets!["eth0"];
-        eth0.Match!.MacAddress.Should().Be("02:00:00:ad:e2:71");
-        eth0.Addresses.Should().BeEquivalentTo(["192.168.8.210/24"]);
-        eth0.Gateway4.Should().Be("192.168.8.1");
-        eth0.Nameservers!.Addresses.Should().BeEquivalentTo(["192.168.8.1"]);
+        eth0.Match!.MacAddress.Should().Be("00:11:22:aa:bb:cc");
+        eth0.Addresses.Should().BeEquivalentTo(["10.0.0.5/24"]);
+        eth0.Gateway4.Should().Be("10.0.0.1");
+        eth0.Nameservers!.Addresses.Should().BeEquivalentTo(["10.0.0.1"]);
     }
 
     [Fact]

--- a/test/Eryph.GuestServices.Provisioning.Tests/State/FileDataSourceCacheTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/State/FileDataSourceCacheTests.cs
@@ -67,6 +67,46 @@ public sealed class FileDataSourceCacheTests : IDisposable
     }
 
     [Fact]
+    public async Task Load_reparses_v2_network_config_with_match_block()
+    {
+        // End-to-end regression for issue #59: `run --stage network` does not
+        // re-read the cidata disk — it loads datasource.json and re-parses the
+        // raw NetworkConfig text. The reporter's config selects the NIC via a
+        // v2 `match: {macaddress}` block; that mapping must survive the reload
+        // as a populated StructuredNetworkConfig (it previously came back null
+        // because the parse threw and was swallowed).
+        const string rawNetworkConfig =
+            "ethernets:\n" +
+            "  eth0:\n" +
+            "    addresses: [192.168.8.210/24]\n" +
+            "    gateway4: 192.168.8.1\n" +
+            "    match: {macaddress: '02:00:00:ad:e2:71'}\n" +
+            "    nameservers:\n" +
+            "      addresses: [192.168.8.1]\n" +
+            "version: 2\n";
+
+        var cache = NewCache();
+        await cache.SaveAsync(
+            new DataSourceResult
+            {
+                SourceName = "NoCloud",
+                InstanceId = "vm1",
+                NetworkConfig = rawNetworkConfig,
+            },
+            CancellationToken.None);
+
+        var restored = await cache.LoadAsync(CancellationToken.None);
+
+        restored.Should().NotBeNull();
+        restored!.StructuredNetworkConfig.Should().NotBeNull();
+        restored.StructuredNetworkConfig!.Ethernets.Should().NotBeNull().And.ContainKey("eth0");
+        var eth0 = restored.StructuredNetworkConfig.Ethernets!["eth0"];
+        eth0.Match!.MacAddress.Should().Be("02:00:00:ad:e2:71");
+        eth0.Addresses.Should().BeEquivalentTo(["192.168.8.210/24"]);
+        eth0.Gateway4.Should().Be("192.168.8.1");
+    }
+
+    [Fact]
     public async Task Reset_removes_the_cache()
     {
         var cache = NewCache();

--- a/test/Eryph.GuestServices.Provisioning.Tests/State/FileDataSourceCacheTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/State/FileDataSourceCacheTests.cs
@@ -104,6 +104,7 @@ public sealed class FileDataSourceCacheTests : IDisposable
         eth0.Match!.MacAddress.Should().Be("02:00:00:ad:e2:71");
         eth0.Addresses.Should().BeEquivalentTo(["192.168.8.210/24"]);
         eth0.Gateway4.Should().Be("192.168.8.1");
+        eth0.Nameservers!.Addresses.Should().BeEquivalentTo(["192.168.8.1"]);
     }
 
     [Fact]

--- a/test/Eryph.GuestServices.Provisioning.Tests/Windows/BuildSetDnsServersCommandTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Windows/BuildSetDnsServersCommandTests.cs
@@ -1,0 +1,51 @@
+using System.Runtime.Versioning;
+using AwesomeAssertions;
+using Eryph.GuestServices.Provisioning.Windows;
+
+namespace Eryph.GuestServices.Provisioning.Tests.Windows;
+
+/// <summary>
+/// Direct tests for <see cref="WindowsOs.BuildSetDnsServersCommand"/> — the
+/// PowerShell command DNS is applied with. DNS cannot be set through CIM on
+/// Windows (MSFT_DNSClientServerAddress has no settable property or static set
+/// method, and a raw MI ModifyInstance is rejected as "Invalid parameter"), so
+/// the applier shells out to Set-DnsClientServerAddress. A wrong parameter name
+/// or a quoting slip here would only surface on a real guest — that exact class
+/// of bug (an invalid CIM method name) is what slipped through before.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class BuildSetDnsServersCommandTests
+{
+    [Fact]
+    public void Mixed_v4_and_v6_servers_go_into_one_cmdlet_call_quoted()
+    {
+        var cmd = WindowsOs.BuildSetDnsServersCommand(
+            12, ["10.249.249.1", "1.1.1.1", "fd00:dead:beef::1"]);
+
+        cmd.Should().Be(
+            "Set-DnsClientServerAddress -InterfaceIndex 12 "
+            + "-ServerAddresses '10.249.249.1','1.1.1.1','fd00:dead:beef::1' -ErrorAction Stop");
+    }
+
+    [Fact]
+    public void Empty_list_resets_the_interface_to_dhcp()
+    {
+        var cmd = WindowsOs.BuildSetDnsServersCommand(7, []);
+
+        cmd.Should().Be(
+            "Set-DnsClientServerAddress -InterfaceIndex 7 -ResetServerAddresses -ErrorAction Stop");
+    }
+
+    [Fact]
+    public void Address_with_a_single_quote_is_escaped_and_cannot_break_out()
+    {
+        // Defensive: addresses come from cloud-config; a stray quote must be
+        // doubled so it stays inside the PowerShell single-quoted literal
+        // rather than terminating it.
+        var cmd = WindowsOs.BuildSetDnsServersCommand(1, ["10.0.0.1'; Remove-Item C:\\ #"]);
+
+        cmd.Should().Contain("'10.0.0.1''; Remove-Item C:\\ #'");
+        cmd.Should().StartWith("Set-DnsClientServerAddress -InterfaceIndex 1 -ServerAddresses '");
+        cmd.Should().EndWith("-ErrorAction Stop");
+    }
+}

--- a/test/Eryph.GuestServices.Provisioning.Tests/Windows/BuildSetDnsServersCommandTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/Windows/BuildSetDnsServersCommandTests.cs
@@ -37,6 +37,29 @@ public sealed class BuildSetDnsServersCommandTests
     }
 
     [Fact]
+    public void Null_and_blank_entries_are_dropped()
+    {
+        // A YAML `~`/null/empty nameserver deserializes to null/blank; it must be
+        // dropped (not NRE in FormatPsStringList, not emitted as an empty quote).
+        var cmd = WindowsOs.BuildSetDnsServersCommand(3, [null!, "", "  ", "10.0.0.1", " 1.1.1.1 "]);
+
+        cmd.Should().Be(
+            "Set-DnsClientServerAddress -InterfaceIndex 3 "
+            + "-ServerAddresses '10.0.0.1','1.1.1.1' -ErrorAction Stop");
+    }
+
+    [Fact]
+    public void List_that_is_all_blank_resets_the_interface()
+    {
+        // Count > 0 (so the applier's guard lets it through) but every entry is
+        // blank — must collapse to a reset, never an invalid -ServerAddresses.
+        var cmd = WindowsOs.BuildSetDnsServersCommand(4, [null!, "   "]);
+
+        cmd.Should().Be(
+            "Set-DnsClientServerAddress -InterfaceIndex 4 -ResetServerAddresses -ErrorAction Stop");
+    }
+
+    [Fact]
     public void Address_with_a_single_quote_is_escaped_and_cannot_break_out()
     {
         // Defensive: addresses come from cloud-config; a stray quote must be

--- a/test/e2e/Helpers.ps1
+++ b/test/e2e/Helpers.ps1
@@ -896,33 +896,68 @@ function Save-GuestDiagnostics {
   try { New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null } catch { }
   Write-Host "Collecting guest diagnostics to $OutputDir ..."
 
+  # Files pulled byte-for-byte over the egs VMBus channel. egs-tool download-file
+  # takes the VmId and needs no SSH alias or shell, so (a) there is no
+  # $-variable double-evaluation to corrupt them, (b) it works on a FAILED run
+  # before add-ssh-config has even succeeded, and (c) it sidesteps scp — egs
+  # exposes no SFTP subsystem, so scp against the egs server always fails.
+  # agent.log is THE key diagnostic (the agent's own operational log); it was
+  # previously never captured.
+  $pulls = [ordered]@{
+    'agent.log'       = 'C:\ProgramData\eryph\guest-services\logs\agent.log'
+    'state.json'      = 'C:\ProgramData\eryph\provisioning\state.json'
+    'datasource.json' = 'C:\ProgramData\eryph\provisioning\datasource.json'
+  }
+
+  # Dynamic queries that have to run in the guest. egs already runs every SSH
+  # exec command through `powershell -Command "<command>"`, so we send the BARE
+  # script — re-wrapping it in another `powershell -NoProfile -Command "..."`
+  # makes the guest evaluate it TWICE, expanding $_/$d host-side to nothing
+  # before the inner shell runs (issue #52). All scripts use single quotes only
+  # so they survive intact with no embedded double quotes to break the wrap.
+  #
+  # The config drive is eryph's NoCloud cidata ISO: volume label 'cidata' with
+  # meta-data / user-data / network-config at the root (NOT an OpenStack
+  # 'config-2' volume with an \openstack\ tree).
+  $cidata = '$d=(Get-Volume | Where-Object FileSystemLabel -eq ''cidata'').DriveLetter; if ($d)'
   $probes = [ordered]@{
-    'state.json' =
-      'Get-Content -Raw -LiteralPath C:\ProgramData\eryph\provisioning\state.json'
     'provisioning-tree.txt' =
       'Get-ChildItem -Recurse -Path C:\ProgramData\eryph\provisioning -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName'
-    'script-logs.txt' =
-      'Get-ChildItem -Path C:\ProgramData\eryph\provisioning\logs -Filter *.log -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName; ''-----''; Get-Content -Raw -LiteralPath $_.FullName }'
     'eventlog.txt' =
       'Get-WinEvent -LogName Application -MaxEvents 300 -ErrorAction SilentlyContinue | Where-Object { $_.ProviderName -match ''eryph|egs'' -or $_.Message -match ''provisioning|egs-service'' } | Sort-Object TimeCreated | Format-List TimeCreated, LevelDisplayName, ProviderName, Message | Out-String'
     'configdrive-tree.txt' =
-      '$d=(Get-Volume | Where-Object FileSystemLabel -eq ''config-2'').DriveLetter; if ($d) { Get-ChildItem -Recurse -Path ($d + '':\openstack'') -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName } else { ''config-2 volume not found'' }'
-    'configdrive-user-data.txt' =
-      '$d=(Get-Volume | Where-Object FileSystemLabel -eq ''config-2'').DriveLetter; if ($d) { Get-ChildItem -Recurse -Path ($d + '':\openstack'') -Filter user_data -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName; ''-----''; Get-Content -Raw -LiteralPath $_.FullName } }'
+      "$cidata { Get-ChildItem -Recurse -LiteralPath (`$d + ':\') -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName } else { 'cidata volume not found' }"
     'configdrive-meta-data.txt' =
-      '$d=(Get-Volume | Where-Object FileSystemLabel -eq ''config-2'').DriveLetter; if ($d) { Get-ChildItem -Recurse -Path ($d + '':\openstack'') -Filter meta_data.json -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName; ''-----''; Get-Content -Raw -LiteralPath $_.FullName } }'
+      "$cidata { Get-Content -Raw -LiteralPath (`$d + ':\meta-data') -ErrorAction SilentlyContinue } else { 'cidata volume not found' }"
+    'configdrive-network-config.txt' =
+      "$cidata { Get-Content -Raw -LiteralPath (`$d + ':\network-config') -ErrorAction SilentlyContinue } else { 'cidata volume not found' }"
+    'configdrive-user-data.txt' =
+      "$cidata { Get-Content -Raw -LiteralPath (`$d + ':\user-data') -ErrorAction SilentlyContinue } else { 'cidata volume not found' }"
   }
 
   # ssh.exe non-zero exits must not abort the loop.
   $savedPref = $PSNativeCommandUseErrorActionPreference
   $PSNativeCommandUseErrorActionPreference = $false
   try {
+    foreach ($name in $pulls.Keys) {
+      $dest = Join-Path $OutputDir $name
+      try {
+        egs-tool download-file $vmId $pulls[$name] $dest 2>&1 | Out-Null
+        if (-not (Test-Path -LiteralPath $dest)) {
+          Set-Content -LiteralPath $dest -Value "(not present in guest: $($pulls[$name]))"
+        }
+      }
+      catch {
+        Set-Content -LiteralPath $dest -Value "download failed: $_"
+      }
+    }
+
     foreach ($name in $probes.Keys) {
       $dest = Join-Path $OutputDir $name
       try {
-        $script = $probes[$name]
+        # Bare script — egs wraps it in powershell -Command itself (issue #52).
         $out = ssh.exe -o StrictHostKeyChecking=no -o ConnectTimeout=10 $hostName `
-          "powershell -NoProfile -Command `"$script`"" 2>&1
+          $probes[$name] 2>&1
         Set-Content -LiteralPath $dest -Value ($out | Out-String)
       }
       catch {
@@ -931,12 +966,11 @@ function Save-GuestDiagnostics {
     }
 
     # Also pull the egs-service collect-logs bundle (state + per-script logs).
+    # Build it via a bare exec command, then fetch with download-file (no scp).
     try {
       $bundleCmd = "& 'C:\Program Files\eryph\guest-services\bin\egs-service.exe' collect-logs C:\Windows\Temp\egs-bundle.zip"
-      ssh.exe -o StrictHostKeyChecking=no $hostName `
-        "powershell -NoProfile -Command `"$bundleCmd`"" 2>&1 | Out-Null
-      scp.exe -o StrictHostKeyChecking=no `
-        "${hostName}:C:/Windows/Temp/egs-bundle.zip" (Join-Path $OutputDir 'egs-bundle.zip') 2>&1 | Out-Null
+      ssh.exe -o StrictHostKeyChecking=no $hostName $bundleCmd 2>&1 | Out-Null
+      egs-tool download-file $vmId 'C:\Windows\Temp\egs-bundle.zip' (Join-Path $OutputDir 'egs-bundle.zip') 2>&1 | Out-Null
     }
     catch {
       Write-Host "collect-logs bundle pull failed (non-fatal): $_"

--- a/test/fixtures/network-config/issue-59-v2-match.yaml
+++ b/test/fixtures/network-config/issue-59-v2-match.yaml
@@ -1,0 +1,8 @@
+ethernets:
+  eth0:
+    addresses: [192.168.8.210/24]
+    gateway4: 192.168.8.1
+    match: {macaddress: '02:00:00:ad:e2:71'}
+    nameservers:
+      addresses: [192.168.8.1]
+version: 2

--- a/test/fixtures/network-config/issue-59-v2-match.yaml
+++ b/test/fixtures/network-config/issue-59-v2-match.yaml
@@ -1,8 +1,8 @@
 ethernets:
   eth0:
-    addresses: [192.168.8.210/24]
-    gateway4: 192.168.8.1
-    match: {macaddress: '02:00:00:ad:e2:71'}
+    addresses: [10.0.0.5/24]
+    gateway4: 10.0.0.1
+    match: {macaddress: '00:11:22:aa:bb:cc'}
     nameservers:
-      addresses: [192.168.8.1]
+      addresses: [10.0.0.1]
 version: 2


### PR DESCRIPTION
Fixes #59. `egs-service run --stage network` logged "No network-config ethernets to apply" even though the datasource had read the config. The netplan-standard selector

```yaml
ethernets:
  eth0:
    match: {macaddress: '00:11:22:aa:bb:cc'}
```

failed because `match` was typed as a `string`: deserializing the mapping threw, the exception was swallowed, and `StructuredNetworkConfig` came back null.

## Parsing

- `match` is now `NetworkMatch { Name, MacAddress, Driver }`. The applier binds the adapter by `match.macaddress`, falling back to the top-level `macaddress`.
- Unwrap a top-level `network:` key — netplan files and many cloud-init samples nest everything under it.
- Tolerate the `addresses:` map form (`"ip/prefix": {lifetime,label}`), a leading UTF-8 BOM, and null entries in the `addresses:` list. Each of these used to null the whole config.
- v2 constructs we don't apply on Windows (bonds/bridges/vlans, dhcp4/6-overrides, routing-policy, set-name, wakeonlan, accept-ra, MAC-set) now log a warning instead of disappearing silently.

## DNS apply

Found while testing the v2 static path on a real guest: applying static config threw `CimException: Method "SetServerAddress" not found` and failed the whole Network stage. DNS is the one interface setting that can't go through CIM — `MSFT_DNSClientServerAddress` has no writable property and no static set method, and a raw `ModifyInstance` with the cmdlet's operation options is rejected as "Invalid parameter". `WindowsOs.SetDnsServersAsync` now uses `Set-DnsClientServerAddress` (one call handles a mixed IPv4+IPv6 list; an empty list resets to DHCP). This never surfaced before: unit tests run against the dry-run OS and the only live test was v1 DHCP.

## Tests

- v2 parser and applier coverage: match selectors, the #59 flow-style payload, static dual-stack, dhcp4+dhcp6, multiple ethernets, the `network:` wrapper, address map/edge forms, anchors + merge keys, comments/CRLF/BOM.
- Unit tests for the `Set-DnsClientServerAddress` command builder.
- Fixed `Save-GuestDiagnostics` in the e2e harness: it now captures `agent.log`, reads the NoCloud cidata layout (was looking for an OpenStack config-2 tree), sends bare exec scripts (the double-`powershell -Command` wrap broke every probe), and pulls the bundle with `egs-tool download-file` instead of scp.

Verified end-to-end on a winsrv2022 catlet: static IPv4+IPv6 addresses, both gateways, IPv4+IPv6 DNS servers, search suffix, MTU, and routes (including `to: default`) all applied, with the NIC matched via `match.macaddress`. Docs carry the v1/v2 coverage matrix.
