### PR TITLE
docs(rfcs): RFC updates — sync index, promote 0001, add 0032

### DIFF
--- a/docs/rfcs/0001-vendor-data-merge-policy.md
+++ b/docs/rfcs/0001-vendor-data-merge-policy.md
@@ -1,6 +1,6 @@
 # RFC 0001 — Vendor-data merge policy
 
-Status: Draft
+Status: Implemented (option 2 — deep-merge per cloud-init default; vendor-data resolved through the same pipeline and merged with user-data winning on conflict)
 
 ## Problem
 
@@ -25,11 +25,25 @@ No vendor-data support at all. User-data only.
 2. **Deep-merge per cloud-init default.** List concat, dict merge, scalar override. Compatible but subtler.
 3. **No merge for v1.** Vendor-data is parsed but discarded with a single Info log; we revisit when a real use case arrives.
 
-## Tentative direction
+## Tentative direction (superseded by Decision below)
 
 **(3) for v1**, **(2) for v2 when a use case appears**. Rationale: deferring is cheap (the chassis already accepts vendor-data; the discard happens in `UserDataPipeline`). Picking the wrong merge policy without a real-world example to validate against is risky.
 
-## Open questions
+## Decision
 
-- Does Azure's `ovf-env.xml` contents count as vendor-data once parsed by Azure PA? (Probably not — PA already applied it; nothing for us to merge.)
-- Should an explicit `cloud_init_merge` directive in user-data be honored, or fixed per RFC outcome?
+**Option (2) — deep-merge per cloud-init default — was chosen and implemented.** The "wait for a real use case" condition was met when the OpenStack datasource landed: OpenStack ships `vendor_data.json`, so vendor-data became a live, producer-backed payload rather than a hypothetical. Discarding it (option 3) would have silently dropped provider-supplied cloud-config.
+
+How it works today:
+
+- **Same pipeline, lower priority.** `StageRunner` resolves vendor-data through the *same* `UserDataPipeline` as user-data, then calls `ResolvedUserData.Combine(resolvedVendor, resolvedUser)` — vendor-data is the lower-priority source, user-data the higher.
+- **Cloud-config merge** is `CloudConfig.CloudConfigMerge.Merge`: scalars → user-data (right) wins when non-null; lists → concatenated vendor-first; dicts → deep-merged; `users` / `groups` / `chpasswd` users → merged by `Name` with the user-data entry winning on conflict. This matches cloud-init's default `cloud_init_merge` semantics.
+- **Scripts and boothooks** are concatenated vendor-first, so vendor-data entries run before user-data entries.
+- **Producers:** OpenStack `vendor_data.json` (with cloud-init's `convert_vendordata` extraction cloned in `OpenStackMetadataReader.ConvertVendorData`) and NoCloud's `vendor-data` file. For datasources that supply none, `GetVendorDataBytes()` returns empty and the merge is a no-op.
+- **Tests:** `ResolvedUserDataCombineTests` (`User_data_wins_over_vendor_data_on_conflict`, `Vendor_data_fills_fields_user_data_omits`).
+
+Implemented in commit `679cb3e` (alongside the OpenStack datasource that motivated it).
+
+## Open questions (resolved)
+
+- *Does Azure's `ovf-env.xml` count as vendor-data once parsed by Azure PA?* — **No.** `AzureDataSource` sets `VendorData = null`; the platform agent has already applied that config, so there is nothing for us to merge. Confirms the original guess.
+- *Should an explicit `cloud_init_merge` directive in user-data be honored, or fixed per RFC outcome?* — **Fixed per this RFC.** The merge strategy is not user-configurable; there is no `cloud_init_merge` / `merge_how` handling. Revisit only if a concrete need for per-payload merge tuning appears.

--- a/docs/rfcs/0001-vendor-data-merge-policy.md
+++ b/docs/rfcs/0001-vendor-data-merge-policy.md
@@ -46,4 +46,4 @@ Implemented in commit `679cb3e` (alongside the OpenStack datasource that motivat
 ## Open questions (resolved)
 
 - *Does Azure's `ovf-env.xml` count as vendor-data once parsed by Azure PA?* — **No.** `AzureDataSource` sets `VendorData = null`; the platform agent has already applied that config, so there is nothing for us to merge. Confirms the original guess.
-- *Should an explicit `cloud_init_merge` directive in user-data be honored, or fixed per RFC outcome?* — **Fixed per this RFC.** The merge strategy is not user-configurable; there is no `cloud_init_merge` / `merge_how` handling. Revisit only if a concrete need for per-payload merge tuning appears.
+- *Should an explicit `cloud_init_merge` directive in user-data be honored, or fixed per RFC outcome?* — **Fixed for vendor-data precedence; the general question moved to [RFC 0032](0032-cloud-config-merge-model.md).** Today the merge strategy is not user-configurable (no `cloud_init_merge` / `merge_how` handling). Whether eryph should add per-fragment merge control across its multi-source cloud-config stacking is a broader decision than vendor-data, and is owned by RFC 0032.

--- a/docs/rfcs/0032-cloud-config-merge-model.md
+++ b/docs/rfcs/0032-cloud-config-merge-model.md
@@ -1,0 +1,143 @@
+# RFC 0032 — Cloud-config merge model & merge control
+
+Status: Draft
+
+## Problem
+
+Eryph rarely provisions from a single cloud-config. A catlet is composed
+from multiple fodder/gene fragments, and on top of that the agent stacks
+cloud-config from several independent sources at runtime. They all collapse
+into one effective cloud-config through a single deep-merge, but **how** they
+combine — the precedence order and the per-key strategy — has never been
+written down as a decision. It lives only as code and source-gen attributes.
+
+Worse, the merge is **hardcoded**: a later fragment can only ever *append* to
+a list, never *replace* it. There is no way for a fragment to say "drop
+whatever `runcmd` / `packages` / `users` accumulated and use mine instead."
+cloud-init solves this with per-fragment merge-control directives
+(`merge_how` / `merge_type`, historically `cloud_init_merge`). Eryph has no
+equivalent and no recorded decision on whether it should.
+
+This RFC captures the existing model as an agreed design and decides what to
+do about merge control.
+
+## What cloud-init does
+
+Cloud-init merges cloud-config parts in order and lets any part override the
+default strategy:
+
+- **Default strategy** (`list(append)+dict(no_replace,recurse_list)+str()`):
+  scalars — later wins; lists — concatenated; dicts — deep-merged, novel keys
+  added, existing keys recursed.
+- **Per-fragment control:** a part may carry `merge_how:` (a.k.a.
+  `merge_type:`) selecting `list`/`dict`/`str` mergers with modifiers like
+  `append`, `no_replace`, `replace`, `recurse_dict`, `recurse_list`,
+  `recurse_array`. A part can thus opt into "replace this list" rather than
+  the default append.
+- A handful of keys have bespoke merge semantics regardless of strategy
+  (`users`, `runcmd`, write_files by path, etc.).
+
+See https://docs.cloud-init.io/en/latest/reference/merging.html.
+
+## What cloudbase-init does
+
+No merge model. User-data only, single payload, last-writer semantics. Nothing
+to mirror.
+
+## Eryph context — the sources that stack
+
+All of these funnel through one function, `CloudConfig.CloudConfigMerge.Merge(left, right)`:
+
+| Source | Where | Precedence (who wins on conflict) |
+|---|---|---|
+| Multipart MIME parts (multiple `#cloud-config` parts) | `UserDataResolutionContext.MergeCloudConfig` | later part over earlier |
+| `#include` URL fragments | same, via recursive dispatch | later over earlier |
+| vendor-data vs user-data | `ResolvedUserData.Combine` (RFC 0001) | user-data over vendor-data |
+| secure-config bootstrap fragment | same merge path (RFC 0029) | fragment over base |
+
+The **per-property strategy** is source-generated from `[MergeBehavior(MergeKind)]`
+attributes on the model (`MergeKind.cs`):
+
+- `RightWins` — scalars (`string?`/`bool?`/numeric/enum/`object?`).
+- `Concat` — non-keyed lists (`runcmd`, `packages`, `ssh_authorized_keys`, …),
+  left-then-right.
+- `DeepMerge` — nested records, field by field.
+- `KeyedByName` — `users` / `groups` / `chpasswd.users`, matched by `Name`,
+  later entry deep-merged onto earlier.
+- `Auto` — inferred from the declared type.
+
+This is a faithful clone of cloud-init's *default* strategy. What it has no
+representation for is the *override* — there is no `merge_how` parsing, and
+`MergeKind` is fixed at the model level, identical for every source.
+
+Why this matters for eryph specifically: fodder/gene composition is additive
+by design, so "append" is the right default — but it is also the *only*
+option today. An author who wants a fragment to take authoritative control of
+a list (e.g. a hardening gene that must define the *exact* `users` set, or a
+fragment that replaces an inherited `runcmd` rather than tacking onto it)
+cannot express that. The limitation is invisible until someone hits it, and
+then there is no escape hatch.
+
+## Options for merge control
+
+1. **Keep it fixed (status quo).** Append-only, no per-fragment control.
+   Simplest; documents the current behaviour and closes the question. Cost:
+   no way to replace inherited lists; authors work around it by not splitting
+   fragments, which defeats gene composition.
+
+2. **Support cloud-init `merge_how` / `merge_type` verbatim.** Parse the
+   directive per part and switch mergers accordingly. Maximum cloud-init
+   parity; familiar to anyone who has used it. Cost: the directive is fiddly
+   and underspecified at the edges, applies per-part (not per-key), and the
+   source-generated merger would need a runtime-selectable strategy it does
+   not currently have.
+
+3. **Eryph-native, per-key control directive.** A small top-level key (e.g.
+   `eryph_merge:` / `merge:`) that names keys to `replace` instead of the
+   default. Narrower and clearer than cloud-init's part-level switches, fits
+   the source-gen model (a replace-set consulted per property), and targets
+   the actual need (replace a specific inherited list) without importing the
+   whole `merge_how` grammar. Cost: not cloud-init-compatible syntax;
+   authors must learn it.
+
+4. **(2) for compatibility + (3) for ergonomics.** Honor `merge_how` when
+   present for parity, expose the native directive as the recommended path.
+   Most capable; most surface area.
+
+## Tentative direction
+
+- **Ratify the existing default model** (precedence chain + `MergeKind`
+  taxonomy above) as the agreed design — independent of the control question.
+  This is descriptive, not a behaviour change.
+- **Lean toward (3)** for merge control: an eryph-native per-key `replace`
+  directive, because the concrete need is "let a fragment own a list," it
+  composes cleanly with the source-generated merger, and it avoids committing
+  to cloud-init's full part-level `merge_how` semantics before we have a real
+  fragment that needs them. Revisit (2) if cloud-init-syntax compatibility
+  turns out to matter for imported user-data.
+- **No implementation until a fragment actually needs replace semantics.** The
+  default append behaviour is correct for the composition we do today; this
+  RFC exists so the decision is made deliberately when the need arrives rather
+  than reactively.
+
+## Open questions
+
+- **Granularity:** per-key (option 3) or per-part (cloud-init's model)? Gene
+  composition is key-oriented, which argues per-key — but a fragment that
+  wants to replace *everything* it touches would prefer a part-level switch.
+- **Where does the directive live** when a fragment is itself multipart or
+  arrives via `#include`? Presumably on the fragment that declares it, applied
+  as that fragment merges onto the accumulator.
+- **Interaction with `KeyedByName`** (`users`/`groups`): does `replace` drop
+  the whole list, or replace only same-named entries? Cloud-init keeps the
+  by-name semantics; we likely should too.
+- **Validation/observability:** a replace is destructive — should it be logged
+  at Info so a surprising "where did my inherited `runcmd` go" is traceable?
+- **Does eryph's fodder layer** (outside the guest agent) already resolve some
+  of this before it reaches user-data, narrowing what the agent must handle?
+
+## Authoring note
+
+This RFC supersedes the narrow "merge is fixed" disposition recorded in
+RFC 0001's resolved open questions: that answer was reasoned about vendor-data
+precedence only. The general merge-control decision is owned here.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -43,6 +43,7 @@ Design notes for the eryph guest provisioning agent. Each RFC captures a deferre
 | [0027](0027-set-locale-module.md) | `locale` / `keyboard` cloud-config module on Windows | Implemented |
 | [0028](0028-linux-keys-module.md) | Acknowledged-but-no-op top-level keys — Info-log Linux / deferred keys via `CloudConfigSerializer` | Implemented |
 | [0029](0029-secure-config-bootstrap-handshake.md) | Secure config delivery via bootstrap handshake | Draft |
+| [0030](0030-eryph-remote-channel.md) | Remote access over an eryph-authorized channel | Draft |
 | [0031](0031-cloud-init-compatible-kvp-status.md) | Cloud-init-compatible provisioning status over Hyper-V KVP | Accepted |
 
 ## Authoring

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -45,6 +45,7 @@ Design notes for the eryph guest provisioning agent. Each RFC captures a deferre
 | [0029](0029-secure-config-bootstrap-handshake.md) | Secure config delivery via bootstrap handshake | Draft |
 | [0030](0030-eryph-remote-channel.md) | Remote access over an eryph-authorized channel | Draft |
 | [0031](0031-cloud-init-compatible-kvp-status.md) | Cloud-init-compatible provisioning status over Hyper-V KVP | Accepted |
+| [0032](0032-cloud-config-merge-model.md) | Cloud-config merge model & merge control | Draft |
 
 ## Authoring
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -14,7 +14,7 @@ Design notes for the eryph guest provisioning agent. Each RFC captures a deferre
 
 | # | Title | Status |
 |---|---|---|
-| [0001](0001-vendor-data-merge-policy.md) | Vendor-data merge policy | Draft |
+| [0001](0001-vendor-data-merge-policy.md) | Vendor-data merge policy | Implemented |
 | [0002](0002-network-config-v1-v2-application.md) | Network-config v1/v2 application on Windows | Implemented |
 | [0003](0003-module-frequencies.md) | Module frequencies (per-instance / per-boot / per-once) | Implemented |
 | [0004](0004-datasource-readiness-timeout.md) | Datasource readiness — probe timeout, retry backoff | Implemented |


### PR DESCRIPTION
## Purpose

RFC housekeeping and re-evaluation pass. Brings the RFC index back in sync with the files and records two merge-related decisions that had drifted from (or were missing in) the docs.

## Changes

- **Sync the index** — RFC 0030 (eryph-remote-channel, Draft) existed as a file but was missing from the README table, which skipped 0029 → 0031. Added it.
- **Promote RFC 0001 (vendor-data merge) Draft → Implemented** — re-evaluated against the code: option 2 (deep-merge per cloud-init default) is fully implemented and tested. Vendor-data resolves through the same `UserDataPipeline` and merges via `ResolvedUserData.Combine` (user-data wins, vendor scripts run first); OpenStack `vendor_data.json` and NoCloud `vendor-data` are live producers. Both open questions resolved (Azure surfaces no vendor-data; merge policy is fixed).
- **Add RFC 0032 (cloud-config merge model & merge control, Draft)** — captures the existing deep-merge model (cross-source precedence chain + `MergeKind` taxonomy) as an agreed design, and opens the decision on per-fragment merge control that eryph's multi-fragment fodder/gene composition needs (cloud-init `merge_how` vs an eryph-native per-key `replace` directive). Cross-references RFC 0001, whose "merge is fixed" note was scoped to vendor-data only.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)