### PR TITLE
Cloud-config merge library and merge_how/merge_type support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,10 +95,10 @@ jobs:
       targetPath: '$(Build.ArtifactStagingDirectory)/$(toolArtifactName)'
       artifactName: tool
 
-  # Library packages consumed by eryph (hvsocket + KVP). Only the four
-  # IsPackable=true libraries emit a .nupkg; everything else in src/ is
-  # IsPackable=false (set in src/Directory.Build.props), so the glob is
-  # safe. Version comes from GitVersion.MsBuild in the projects.
+  # Library packages consumed by eryph. Only the IsPackable=true libraries
+  # emit a .nupkg; everything else in src/ is IsPackable=false (set in
+  # src/Directory.Build.props), so the glob is safe. Version comes from
+  # GitVersion.MsBuild in the projects.
   - task: DotNetCoreCLI@2
     displayName: dotnet pack (libraries)
     inputs:

--- a/docs/rfcs/0032-cloud-config-merge-model.md
+++ b/docs/rfcs/0032-cloud-config-merge-model.md
@@ -1,6 +1,6 @@
 # RFC 0032 — Cloud-config merge model & merge control
 
-Status: Draft
+Status: Accepted
 
 ## Problem
 
@@ -104,37 +104,147 @@ then there is no escape hatch.
    present for parity, expose the native directive as the recommended path.
    Most capable; most surface area.
 
-## Tentative direction
+## Decision
 
 - **Ratify the existing default model** (precedence chain + `MergeKind`
-  taxonomy above) as the agreed design — independent of the control question.
-  This is descriptive, not a behaviour change.
-- **Lean toward (3)** for merge control: an eryph-native per-key `replace`
-  directive, because the concrete need is "let a fragment own a list," it
-  composes cleanly with the source-generated merger, and it avoids committing
-  to cloud-init's full part-level `merge_how` semantics before we have a real
-  fragment that needs them. Revisit (2) if cloud-init-syntax compatibility
-  turns out to matter for imported user-data.
-- **No implementation until a fragment actually needs replace semantics.** The
-  default append behaviour is correct for the composition we do today; this
-  RFC exists so the decision is made deliberately when the need arrives rather
-  than reactively.
+  taxonomy above) as the agreed design.
+- **Adopt option (2): cloud-init `merge_how` / `merge_type`.** A fragment
+  controls how it merges onto the accumulated config with cloud-init's own
+  part-level directive — both the string form
+  (`merge_how: "list(append)+dict(no_replace,recurse_list)+str()"`) and the
+  structured list form (`- name: list` / `settings: [...]`). This keeps eryph
+  on its cloud-init-parity north star and means fodder authored against
+  cloud-init's documented behaviour merges identically here.
+- **Default (no directive) = cloud-init's default merger**, which is the
+  behaviour already implemented (lists append/concat, dicts deep-merge, scalars
+  later-wins). Existing fodder is therefore unaffected.
+- **Supported in both merge sites:** the host-side pre-merge library
+  (`CloudConfigComposer`) and the guest provisioning pipeline
+  (`UserDataResolutionContext` cloud-config accumulation). The directive is
+  read per fragment from its raw YAML and applied as that fragment merges onto
+  the accumulator.
 
-## Open questions
+### Semantics implemented
 
-- **Granularity:** per-key (option 3) or per-part (cloud-init's model)? Gene
-  composition is key-oriented, which argues per-key — but a fragment that
-  wants to replace *everything* it touches would prefer a part-level switch.
-- **Where does the directive live** when a fragment is itself multipart or
-  arrives via `#include`? Presumably on the fragment that declares it, applied
-  as that fragment merges onto the accumulator.
-- **Interaction with `KeyedByName`** (`users`/`groups`): does `replace` drop
-  the whole list, or replace only same-named entries? Cloud-init keeps the
-  by-name semantics; we likely should too.
-- **Validation/observability:** a replace is destructive — should it be logged
-  at Info so a surprising "where did my inherited `runcmd` go" is traceable?
-- **Does eryph's fodder layer** (outside the guest agent) already resolve some
-  of this before it reaches user-data, narrowing what the agent must handle?
+The directive is parsed into a `CloudInitMergeOptions` (list / dict / str
+actions) threaded through the source-generated merge:
+
+- **list:** `append` (default), `prepend`, `replace`, `no_replace`.
+- **dict:** deep-merge/recurse (default), `replace` (incoming value replaces).
+- **str:** `replace` (default). `str(append)` is parsed but not applied to
+  typed scalars — concatenating distinct typed scalars (e.g. two hostnames)
+  is not meaningful; revisit if a real use case appears.
+- **`KeyedByName`** (`users` / `groups` / `chpasswd`): honours the same list
+  actions as plain lists — `replace` swaps the whole list, `no_replace` keeps
+  the accumulated one, `prepend`/`append` set ordering — while same-named
+  entries are deep-merged (incoming wins), matching cloud-init's effective
+  result.
+
+One deliberate simplification: `dict(no_replace)` maps to the default recurse
+merger, in which a conflicting key takes the incoming (right) value — the
+behaviour eryph already had. cloud-init's `no_replace` technically means the
+*accumulated* value is kept on a key conflict. Wholesale `dict(replace)` is
+supported; left-wins-on-key (true `no_replace`) is not modelled, because no
+fodder needs it yet. Revisit if one does.
+
+Settings the model does not represent (e.g. `recurse_array`, `allow_delete`)
+are parsed permissively and ignored rather than rejected.
+
+## Resolved questions
+
+- **Granularity:** part-level (cloud-init's model). A fragment's directive
+  governs every key it carries as it merges onto the accumulator.
+- **Where the directive lives:** on the fragment that declares it, read from
+  that fragment's raw YAML and applied at the point it merges. A fragment
+  arriving via multipart or `#include` carries its own directive.
+- **Interaction with `KeyedByName`:** all four list actions apply —
+  `list(replace)` drops the whole list, `no_replace` keeps the accumulated
+  one, `prepend`/`append` set ordering — with same-named entries deep-merged.
+- **Default behaviour is non-destructive**, so no special logging is required;
+  a `replace` is an explicit, author-chosen directive.
+
+## Implementation — merge as a library feature for eryph
+
+The merge model above is currently reachable only from inside the guest agent.
+Eryph wants to merge fodder **before** the guest boots — collapse the several
+`type: cloud-config` fodder fragments of a catlet into one cloud-config and
+write that single document to the NoCloud seed disk, rather than shipping a
+pile of fragments for cloud-init to reconcile at runtime. That makes the merge
+a build-time, host-side concern, so it must be exposed as a referenceable
+library.
+
+### What already exists
+
+- `CloudConfig.CloudConfigMerge.Merge(CloudConfig left, CloudConfig right)` is
+  **public** and is exactly the source-generated deep merge described above.
+  Folding an ordered list of fragments left-to-right *is* the pre-merge.
+- `CloudConfig.Yaml.CloudConfigYamlSerializer.Deserialize(string)` is
+  **public** (YAML → model, with `onUnknownKey` warnings and
+  `InvalidConfigException` on malformed input). `EryphFodderSmokeTests` already
+  exercises this against real genepool `cloud-config` fodder.
+
+### Gaps to close
+
+1. **Serialization (model → YAML).** The Yaml library only deserializes — the
+   guest agent consumes cloud-config and never emits it. The pre-merge use case
+   is the inverse, so a `Serialize(CloudConfig)` is needed. It MUST reuse the
+   same converter/alias/naming configuration as the deserializer (the
+   `WithAttributeOverride` rules, `BoolOrString`, `write_files` permissions,
+   runcmd shapes, `ssh_deletekeys`/`locale_configfile` aliases, snake_case),
+   emit the `#cloud-config` header, and omit null/empty members. Round-trip
+   fidelity (parse → serialize → parse is stable) is the main risk and must be
+   pinned with tests. Several existing `IYamlTypeConverter`s implement only the
+   read path and will need their write path filled in.
+
+2. **Packaging.** Neither `Eryph.GuestServices.CloudConfig` nor
+   `.CloudConfig.Yaml` is `IsPackable` today (only Core/Sockets/HvDataExchange
+   are). Both opt in with an `IsPackable`/`PackageId` so eryph can take a
+   `PackageReference`. The source-generated `Merge` is baked into the
+   `CloudConfig` assembly, so the analyzer/source-gen project does not ship.
+
+### Proposed surface
+
+A thin facade in the Yaml library (it needs both the model and the serializer):
+
+```csharp
+namespace Eryph.GuestServices.CloudConfig.Yaml;
+
+public static class CloudConfigComposer
+{
+    // Parse each fragment, fold left→right via CloudConfigMerge.Merge,
+    // serialize the single result as a #cloud-config document.
+    public static string Merge(IEnumerable<string> cloudConfigFragments,
+                               Action<string>? onUnknownKey = null);
+
+    // Same, stopping at the merged model (for callers that validate or
+    // post-process before serialising).
+    public static CloudConfig MergeToModel(IEnumerable<string> cloudConfigFragments,
+                                           Action<string>? onUnknownKey = null);
+}
+```
+
+Fragment order is precedence: a later fragment wins on scalars and concatenates
+onto earlier lists, exactly per the model above. Callers may run
+`CloudConfigValidations` on the merged result to fail fast before writing the
+seed disk.
+
+### Relationship to the merge-control decision
+
+This exposure is **decision-neutral** with respect to the open
+`replace`/`merge_how` question. The facade surfaces only the *default* append
+merge, which already exists and is stable. A future per-key `replace` directive
+(or `merge_how` support) extends the same fold without changing the
+`CloudConfigComposer` API, so building the library exposure now does not
+pre-commit the control design. The exposure can therefore land while this RFC's
+*control* sections remain Draft; only the merge-control directive itself waits
+on a concrete fragment that needs it.
+
+### Scope boundary
+
+The facade collapses cloud-config fragments only. Boothooks, `x-shellscript`
+parts, and multipart structure are not merged — eryph decides which fragments
+are cloud-config and feeds those in. Non-cloud-config payloads continue to ride
+as their own user-data parts.
 
 ## Authoring note
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -45,7 +45,7 @@ Design notes for the eryph guest provisioning agent. Each RFC captures a deferre
 | [0029](0029-secure-config-bootstrap-handshake.md) | Secure config delivery via bootstrap handshake | Draft |
 | [0030](0030-eryph-remote-channel.md) | Remote access over an eryph-authorized channel | Draft |
 | [0031](0031-cloud-init-compatible-kvp-status.md) | Cloud-init-compatible provisioning status over Hyper-V KVP | Accepted |
-| [0032](0032-cloud-config-merge-model.md) | Cloud-config merge model & merge control | Draft |
+| [0032](0032-cloud-config-merge-model.md) | Cloud-config merge model & merge control | Accepted |
 
 ## Authoring
 

--- a/src/Eryph.GuestServices.CloudConfig.SourceGen/CloudConfigGenerator.cs
+++ b/src/Eryph.GuestServices.CloudConfig.SourceGen/CloudConfigGenerator.cs
@@ -216,6 +216,7 @@ public sealed class CloudConfigGenerator : IIncrementalGenerator
         if (isRootEntryPoint)
         {
             sb.AppendLine("    {");
+            sb.AppendLine("        if (options is null) throw new global::System.ArgumentNullException(nameof(options));");
             sb.Append("        return new ").Append(fq).Append("()");
         }
 

--- a/src/Eryph.GuestServices.CloudConfig.SourceGen/CloudConfigGenerator.cs
+++ b/src/Eryph.GuestServices.CloudConfig.SourceGen/CloudConfigGenerator.cs
@@ -192,13 +192,21 @@ public sealed class CloudConfigGenerator : IIncrementalGenerator
         // CloudConfigMerge (e.g. records under Eryph.GuestServices.CloudConfig.Linux).
         sb.AppendLine($"    /// <summary>Source-generated deep merge for <see cref=\"{fq.Replace('<', '{').Replace('>', '}')}\"/>.</summary>");
 
+        // Every merge method carries the per-fragment cloud-init merge_how
+        // directive (RFC 0032) so list/dict overrides reach the hand-written
+        // helpers. The root overload is the strategy-aware entry point; a
+        // convenience Merge(left, right) using the default lives in the
+        // hand-written partial.
+        const string optionsParam =
+            "global::Eryph.GuestServices.CloudConfig.CloudInitMergeOptions options";
+
         if (isRootEntryPoint)
         {
-            sb.AppendLine($"    public static {fq} {methodName}({fq} left, {fq} right)");
+            sb.AppendLine($"    public static {fq} {methodName}({fq} left, {fq} right, {optionsParam})");
         }
         else
         {
-            sb.AppendLine($"    private static {fq}? {methodName}({fq}? left, {fq}? right)");
+            sb.AppendLine($"    private static {fq}? {methodName}({fq}? left, {fq}? right, {optionsParam})");
             sb.AppendLine("    {");
             sb.AppendLine("        if (left is null) return right;");
             sb.AppendLine("        if (right is null) return left;");
@@ -235,7 +243,7 @@ public sealed class CloudConfigGenerator : IIncrementalGenerator
         return kind switch
         {
             MergeKindEnum.RightWins => BuildRightWinsExpression(p),
-            MergeKindEnum.Concat => $"Concat(left.{p.Name}, right.{p.Name})",
+            MergeKindEnum.Concat => $"Concat(left.{p.Name}, right.{p.Name}, options)",
             MergeKindEnum.DeepMerge => BuildDeepMergeCall(p, recordNames),
             MergeKindEnum.KeyedByName => BuildKeyedByNameCall(p),
             MergeKindEnum.DictMerge => BuildDictMergeCall(p, recordNames),
@@ -373,7 +381,7 @@ public sealed class CloudConfigGenerator : IIncrementalGenerator
             return $"right.{p.Name} ?? left.{p.Name}";
 
         var helper = $"Merge{named.Name}";
-        return $"{helper}(left.{p.Name}, right.{p.Name})";
+        return $"{helper}(left.{p.Name}, right.{p.Name}, options)";
     }
 
     private static string BuildKeyedByNameCall(PropertyInfo p)
@@ -381,7 +389,7 @@ public sealed class CloudConfigGenerator : IIncrementalGenerator
         if (string.IsNullOrEmpty(p.KeyedMergeMethod))
             return $"right.{p.Name} ?? left.{p.Name}";
 
-        return $"MergeByName(left.{p.Name}, right.{p.Name}, e => e.Name, {p.KeyedMergeMethod})";
+        return $"MergeByName(left.{p.Name}, right.{p.Name}, e => e.Name, {p.KeyedMergeMethod}, options)";
     }
 
     private static string BuildDictMergeCall(PropertyInfo p, HashSet<string> recordNames)
@@ -400,10 +408,10 @@ public sealed class CloudConfigGenerator : IIncrementalGenerator
         {
             var valueName = ((INamedTypeSymbol)valueType).Name;
             var helper = $"Merge{valueName}";
-            return $"MergeDict(left.{p.Name}, right.{p.Name}, {helper})";
+            return $"MergeDict(left.{p.Name}, right.{p.Name}, {helper}, options)";
         }
 
-        return $"MergeDict(left.{p.Name}, right.{p.Name})";
+        return $"MergeDict(left.{p.Name}, right.{p.Name}, options)";
     }
 
     private static void EmitInventory(SourceProductionContext spc, RecordTypeInfo root)

--- a/src/Eryph.GuestServices.CloudConfig.Yaml/CloudConfigComposer.cs
+++ b/src/Eryph.GuestServices.CloudConfig.Yaml/CloudConfigComposer.cs
@@ -53,10 +53,16 @@ public static class CloudConfigComposer
         ArgumentNullException.ThrowIfNull(cloudConfigFragments);
 
         CloudConfigModel? merged = null;
-        foreach (var fragment in cloudConfigFragments)
+        foreach (var raw in cloudConfigFragments)
         {
-            if (string.IsNullOrWhiteSpace(fragment))
+            if (string.IsNullOrWhiteSpace(raw))
                 continue;
+
+            // Strip a leading UTF-8 BOM (U+FEFF) — fragments authored via
+            // PowerShell Set-Content -Encoding UTF8 carry one, and YamlDotNet
+            // rejects it before #cloud-config (mirrors the provisioning
+            // pipeline's UserDataEncoding handling).
+            var fragment = StripBom(raw);
 
             var parsed = CloudConfigYamlSerializer.Deserialize(fragment, onUnknownKey);
             if (merged is null)
@@ -76,4 +82,7 @@ public static class CloudConfigComposer
 
         return merged;
     }
+
+    private static string StripBom(string text) =>
+        text.Length > 0 && text[0] == '\uFEFF' ? text[1..] : text;
 }

--- a/src/Eryph.GuestServices.CloudConfig.Yaml/CloudConfigComposer.cs
+++ b/src/Eryph.GuestServices.CloudConfig.Yaml/CloudConfigComposer.cs
@@ -1,0 +1,79 @@
+using CloudConfigModel = Eryph.GuestServices.CloudConfig.CloudConfig;
+
+namespace Eryph.GuestServices.CloudConfig.Yaml;
+
+/// <summary>
+/// Host-side composition of several cloud-config fragments into one document.
+/// Eryph uses this to pre-merge the <c>type: cloud-config</c> fodder of a
+/// catlet before building the NoCloud seed disk, rather than shipping a pile
+/// of fragments for cloud-init to reconcile at runtime.
+/// </summary>
+/// <remarks>
+/// Fragment order is precedence. Fragments are folded left-to-right with the
+/// same deep-merge the guest agent applies (see RFC 0032): a later fragment
+/// wins on scalar conflicts, lists are concatenated, records are deep-merged,
+/// and <c>users</c>/<c>groups</c>/<c>chpasswd</c> entries merge by name. A
+/// fragment can override that default with a cloud-init <c>merge_how</c> /
+/// <c>merge_type</c> directive (e.g. <c>list(replace)</c>), read per fragment
+/// and applied as it merges onto the accumulator.
+/// </remarks>
+public static class CloudConfigComposer
+{
+    /// <summary>
+    /// Parse, deep-merge, and re-serialize <paramref name="cloudConfigFragments"/>
+    /// into a single <c>#cloud-config</c> document. Empty or whitespace-only
+    /// fragments are skipped. Returns <c>null</c> when there is nothing to emit.
+    /// </summary>
+    /// <param name="cloudConfigFragments">
+    /// Cloud-config YAML fragments in precedence order (later wins on conflict).
+    /// </param>
+    /// <param name="onUnknownKey">
+    /// Optional callback invoked once per unknown top-level key encountered in
+    /// any fragment — mirrors cloud-init's warn-but-continue behaviour.
+    /// </param>
+    public static string? Merge(
+        IEnumerable<string> cloudConfigFragments,
+        Action<string>? onUnknownKey = null)
+    {
+        var merged = MergeToModel(cloudConfigFragments, onUnknownKey);
+        return merged is null ? null : CloudConfigYamlSerializer.Serialize(merged);
+    }
+
+    /// <summary>
+    /// As <see cref="Merge"/> but stops at the merged model, for callers that
+    /// validate or post-process before serializing. Each fragment's
+    /// <c>merge_how</c> / <c>merge_type</c> directive, if present, governs how
+    /// that fragment merges onto the accumulator. Returns <c>null</c> when no
+    /// non-empty fragment was supplied.
+    /// </summary>
+    public static CloudConfigModel? MergeToModel(
+        IEnumerable<string> cloudConfigFragments,
+        Action<string>? onUnknownKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(cloudConfigFragments);
+
+        CloudConfigModel? merged = null;
+        foreach (var fragment in cloudConfigFragments)
+        {
+            if (string.IsNullOrWhiteSpace(fragment))
+                continue;
+
+            var parsed = CloudConfigYamlSerializer.Deserialize(fragment, onUnknownKey);
+            if (merged is null)
+            {
+                // First fragment: nothing to merge onto, so its merge_how
+                // directive (which governs how it stacks onto an accumulator)
+                // does not apply yet.
+                merged = parsed;
+                continue;
+            }
+
+            // cloud-init semantics: the incoming fragment's merge_how / merge_type
+            // controls how it merges onto the accumulated config.
+            var options = MergeDirectiveReader.Read(fragment) ?? CloudInitMergeOptions.CloudInitDefault;
+            merged = CloudConfigMerge.Merge(merged, parsed, options);
+        }
+
+        return merged;
+    }
+}

--- a/src/Eryph.GuestServices.CloudConfig.Yaml/CloudConfigYamlSerializer.cs
+++ b/src/Eryph.GuestServices.CloudConfig.Yaml/CloudConfigYamlSerializer.cs
@@ -12,40 +12,16 @@ namespace Eryph.GuestServices.CloudConfig.Yaml;
 
 public static class CloudConfigYamlSerializer
 {
-    private static readonly Lazy<IDeserializer> Deserializer = new(() =>
-    {
-        var builder = new DeserializerBuilder()
-            .WithCaseInsensitivePropertyMatching()
-            // Cloud-init's runtime behaviour for unknown cloud-config keys
-            // (see cloudinit/config/schema.py `validate_cloudconfig_schema`)
-            // is "warn and continue", NOT "fail" and NOT "silent". We mirror
-            // that: deserialization is tolerant (this flag), and a separate
-            // top-level walker calls the caller-supplied `onUnknownKey`
-            // callback so the DI'd `CloudConfigSerializer` can log at
-            // Warning. Cross-cloud cloud-config with Linux-only keys
-            // (apt, snap, ntp_client, …) parses cleanly; typos like
-            // `hsotname:` surface visibly in the cloud-init.log analogue.
-            .IgnoreUnmatchedProperties()
+    // Naming conventions and key aliases that BOTH the read and write paths
+    // must agree on, factored out so the round-trip cannot drift: the keys a
+    // CloudConfig deserialises from are exactly the keys it serialises back to.
+    // BuilderSkeleton<T> is the common base of DeserializerBuilder and
+    // SerializerBuilder, so the same fluent calls configure either one.
+    private static TBuilder ConfigureNamingAndAliases<TBuilder>(TBuilder builder)
+        where TBuilder : BuilderSkeleton<TBuilder>
+        => builder
             .WithEnumNamingConvention(UnderscoredNamingConvention.Instance)
             .WithNamingConvention(UnderscoredNamingConvention.Instance)
-            .WithAttributeOverride<CloudConfig>(
-                c => c.SshAuthorizedKeys!,
-                new YamlConverterAttribute(typeof(StringListYamlConverter)))
-            .WithAttributeOverride<CloudConfig>(
-                c => c.Runcmd!,
-                new YamlConverterAttribute(typeof(RuncmdListYamlConverter)))
-            .WithAttributeOverride<CloudConfig>(
-                c => c.Bootcmd!,
-                new YamlConverterAttribute(typeof(RuncmdListYamlConverter)))
-            .WithAttributeOverride<CloudConfig>(
-                c => c.SshImportId!,
-                new YamlConverterAttribute(typeof(StringListYamlConverter)))
-            .WithAttributeOverride<PhoneHomeConfig>(
-                p => p.Post!,
-                new YamlConverterAttribute(typeof(StringListYamlConverter)))
-            .WithAttributeOverride<WriteFileConfig>(
-                w => w.Permissions!,
-                new YamlConverterAttribute(typeof(WriteFilePermissionsYamlConverter)))
             // Rename properties whose snake-cased default name conflicts
             // with a C# rule (e.g. AnsibleConfig.AnsibleConfigPath maps to
             // ansible_config — clashing with the type name) or whose
@@ -73,6 +49,44 @@ public static class CloudConfigYamlSerializer
             .WithAttributeOverride<CloudConfig>(
                 c => c.LocaleConfigFile!,
                 new YamlMemberAttribute { Alias = "locale_configfile", ApplyNamingConventions = false });
+
+    private static readonly Lazy<IDeserializer> Deserializer = new(() =>
+    {
+        var builder = ConfigureNamingAndAliases(
+            new DeserializerBuilder()
+                .WithCaseInsensitivePropertyMatching()
+                // Cloud-init's runtime behaviour for unknown cloud-config keys
+                // (see cloudinit/config/schema.py `validate_cloudconfig_schema`)
+                // is "warn and continue", NOT "fail" and NOT "silent". We mirror
+                // that: deserialization is tolerant (this flag), and a separate
+                // top-level walker calls the caller-supplied `onUnknownKey`
+                // callback so the DI'd `CloudConfigSerializer` can log at
+                // Warning. Cross-cloud cloud-config with Linux-only keys
+                // (apt, snap, ntp_client, …) parses cleanly; typos like
+                // `hsotname:` surface visibly in the cloud-init.log analogue.
+                .IgnoreUnmatchedProperties())
+            // The shorthand converters below are attached via per-property
+            // YamlConverterAttribute so a scalar can stand in for a list on
+            // read. They are read-only concerns: the serialiser emits the
+            // canonical list/sequence form and needs none of them.
+            .WithAttributeOverride<CloudConfig>(
+                c => c.SshAuthorizedKeys!,
+                new YamlConverterAttribute(typeof(StringListYamlConverter)))
+            .WithAttributeOverride<CloudConfig>(
+                c => c.Runcmd!,
+                new YamlConverterAttribute(typeof(RuncmdListYamlConverter)))
+            .WithAttributeOverride<CloudConfig>(
+                c => c.Bootcmd!,
+                new YamlConverterAttribute(typeof(RuncmdListYamlConverter)))
+            .WithAttributeOverride<CloudConfig>(
+                c => c.SshImportId!,
+                new YamlConverterAttribute(typeof(StringListYamlConverter)))
+            .WithAttributeOverride<PhoneHomeConfig>(
+                p => p.Post!,
+                new YamlConverterAttribute(typeof(StringListYamlConverter)))
+            .WithAttributeOverride<WriteFileConfig>(
+                w => w.Permissions!,
+                new YamlConverterAttribute(typeof(WriteFilePermissionsYamlConverter)));
 
         // Build the type inspector first as some of our type converters require it.
         var typeInspector = builder.BuildTypeInspector();
@@ -109,6 +123,35 @@ public static class CloudConfigYamlSerializer
                 s => s.Before<DictionaryNodeDeserializer>())
             .Build();
     });
+
+    private static readonly Lazy<ISerializer> Serializer = new(() =>
+        ConfigureNamingAndAliases(new SerializerBuilder())
+            // RuncmdEntry and BoolOrString do not map to a plain mapping/scalar
+            // by default — they need the two-shape (string|sequence) and
+            // bool|string emitters. Records (users, write_files, …), lists, and
+            // dictionaries all serialise correctly via the defaults, so the
+            // read-only shorthand converters are intentionally NOT registered.
+            .WithTypeConverter(new RuncmdEntryYamlTypeConverter())
+            .WithTypeConverter(new BoolOrStringYamlConverter())
+            // Omit unset members so the emitted document carries only the keys
+            // the cloud-config actually set. OmitDefaults (not OmitNull) also
+            // drops non-nullable value-type defaults such as an Empty
+            // BoolOrString (manage_etc_hosts / resize_rootfs / power_state).
+            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults)
+            .Build());
+
+    /// <summary>
+    /// Serialize a <see cref="CloudConfig"/> back to a <c>#cloud-config</c>
+    /// YAML document. Uses the same naming conventions and key aliases as
+    /// <see cref="Deserialize(string)"/>, so the result round-trips: parsing
+    /// the output yields an equivalent model. Unset members are omitted.
+    /// </summary>
+    public static string Serialize(CloudConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        var body = Serializer.Value.Serialize(config);
+        return "#cloud-config\n" + body;
+    }
 
     public static CloudConfig Deserialize(string yaml) => Deserialize(yaml, onUnknownKey: null);
 
@@ -158,6 +201,11 @@ public static class CloudConfigYamlSerializer
             .Select(f => f.YamlName)
             .ToHashSet(StringComparer.OrdinalIgnoreCase));
 
+    // cloud-init merge directives — recognised top-level keys that are not
+    // part of the cloud-config schema (handled by MergeDirectiveReader).
+    private static readonly HashSet<string> MergeDirectiveKeys =
+        new(["merge_how", "merge_type"], StringComparer.OrdinalIgnoreCase);
+
     private static void WalkForUnknownTopLevelKeys(string yaml, Action<string> onUnknownKey)
     {
         // Parse to YamlDocument so we can inspect the keys without going
@@ -183,6 +231,10 @@ public static class CloudConfigYamlSerializer
             if (entry.Key is not YamlScalarNode keyNode) continue;
             var keyName = keyNode.Value;
             if (string.IsNullOrEmpty(keyName)) continue;
+            // merge_how / merge_type are cloud-init merge directives (RFC 0032),
+            // not config keys — recognised, but intentionally absent from the
+            // typed model, so they must not surface as "unknown key" warnings.
+            if (MergeDirectiveKeys.Contains(keyName)) continue;
             if (!known.Contains(keyName))
                 onUnknownKey(keyName);
         }

--- a/src/Eryph.GuestServices.CloudConfig.Yaml/Converters/BoolOrStringYamlConverter.cs
+++ b/src/Eryph.GuestServices.CloudConfig.Yaml/Converters/BoolOrStringYamlConverter.cs
@@ -41,13 +41,32 @@ internal sealed class BoolOrStringYamlConverter : IYamlTypeConverter
 
     public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)
     {
-        // The agent reads cloud-config but does not currently emit it. If
-        // a future serialise path needs to round-trip BoolOrString it must
-        // decide how to express the empty case (skip the key entirely?
-        // emit `~`?) — leaving as NotImplementedException so the gap is
-        // obvious if someone wires up a serialise path before the design
-        // question is answered.
-        throw new NotImplementedException(
-            "Serialising BoolOrString is not implemented — the agent only reads cloud-config.");
+        var bos = value is BoolOrString b ? b : BoolOrString.Empty;
+
+        if (bos.IsBool)
+        {
+            // Plain scalar so it resolves back to a YAML 1.1 bool token on read.
+            emitter.Emit(new Scalar(bos.Bool!.Value ? "true" : "false"));
+            return;
+        }
+
+        if (bos.IsString)
+        {
+            var text = bos.String!;
+            // A string variant whose text is a bool token (e.g. "yes") MUST be
+            // quoted, otherwise the deserialiser would read it back as a Bool.
+            // Empty strings are quoted too so they are not parsed as Empty.
+            var style = text.Length == 0 || Yaml11BoolTokens.IsBoolToken(text)
+                ? ScalarStyle.SingleQuoted
+                : ScalarStyle.Any;
+            emitter.Emit(new Scalar(
+                AnchorName.Empty, TagName.Empty, text, style,
+                isPlainImplicit: true, isQuotedImplicit: true));
+            return;
+        }
+
+        // Empty: OmitDefaults normally drops the property before we reach here,
+        // so this is a defensive fallback emitting an explicit empty scalar.
+        emitter.Emit(new Scalar(string.Empty));
     }
 }

--- a/src/Eryph.GuestServices.CloudConfig.Yaml/Converters/RuncmdEntryYamlTypeConverter.cs
+++ b/src/Eryph.GuestServices.CloudConfig.Yaml/Converters/RuncmdEntryYamlTypeConverter.cs
@@ -34,11 +34,12 @@ internal class RuncmdEntryYamlTypeConverter : IYamlTypeConverter
         // shapes — a shell-command string or an argv sequence — NOT to a
         // mapping of its internal fields. Default serialisation would emit
         // the record's properties, which is invalid runcmd.
+        // Fail fast rather than emit a broken runcmd entry: a null or
+        // non-RuncmdEntry value here is a programming error, not valid input.
+        ArgumentNullException.ThrowIfNull(value);
         if (value is not RuncmdEntry entry)
-        {
-            emitter.Emit(new Scalar(string.Empty));
-            return;
-        }
+            throw new InvalidOperationException(
+                $"Expected a {nameof(RuncmdEntry)} to serialise, got {value.GetType().Name}.");
 
         if (entry.IsShellCommand)
         {

--- a/src/Eryph.GuestServices.CloudConfig.Yaml/Converters/RuncmdEntryYamlTypeConverter.cs
+++ b/src/Eryph.GuestServices.CloudConfig.Yaml/Converters/RuncmdEntryYamlTypeConverter.cs
@@ -28,6 +28,28 @@ internal class RuncmdEntryYamlTypeConverter : IYamlTypeConverter
         };
     }
 
-    public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer) =>
-        serializer(value, type);
+    public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)
+    {
+        // A RuncmdEntry serialises back to one of cloud-init's two runcmd
+        // shapes — a shell-command string or an argv sequence — NOT to a
+        // mapping of its internal fields. Default serialisation would emit
+        // the record's properties, which is invalid runcmd.
+        if (value is not RuncmdEntry entry)
+        {
+            emitter.Emit(new Scalar(string.Empty));
+            return;
+        }
+
+        if (entry.IsShellCommand)
+        {
+            emitter.Emit(new Scalar(entry.Command ?? string.Empty));
+            return;
+        }
+
+        emitter.Emit(new SequenceStart(
+            AnchorName.Empty, TagName.Empty, isImplicit: true, SequenceStyle.Flow));
+        foreach (var arg in entry.Argv ?? [])
+            emitter.Emit(new Scalar(arg));
+        emitter.Emit(new SequenceEnd());
+    }
 }

--- a/src/Eryph.GuestServices.CloudConfig.Yaml/Eryph.GuestServices.CloudConfig.Yaml.csproj
+++ b/src/Eryph.GuestServices.CloudConfig.Yaml/Eryph.GuestServices.CloudConfig.Yaml.csproj
@@ -7,6 +7,15 @@
     <RootNamespace>Eryph.GuestServices.CloudConfig.Yaml</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Consumed by eryph: cloud-config YAML (de)serialization and
+         CloudConfigComposer, which pre-merges cloud-config fodder into a
+         single document for the NoCloud seed disk. -->
+    <IsPackable>true</IsPackable>
+    <PackageId>Eryph.GuestServices.CloudConfig.Yaml</PackageId>
+    <Description>YAML (de)serialization for the eryph guest services cloud-config model, including CloudConfigComposer for merging cloud-config fragments into one document.</Description>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Eryph.ConfigModel.Yaml" Version="0.10.0" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />

--- a/src/Eryph.GuestServices.CloudConfig.Yaml/MergeDirectiveReader.cs
+++ b/src/Eryph.GuestServices.CloudConfig.Yaml/MergeDirectiveReader.cs
@@ -1,0 +1,93 @@
+using YamlDotNet.RepresentationModel;
+
+namespace Eryph.GuestServices.CloudConfig.Yaml;
+
+/// <summary>
+/// Reads cloud-init's <c>merge_how</c> / <c>merge_type</c> directive from a raw
+/// cloud-config fragment and resolves it to <see cref="CloudInitMergeOptions"/>
+/// (RFC 0032). Both the string form
+/// (<c>list(append)+dict(no_replace)+str()</c>) and the structured list form
+/// (<c>- name: list / settings: [...]</c>) are supported. The directive is a
+/// merge instruction, not config, so it never appears on the typed
+/// <see cref="CloudConfig"/> model — it is extracted from the YAML directly.
+/// </summary>
+public static class MergeDirectiveReader
+{
+    private const string MergeHowKey = "merge_how";
+    private const string MergeTypeKey = "merge_type";
+
+    /// <summary>
+    /// Returns the merge options declared by the fragment, or <c>null</c> when
+    /// it carries no directive (the caller then uses the cloud-init default).
+    /// Malformed YAML yields <c>null</c> — the typed deserializer surfaces the
+    /// real parse error.
+    /// </summary>
+    public static CloudInitMergeOptions? Read(string yaml)
+    {
+        if (string.IsNullOrWhiteSpace(yaml))
+            return null;
+
+        YamlMappingNode? root;
+        try
+        {
+            var stream = new YamlStream();
+            stream.Load(new StringReader(yaml));
+            if (stream.Documents.Count == 0)
+                return null;
+            root = stream.Documents[0].RootNode as YamlMappingNode;
+        }
+        catch
+        {
+            return null;
+        }
+
+        if (root is null)
+            return null;
+
+        var directive = FindValue(root, MergeHowKey) ?? FindValue(root, MergeTypeKey);
+        return directive switch
+        {
+            YamlScalarNode scalar => CloudInitMergeOptions.Parse(scalar.Value),
+            YamlSequenceNode sequence => FromStructured(sequence),
+            _ => null,
+        };
+    }
+
+    private static YamlNode? FindValue(YamlMappingNode root, string key)
+    {
+        foreach (var entry in root.Children)
+        {
+            if (entry.Key is YamlScalarNode k
+                && string.Equals(k.Value, key, StringComparison.OrdinalIgnoreCase))
+                return entry.Value;
+        }
+        return null;
+    }
+
+    // Structured form: a sequence of { name: <merger>, settings: [<setting>, ...] }.
+    private static CloudInitMergeOptions FromStructured(YamlSequenceNode sequence)
+    {
+        var options = CloudInitMergeOptions.CloudInitDefault;
+        foreach (var node in sequence)
+        {
+            if (node is not YamlMappingNode merger)
+                continue;
+
+            var name = (FindValue(merger, "name") as YamlScalarNode)?.Value;
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+
+            var settings = FindValue(merger, "settings") switch
+            {
+                YamlSequenceNode s => s.Children
+                    .OfType<YamlScalarNode>()
+                    .Select(n => n.Value ?? string.Empty),
+                YamlScalarNode single => [single.Value ?? string.Empty],
+                _ => Enumerable.Empty<string>(),
+            };
+
+            options = options.WithMerger(name!, settings);
+        }
+        return options;
+    }
+}

--- a/src/Eryph.GuestServices.CloudConfig/CloudConfigMerge.cs
+++ b/src/Eryph.GuestServices.CloudConfig/CloudConfigMerge.cs
@@ -14,6 +14,12 @@ namespace Eryph.GuestServices.CloudConfig;
 // fragments declaring the same user name produce a single user record,
 // with later declarations winning on conflict.
 //
+// A per-fragment cloud-init merge_how / merge_type directive (RFC 0032) is
+// carried as a CloudInitMergeOptions and threaded through every helper so a
+// fragment can opt into list replace/prepend/no_replace or dict replace.
+// CloudInitMergeOptions.CloudInitDefault reproduces the behaviour above, so
+// the parameterless callers and the no-directive path are unchanged.
+//
 // The per-property merge code is source-generated from the model's
 // [CloudInitRoot] / [CloudInitRecord] / [CloudInitField] / [MergeBehavior]
 // attributes — see Eryph.GuestServices.CloudConfig.SourceGen. The hand-
@@ -23,15 +29,24 @@ namespace Eryph.GuestServices.CloudConfig;
 // scalar overrides.
 public static partial class CloudConfigMerge
 {
-    private static UserConfig MergeUser(UserConfig left, UserConfig right) => new()
+    /// <summary>
+    /// Deep-merge two cloud-configs using cloud-init's default merger. The
+    /// source-generated <c>Merge(left, right, options)</c> overload carries
+    /// the per-fragment <see cref="CloudInitMergeOptions"/>; this is the
+    /// convenience entry point for callers that do not vary the strategy.
+    /// </summary>
+    public static CloudConfig Merge(CloudConfig left, CloudConfig right) =>
+        Merge(left, right, CloudInitMergeOptions.CloudInitDefault);
+
+    private static UserConfig MergeUser(UserConfig left, UserConfig right, CloudInitMergeOptions options) => new()
     {
         Name = right.Name ?? left.Name,
         Passwd = right.Passwd ?? left.Passwd,
         PlainTextPasswd = right.PlainTextPasswd ?? left.PlainTextPasswd,
         HashedPasswd = right.HashedPasswd ?? left.HashedPasswd,
         LockPasswd = right.LockPasswd ?? left.LockPasswd,
-        Groups = Concat(left.Groups, right.Groups),
-        SshAuthorizedKeys = Concat(left.SshAuthorizedKeys, right.SshAuthorizedKeys),
+        Groups = Concat(left.Groups, right.Groups, options),
+        SshAuthorizedKeys = Concat(left.SshAuthorizedKeys, right.SshAuthorizedKeys, options),
         Inactive = right.Inactive ?? left.Inactive,
         Shell = right.Shell ?? left.Shell,
         HomeDir = right.HomeDir ?? left.HomeDir,
@@ -39,10 +54,10 @@ public static partial class CloudConfigMerge
         // Sudo widened from string? to IReadOnlyList<string>? — cloud-init
         // accepts a single string OR a list of strings, and stacking two
         // fragments that each carry sudoers lines concatenates them.
-        Sudo = Concat(left.Sudo, right.Sudo),
+        Sudo = Concat(left.Sudo, right.Sudo, options),
         System = right.System ?? left.System,
         Gecos = right.Gecos ?? left.Gecos,
-        SshImportId = Concat(left.SshImportId, right.SshImportId),
+        SshImportId = Concat(left.SshImportId, right.SshImportId, options),
         SshRedirectUser = right.SshRedirectUser ?? left.SshRedirectUser,
         Expiredate = right.Expiredate ?? left.Expiredate,
         NoCreateHome = right.NoCreateHome ?? left.NoCreateHome,
@@ -53,39 +68,65 @@ public static partial class CloudConfigMerge
         Snapuser = right.Snapuser ?? left.Snapuser,
     };
 
-    private static GroupConfig MergeGroup(GroupConfig left, GroupConfig right) => new()
+    private static GroupConfig MergeGroup(GroupConfig left, GroupConfig right, CloudInitMergeOptions options) => new()
     {
         Name = right.Name ?? left.Name,
-        Members = Concat(left.Members, right.Members),
+        Members = Concat(left.Members, right.Members, options),
         Gid = right.Gid ?? left.Gid,
     };
 
-    private static ChpasswdListEntry MergeChpasswdEntry(ChpasswdListEntry left, ChpasswdListEntry right) => new()
+    private static ChpasswdListEntry MergeChpasswdEntry(ChpasswdListEntry left, ChpasswdListEntry right, CloudInitMergeOptions options) => new()
     {
         Name = right.Name ?? left.Name,
         Password = right.Password ?? left.Password,
         Type = right.Type ?? left.Type,
     };
 
-    // Concatenates two lists, treating null as empty.
-    private static IReadOnlyList<T>? Concat<T>(IReadOnlyList<T>? left, IReadOnlyList<T>? right)
+    // Concatenates two lists, treating null as empty. The list merge_how
+    // action selects append (default), prepend, replace, or no_replace.
+    private static IReadOnlyList<T>? Concat<T>(
+        IReadOnlyList<T>? left,
+        IReadOnlyList<T>? right,
+        CloudInitMergeOptions options)
     {
-        if (left is null || left.Count == 0) return right;
-        if (right is null || right.Count == 0) return left;
-        var combined = new List<T>(left.Count + right.Count);
-        combined.AddRange(left);
-        combined.AddRange(right);
+        switch (options.List)
+        {
+            // The incoming fragment's list wins outright; a fragment that does
+            // not set the key (right is null) leaves the accumulated list.
+            case ListMergeAction.Replace:
+                return right ?? left;
+            // Keep the accumulated list once it has entries.
+            case ListMergeAction.NoReplace:
+                return left is { Count: > 0 } ? left : right;
+            case ListMergeAction.Prepend:
+                return ConcatInOrder(right, left);
+            default:
+                return ConcatInOrder(left, right);
+        }
+    }
+
+    private static IReadOnlyList<T>? ConcatInOrder<T>(IReadOnlyList<T>? first, IReadOnlyList<T>? second)
+    {
+        if (first is null || first.Count == 0) return second;
+        if (second is null || second.Count == 0) return first;
+        var combined = new List<T>(first.Count + second.Count);
+        combined.AddRange(first);
+        combined.AddRange(second);
         return combined;
     }
 
     // Merges two dictionaries: right entries replace same-key left entries,
     // left-only entries are preserved. Mirrors cloud-init's dict-merge
     // semantics for apt.sources, yum_repos, puppet.conf, etc. — later
-    // declarations win on conflict, novel keys accumulate.
+    // declarations win on conflict, novel keys accumulate. dict(replace)
+    // swaps the whole accumulated dictionary for the incoming one.
     private static IReadOnlyDictionary<TKey, TValue>? MergeDict<TKey, TValue>(
         IReadOnlyDictionary<TKey, TValue>? left,
-        IReadOnlyDictionary<TKey, TValue>? right) where TKey : notnull
+        IReadOnlyDictionary<TKey, TValue>? right,
+        CloudInitMergeOptions options) where TKey : notnull
     {
+        if (options.Dict == DictMergeAction.Replace)
+            return right ?? left;
         if (left is null || left.Count == 0) return right;
         if (right is null || right.Count == 0) return left;
 
@@ -103,8 +144,11 @@ public static partial class CloudConfigMerge
     private static IReadOnlyDictionary<TKey, TValue>? MergeDict<TKey, TValue>(
         IReadOnlyDictionary<TKey, TValue>? left,
         IReadOnlyDictionary<TKey, TValue>? right,
-        Func<TValue?, TValue?, TValue?> merge) where TKey : notnull
+        Func<TValue?, TValue?, CloudInitMergeOptions, TValue?> merge,
+        CloudInitMergeOptions options) where TKey : notnull
     {
+        if (options.Dict == DictMergeAction.Replace)
+            return right ?? left;
         if (left is null || left.Count == 0) return right;
         if (right is null || right.Count == 0) return left;
 
@@ -115,7 +159,7 @@ public static partial class CloudConfigMerge
         {
             if (merged.TryGetValue(kvp.Key, out var existing))
             {
-                var combined = merge(existing, kvp.Value);
+                var combined = merge(existing, kvp.Value, options);
                 if (combined is not null)
                     merged[kvp.Key] = combined;
             }
@@ -128,21 +172,45 @@ public static partial class CloudConfigMerge
     }
 
     // Merges two lists keyed by a name selector: entries with the same
-    // (non-null) name are replaced by the later one (deep-merged), and
-    // unique entries are kept in left-then-right order.
+    // (non-null) name are deep-merged (incoming wins on conflict) and unique
+    // entries are kept. The list merge_how action selects ordering/priority,
+    // mirroring Concat so users/groups honour the same directives as plain
+    // lists:
+    //   - replace    → the incoming list wins outright
+    //   - no_replace → keep the accumulated list once it has entries
+    //   - prepend    → incoming entries first, then novel accumulated entries
+    //   - append     → accumulated entries first, then novel incoming (default)
     private static IReadOnlyList<T>? MergeByName<T>(
         IReadOnlyList<T>? left,
         IReadOnlyList<T>? right,
         Func<T, string?> nameSelector,
-        Func<T, T, T> merge) where T : class
+        Func<T, T, CloudInitMergeOptions, T> merge,
+        CloudInitMergeOptions options) where T : class
     {
+        switch (options.List)
+        {
+            case ListMergeAction.Replace:
+                return right ?? left;
+            case ListMergeAction.NoReplace:
+                return left is { Count: > 0 } ? left : right;
+        }
+
         if (left is null || left.Count == 0) return right;
         if (right is null || right.Count == 0) return left;
+
+        // Prepend lays the incoming entries down first; append (default) lays
+        // the accumulated entries first. Either way a same-named pair is
+        // deep-merged with the incoming (right) entry winning, and it keeps the
+        // slot of whichever list seeds the result.
+        var (first, second) = options.List == ListMergeAction.Prepend
+            ? (right, left)
+            : (left, right);
+        var rightIsSecond = options.List != ListMergeAction.Prepend;
 
         var result = new List<T>(left.Count + right.Count);
         var indexByName = new Dictionary<string, int>(StringComparer.Ordinal);
 
-        foreach (var item in left)
+        foreach (var item in first)
         {
             var name = nameSelector(item);
             if (name is not null)
@@ -150,12 +218,16 @@ public static partial class CloudConfigMerge
             result.Add(item);
         }
 
-        foreach (var item in right)
+        foreach (var item in second)
         {
             var name = nameSelector(item);
             if (name is not null && indexByName.TryGetValue(name, out var idx))
             {
-                result[idx] = merge(result[idx], item);
+                // Always merge as (accumulated-left, incoming-right) so the
+                // incoming fragment wins regardless of which list seeded the slot.
+                result[idx] = rightIsSecond
+                    ? merge(result[idx], item, options)
+                    : merge(item, result[idx], options);
             }
             else
             {

--- a/src/Eryph.GuestServices.CloudConfig/CloudInitMergeOptions.cs
+++ b/src/Eryph.GuestServices.CloudConfig/CloudInitMergeOptions.cs
@@ -1,0 +1,135 @@
+namespace Eryph.GuestServices.CloudConfig;
+
+/// <summary>How a fragment's lists merge onto the accumulated config.</summary>
+public enum ListMergeAction
+{
+    /// <summary>Concatenate left then right (cloud-init default).</summary>
+    Append,
+
+    /// <summary>Concatenate right then left.</summary>
+    Prepend,
+
+    /// <summary>The incoming (right) list replaces the accumulated (left) one.</summary>
+    Replace,
+
+    /// <summary>Keep the accumulated (left) list when it already has entries.</summary>
+    NoReplace,
+}
+
+/// <summary>How a fragment's dictionaries merge onto the accumulated config.</summary>
+public enum DictMergeAction
+{
+    /// <summary>Deep-merge / recurse, novel keys added (cloud-init default).</summary>
+    Recurse,
+
+    /// <summary>The incoming (right) dictionary replaces the accumulated one.</summary>
+    Replace,
+}
+
+/// <summary>How a fragment's scalar strings merge onto the accumulated config.</summary>
+public enum StrMergeAction
+{
+    /// <summary>The incoming (right) value wins (cloud-init default).</summary>
+    Replace,
+
+    /// <summary>Concatenate left + right. Parsed but not applied to typed scalars.</summary>
+    Append,
+}
+
+/// <summary>
+/// Parsed form of cloud-init's <c>merge_how</c> / <c>merge_type</c> directive
+/// (see RFC 0032). Selects per-fragment merge behaviour for lists, dicts, and
+/// strings; threaded through the source-generated <see cref="CloudConfigMerge"/>.
+/// The default matches cloud-init's default merger, which is the behaviour
+/// applied when a fragment carries no directive.
+/// </summary>
+public sealed record CloudInitMergeOptions
+{
+    public ListMergeAction List { get; init; } = ListMergeAction.Append;
+
+    public DictMergeAction Dict { get; init; } = DictMergeAction.Recurse;
+
+    public StrMergeAction Str { get; init; } = StrMergeAction.Replace;
+
+    /// <summary>
+    /// cloud-init's default merger — lists append, dicts deep-merge, scalars
+    /// later-wins. Used whenever a fragment carries no merge directive.
+    /// </summary>
+    public static readonly CloudInitMergeOptions CloudInitDefault = new();
+
+    /// <summary>
+    /// Parse the string form of the directive, e.g.
+    /// <c>list(append)+dict(no_replace,recurse_list)+str()</c>. Unknown
+    /// mergers and settings are ignored permissively. Returns
+    /// <see cref="CloudInitDefault"/> for null/blank input.
+    /// </summary>
+    public static CloudInitMergeOptions Parse(string? mergeHow)
+    {
+        if (string.IsNullOrWhiteSpace(mergeHow))
+            return CloudInitDefault;
+
+        var options = CloudInitDefault;
+        foreach (var (name, settings) in EnumerateMergers(mergeHow!))
+            options = options.WithMerger(name, settings);
+        return options;
+    }
+
+    /// <summary>
+    /// Apply one merger (e.g. name <c>list</c>, settings <c>append, no_replace</c>)
+    /// from either the string or the structured directive form.
+    /// </summary>
+    public CloudInitMergeOptions WithMerger(string name, IEnumerable<string> settings)
+    {
+        // Settings are matched as exact tokens so "no_replace" is never seen as
+        // "replace".
+        var tokens = new HashSet<string>(
+            settings.Select(s => s.Trim().ToLowerInvariant()),
+            StringComparer.Ordinal);
+
+        return name.Trim().ToLowerInvariant() switch
+        {
+            "list" => this with { List = ParseListAction(tokens) },
+            "dict" => this with { Dict = tokens.Contains("replace") ? DictMergeAction.Replace : DictMergeAction.Recurse },
+            "str" => this with { Str = tokens.Contains("append") ? StrMergeAction.Append : StrMergeAction.Replace },
+            _ => this,
+        };
+    }
+
+    private static ListMergeAction ParseListAction(HashSet<string> tokens)
+    {
+        // Tokens are independent flags; if a fragment supplies contradictory
+        // ones (e.g. "replace,no_replace") the most destructive wins by this
+        // ordering. "no_replace" is matched as an exact token, so the earlier
+        // "replace" check never captures it.
+        if (tokens.Contains("replace")) return ListMergeAction.Replace;
+        if (tokens.Contains("no_replace")) return ListMergeAction.NoReplace;
+        if (tokens.Contains("prepend")) return ListMergeAction.Prepend;
+        return ListMergeAction.Append;
+    }
+
+    // Splits "list(append)+dict(no_replace,recurse_list)+str()" into
+    // (name, settings) pairs. Tolerant of whitespace and missing parentheses
+    // (a bare "list" is a merger with no settings).
+    private static IEnumerable<(string Name, string[] Settings)> EnumerateMergers(string mergeHow)
+    {
+        foreach (var raw in mergeHow.Split('+'))
+        {
+            var part = raw.Trim();
+            if (part.Length == 0)
+                continue;
+
+            var open = part.IndexOf('(');
+            if (open < 0)
+            {
+                yield return (part, []);
+                continue;
+            }
+
+            var name = part[..open].Trim();
+            var close = part.IndexOf(')', open);
+            var inner = close < 0 ? part[(open + 1)..] : part[(open + 1)..close];
+            var settings = inner.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            yield return (name, settings);
+        }
+    }
+}

--- a/src/Eryph.GuestServices.CloudConfig/Eryph.GuestServices.CloudConfig.csproj
+++ b/src/Eryph.GuestServices.CloudConfig/Eryph.GuestServices.CloudConfig.csproj
@@ -10,6 +10,16 @@
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)Generated</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Consumed by eryph: the cloud-config model and the source-generated
+         deep merge (CloudConfigMerge.Merge) used to pre-merge fodder before
+         building the NoCloud seed disk. The merge is baked into this assembly,
+         so the source-generator project does not ship (PrivateAssets below). -->
+    <IsPackable>true</IsPackable>
+    <PackageId>Eryph.GuestServices.CloudConfig</PackageId>
+    <Description>Cloud-config model for eryph guest services, with the source-generated cloud-init deep-merge used to compose cloud-config fragments.</Description>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Eryph.ConfigModel.Core" Version="0.10.0" />
     <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.10.0" />
@@ -18,7 +28,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Eryph.GuestServices.CloudConfig.SourceGen\Eryph.GuestServices.CloudConfig.SourceGen.csproj"
                       OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false" />
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Eryph.GuestServices.Provisioning/Serialization/CloudConfigSerializer.cs
+++ b/src/Eryph.GuestServices.Provisioning/Serialization/CloudConfigSerializer.cs
@@ -58,4 +58,7 @@ public sealed class CloudConfigSerializer(ILogger<CloudConfigSerializer> logger)
 
         return config;
     }
+
+    public CloudInitMergeOptions? ReadMergeOptions(string yaml) =>
+        MergeDirectiveReader.Read(yaml);
 }

--- a/src/Eryph.GuestServices.Provisioning/Serialization/ICloudConfigSerializer.cs
+++ b/src/Eryph.GuestServices.Provisioning/Serialization/ICloudConfigSerializer.cs
@@ -3,4 +3,8 @@ namespace Eryph.GuestServices.Provisioning.Serialization;
 public interface ICloudConfigSerializer
 {
     global::Eryph.GuestServices.CloudConfig.CloudConfig Deserialize(string yaml);
+
+    // The fragment's cloud-init merge_how / merge_type directive (RFC 0032),
+    // or null when it carries none (caller uses the cloud-init default).
+    global::Eryph.GuestServices.CloudConfig.CloudInitMergeOptions? ReadMergeOptions(string yaml);
 }

--- a/src/Eryph.GuestServices.Provisioning/UserData/Handlers/CloudConfigPartHandler.cs
+++ b/src/Eryph.GuestServices.Provisioning/UserData/Handlers/CloudConfigPartHandler.cs
@@ -1,3 +1,4 @@
+using Eryph.GuestServices.CloudConfig;
 using Eryph.GuestServices.Provisioning.Serialization;
 using Microsoft.Extensions.Logging;
 
@@ -22,7 +23,10 @@ internal sealed class CloudConfigPartHandler(
         try
         {
             var fragment = serializer.Deserialize(yaml);
-            ctx.MergeCloudConfig(fragment);
+            // cloud-init merge_how / merge_type (RFC 0032): this fragment's
+            // directive controls how it merges onto the accumulated config.
+            var options = serializer.ReadMergeOptions(yaml) ?? CloudInitMergeOptions.CloudInitDefault;
+            ctx.MergeCloudConfig(fragment, options);
             logger.LogDebug("Merged cloud-config fragment from {Filename}", part.Filename ?? "<root>");
         }
         catch (Exception ex)

--- a/src/Eryph.GuestServices.Provisioning/UserData/Handlers/IUserDataHandler.cs
+++ b/src/Eryph.GuestServices.Provisioning/UserData/Handlers/IUserDataHandler.cs
@@ -25,6 +25,10 @@ public interface IUserDataResolutionContext
 {
     void MergeCloudConfig(CloudConfig.CloudConfig fragment);
 
+    // Merge a fragment using its cloud-init merge_how / merge_type directive
+    // (RFC 0032). The parameterless overload uses the cloud-init default.
+    void MergeCloudConfig(CloudConfig.CloudConfig fragment, CloudInitMergeOptions options);
+
     void AddScript(ScriptPayload script);
 
     void AddBoothook(BoothookPayload boothook);

--- a/src/Eryph.GuestServices.Provisioning/UserData/UserDataResolutionContext.cs
+++ b/src/Eryph.GuestServices.Provisioning/UserData/UserDataResolutionContext.cs
@@ -28,10 +28,14 @@ internal sealed class UserDataResolutionContext(
 
     public IReadOnlyList<BoothookPayload> Boothooks => _boothooks;
 
-    public void MergeCloudConfig(CloudConfigModel fragment)
+    public void MergeCloudConfig(CloudConfigModel fragment) =>
+        MergeCloudConfig(fragment, CloudInitMergeOptions.CloudInitDefault);
+
+    public void MergeCloudConfig(CloudConfigModel fragment, CloudInitMergeOptions options)
     {
         ArgumentNullException.ThrowIfNull(fragment);
-        CloudConfig = CloudConfigMerge.Merge(CloudConfig, fragment);
+        ArgumentNullException.ThrowIfNull(options);
+        CloudConfig = CloudConfigMerge.Merge(CloudConfig, fragment, options);
     }
 
     public void AddScript(ScriptPayload script)

--- a/test/Eryph.GuestServices.CloudConfig.SourceGen.Tests/CloudConfigGeneratorTests.cs
+++ b/test/Eryph.GuestServices.CloudConfig.SourceGen.Tests/CloudConfigGeneratorTests.cs
@@ -119,15 +119,15 @@ public sealed class CloudConfigGeneratorTests
             "Merge is the public entry-point for the root type");
         mergeText.Should().Contain("Hostname = right.Hostname ?? left.Hostname",
             "RightWins is the default for nullable scalars");
-        mergeText.Should().Contain("Keys = Concat(left.Keys, right.Keys)",
-            "list-typed properties default to Concat");
-        mergeText.Should().Contain("Sub = MergeSubConfig(left.Sub, right.Sub)",
-            "nested [CloudInitRecord] properties default to DeepMerge");
+        mergeText.Should().Contain("Keys = Concat(left.Keys, right.Keys, options)",
+            "list-typed properties default to Concat, threading the merge options");
+        mergeText.Should().Contain("Sub = MergeSubConfig(left.Sub, right.Sub, options)",
+            "nested [CloudInitRecord] properties default to DeepMerge, threading the merge options");
         mergeText.Should().Contain("MergeSubConfig(",
             "the generator must emit a per-record helper");
-        mergeText.Should().Contain("StringDict = MergeDict(left.StringDict, right.StringDict)",
+        mergeText.Should().Contain("StringDict = MergeDict(left.StringDict, right.StringDict, options)",
             "IReadOnlyDictionary with a scalar value type defaults to plain DictMerge");
-        mergeText.Should().Contain("RecordDict = MergeDict(left.RecordDict, right.RecordDict, MergeSubConfig)",
+        mergeText.Should().Contain("RecordDict = MergeDict(left.RecordDict, right.RecordDict, MergeSubConfig, options)",
             "IReadOnlyDictionary with a [CloudInitRecord] value type passes the per-record merger");
         mergeText.Should().Contain("Union = (right.Union.IsEmpty ? left.Union : right.Union)",
             "structured primitives (value-type structs with a public IsEmpty bool) merge via IsEmpty, not ??");

--- a/test/Eryph.GuestServices.CloudConfig.Tests/CloudConfigMergeOptionsTests.cs
+++ b/test/Eryph.GuestServices.CloudConfig.Tests/CloudConfigMergeOptionsTests.cs
@@ -1,0 +1,131 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.CloudConfig;
+
+namespace Eryph.GuestServices.CloudConfig.Tests;
+
+/// <summary>
+/// The merge engine honours a per-fragment cloud-init merge_how directive
+/// (RFC 0032). The default (parameterless) overload is covered elsewhere; these
+/// pin the non-default list/dict actions.
+/// </summary>
+public sealed class CloudConfigMergeOptionsTests
+{
+    private static CloudConfig WithKeys(params string[] keys) =>
+        new() { SshAuthorizedKeys = keys };
+
+    [Fact]
+    public void Default_appends_lists()
+    {
+        var merged = CloudConfigMerge.Merge(WithKeys("a"), WithKeys("b"));
+
+        merged.SshAuthorizedKeys.Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public void List_replace_drops_the_accumulated_list()
+    {
+        var options = CloudInitMergeOptions.Parse("list(replace)");
+
+        var merged = CloudConfigMerge.Merge(WithKeys("a", "b"), WithKeys("c"), options);
+
+        merged.SshAuthorizedKeys.Should().Equal("c");
+    }
+
+    [Fact]
+    public void List_prepend_puts_incoming_first()
+    {
+        var options = CloudInitMergeOptions.Parse("list(prepend)");
+
+        var merged = CloudConfigMerge.Merge(WithKeys("a"), WithKeys("b"), options);
+
+        merged.SshAuthorizedKeys.Should().Equal("b", "a");
+    }
+
+    [Fact]
+    public void List_no_replace_keeps_the_accumulated_list()
+    {
+        var options = CloudInitMergeOptions.Parse("list(no_replace)");
+
+        var merged = CloudConfigMerge.Merge(WithKeys("a"), WithKeys("b"), options);
+
+        merged.SshAuthorizedKeys.Should().Equal("a");
+    }
+
+    [Fact]
+    public void List_replace_with_absent_incoming_keeps_left()
+    {
+        // A fragment that does not set the key (right is null) leaves the
+        // accumulated list even under list(replace).
+        var options = CloudInitMergeOptions.Parse("list(replace)");
+
+        var merged = CloudConfigMerge.Merge(WithKeys("a", "b"), new CloudConfig(), options);
+
+        merged.SshAuthorizedKeys.Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public void Users_replace_drops_the_whole_keyed_list()
+    {
+        var left = new CloudConfig
+        {
+            Users = [new UserConfig { Name = "admin" }, new UserConfig { Name = "deploy" }],
+        };
+        var right = new CloudConfig { Users = [new UserConfig { Name = "root" }] };
+        var options = CloudInitMergeOptions.Parse("list(replace)");
+
+        var merged = CloudConfigMerge.Merge(left, right, options);
+
+        merged.Users!.Select(u => u.Name).Should().Equal("root");
+    }
+
+    [Fact]
+    public void Users_no_replace_keeps_the_accumulated_list()
+    {
+        var left = new CloudConfig { Users = [new UserConfig { Name = "admin" }] };
+        var right = new CloudConfig { Users = [new UserConfig { Name = "root" }] };
+        var options = CloudInitMergeOptions.Parse("list(no_replace)");
+
+        var merged = CloudConfigMerge.Merge(left, right, options);
+
+        merged.Users!.Select(u => u.Name).Should().Equal("admin");
+    }
+
+    [Fact]
+    public void Users_prepend_puts_incoming_first_and_still_merges_by_name()
+    {
+        var left = new CloudConfig
+        {
+            Users = [new UserConfig { Name = "admin", Groups = ["sudo"] }],
+        };
+        var right = new CloudConfig
+        {
+            Users =
+            [
+                new UserConfig { Name = "deploy" },
+                new UserConfig { Name = "admin", Groups = ["docker"] },
+            ],
+        };
+        var options = CloudInitMergeOptions.Parse("list(prepend)");
+
+        var merged = CloudConfigMerge.Merge(left, right, options);
+
+        // Incoming entries lead; the shared "admin" is deep-merged. The prepend
+        // directive applies recursively, so the nested groups also prepend the
+        // incoming (docker) before the accumulated (sudo).
+        merged.Users!.Select(u => u.Name).Should().Equal("deploy", "admin");
+        var admin = merged.Users!.Single(u => u.Name == "admin");
+        admin.Groups.Should().Equal("docker", "sudo");
+    }
+
+    [Fact]
+    public void Users_default_merges_by_name()
+    {
+        var left = new CloudConfig { Users = [new UserConfig { Name = "admin", Groups = ["sudo"] }] };
+        var right = new CloudConfig { Users = [new UserConfig { Name = "admin", Groups = ["docker"] }] };
+
+        var merged = CloudConfigMerge.Merge(left, right);
+
+        merged.Users.Should().ContainSingle();
+        merged.Users![0].Groups.Should().Equal("sudo", "docker");
+    }
+}

--- a/test/Eryph.GuestServices.CloudConfig.Tests/CloudInitMergeOptionsTests.cs
+++ b/test/Eryph.GuestServices.CloudConfig.Tests/CloudInitMergeOptionsTests.cs
@@ -1,0 +1,69 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.CloudConfig;
+
+namespace Eryph.GuestServices.CloudConfig.Tests;
+
+public sealed class CloudInitMergeOptionsTests
+{
+    [Fact]
+    public void Blank_directive_is_the_cloud_init_default()
+    {
+        CloudInitMergeOptions.Parse(null).Should().BeSameAs(CloudInitMergeOptions.CloudInitDefault);
+        CloudInitMergeOptions.Parse("   ").Should().BeSameAs(CloudInitMergeOptions.CloudInitDefault);
+
+        var def = CloudInitMergeOptions.CloudInitDefault;
+        def.List.Should().Be(ListMergeAction.Append);
+        def.Dict.Should().Be(DictMergeAction.Recurse);
+        def.Str.Should().Be(StrMergeAction.Replace);
+    }
+
+    [Fact]
+    public void Parses_list_actions()
+    {
+        CloudInitMergeOptions.Parse("list(replace)").List.Should().Be(ListMergeAction.Replace);
+        CloudInitMergeOptions.Parse("list(prepend)").List.Should().Be(ListMergeAction.Prepend);
+        CloudInitMergeOptions.Parse("list(append)").List.Should().Be(ListMergeAction.Append);
+    }
+
+    [Fact]
+    public void No_replace_is_not_mistaken_for_replace()
+    {
+        // "no_replace" contains "replace" as a substring — token matching must
+        // not collapse it into Replace.
+        CloudInitMergeOptions.Parse("list(no_replace)").List.Should().Be(ListMergeAction.NoReplace);
+    }
+
+    [Fact]
+    public void Parses_full_cloud_init_default_string_form()
+    {
+        var options = CloudInitMergeOptions.Parse("list(append)+dict(no_replace,recurse_list)+str()");
+
+        options.List.Should().Be(ListMergeAction.Append);
+        options.Dict.Should().Be(DictMergeAction.Recurse);
+        options.Str.Should().Be(StrMergeAction.Replace);
+    }
+
+    [Fact]
+    public void Parses_dict_and_str_overrides()
+    {
+        var options = CloudInitMergeOptions.Parse("dict(replace)+str(append)");
+
+        options.Dict.Should().Be(DictMergeAction.Replace);
+        options.Str.Should().Be(StrMergeAction.Append);
+    }
+
+    [Fact]
+    public void Unknown_mergers_and_settings_are_ignored()
+    {
+        var options = CloudInitMergeOptions.Parse("list(replace,recurse_array)+frob(whatever)");
+
+        options.List.Should().Be(ListMergeAction.Replace);
+        options.Dict.Should().Be(DictMergeAction.Recurse);
+    }
+
+    [Fact]
+    public void Bare_merger_name_without_parens_is_tolerated()
+    {
+        CloudInitMergeOptions.Parse("dict+list(replace)").List.Should().Be(ListMergeAction.Replace);
+    }
+}

--- a/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/CloudConfigComposerTests.cs
+++ b/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/CloudConfigComposerTests.cs
@@ -28,6 +28,21 @@ public sealed class CloudConfigComposerTests
     }
 
     [Fact]
+    public void Strips_leading_utf8_bom_from_fragments()
+    {
+        // PowerShell Set-Content -Encoding UTF8 prefixes a U+FEFF; YamlDotNet
+        // would otherwise reject it before #cloud-config.
+        var model = CloudConfigComposer.MergeToModel(
+        [
+            "\uFEFF#cloud-config\nhostname: web01",
+            "\uFEFFssh_authorized_keys: [k]",
+        ]);
+
+        model!.Hostname.Should().Be("web01");
+        model.SshAuthorizedKeys.Should().Equal("k");
+    }
+
+    [Fact]
     public void Later_fragment_wins_on_scalar_conflict()
     {
         var model = CloudConfigComposer.MergeToModel(

--- a/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/CloudConfigComposerTests.cs
+++ b/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/CloudConfigComposerTests.cs
@@ -1,0 +1,108 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.CloudConfig;
+using Eryph.GuestServices.CloudConfig.Yaml;
+
+namespace Eryph.GuestServices.CloudConfig.Yaml.Tests;
+
+/// <summary>
+/// Coverage for <see cref="CloudConfigComposer"/> — the host-side facade eryph
+/// uses to pre-merge cloud-config fodder into one document. Precedence is
+/// fragment order (later wins on scalars, lists concatenate), per RFC 0032.
+/// </summary>
+public sealed class CloudConfigComposerTests
+{
+    [Fact]
+    public void Returns_null_when_no_fragments()
+    {
+        CloudConfigComposer.MergeToModel([]).Should().BeNull();
+        CloudConfigComposer.Merge([]).Should().BeNull();
+    }
+
+    [Fact]
+    public void Skips_empty_and_whitespace_fragments()
+    {
+        var model = CloudConfigComposer.MergeToModel(["", "   ", "hostname: web01"]);
+
+        model.Should().NotBeNull();
+        model!.Hostname.Should().Be("web01");
+    }
+
+    [Fact]
+    public void Later_fragment_wins_on_scalar_conflict()
+    {
+        var model = CloudConfigComposer.MergeToModel(
+        [
+            "hostname: first",
+            "hostname: second",
+        ]);
+
+        model!.Hostname.Should().Be("second");
+    }
+
+    [Fact]
+    public void Lists_concatenate_in_fragment_order()
+    {
+        var model = CloudConfigComposer.MergeToModel(
+        [
+            "ssh_authorized_keys: [keyA]",
+            "ssh_authorized_keys: [keyB, keyC]",
+        ]);
+
+        model!.SshAuthorizedKeys.Should().Equal("keyA", "keyB", "keyC");
+    }
+
+    [Fact]
+    public void Users_merge_by_name_across_fragments()
+    {
+        var model = CloudConfigComposer.MergeToModel(
+        [
+            """
+            users:
+              - name: admin
+                groups: [sudo]
+            """,
+            """
+            users:
+              - name: admin
+                groups: [docker]
+              - name: deploy
+            """,
+        ]);
+
+        model!.Users.Should().HaveCount(2);
+        var admin = model.Users!.Single(u => u.Name == "admin");
+        admin.Groups.Should().Equal("sudo", "docker");
+        model.Users.Should().Contain(u => u.Name == "deploy");
+    }
+
+    [Fact]
+    public void Merge_produces_a_single_serialisable_cloud_config_document()
+    {
+        var doc = CloudConfigComposer.Merge(
+        [
+            "hostname: web01\nssh_authorized_keys: [keyA]",
+            "ssh_authorized_keys: [keyB]\nruncmd:\n  - echo hi",
+        ]);
+
+        doc.Should().StartWith("#cloud-config\n");
+
+        // The composed document must itself parse back to the merged model.
+        var reparsed = CloudConfigYamlSerializer.Deserialize(doc!);
+        reparsed.Hostname.Should().Be("web01");
+        reparsed.SshAuthorizedKeys.Should().Equal("keyA", "keyB");
+        reparsed.Runcmd.Should().ContainSingle();
+        reparsed.Runcmd![0].Command.Should().Be("echo hi");
+    }
+
+    [Fact]
+    public void Unknown_keys_surface_through_the_callback()
+    {
+        var unknown = new List<string>();
+
+        CloudConfigComposer.MergeToModel(
+            ["hostname: web01\nnot_a_real_key: 1"],
+            unknown.Add);
+
+        unknown.Should().Contain("not_a_real_key");
+    }
+}

--- a/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/CloudConfigSerializeRoundTripTests.cs
+++ b/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/CloudConfigSerializeRoundTripTests.cs
@@ -1,0 +1,172 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.CloudConfig;
+using Eryph.GuestServices.CloudConfig.Yaml;
+
+namespace Eryph.GuestServices.CloudConfig.Yaml.Tests;
+
+/// <summary>
+/// Coverage for the model → YAML serialize path added so eryph can pre-merge
+/// cloud-config fodder into a single document. The contract is round-trip
+/// stability: serialising a parsed cloud-config and parsing the result again
+/// yields an equivalent model, and the output is a valid <c>#cloud-config</c>
+/// document.
+/// </summary>
+public sealed class CloudConfigSerializeRoundTripTests
+{
+    private static CloudConfig RoundTrip(string yaml)
+    {
+        var model = CloudConfigYamlSerializer.Deserialize(yaml);
+        var serialized = CloudConfigYamlSerializer.Serialize(model);
+        return CloudConfigYamlSerializer.Deserialize(serialized);
+    }
+
+    [Fact]
+    public void Output_starts_with_cloud_config_header()
+    {
+        var model = CloudConfigYamlSerializer.Deserialize("hostname: web01");
+
+        var serialized = CloudConfigYamlSerializer.Serialize(model);
+
+        serialized.Should().StartWith("#cloud-config\n");
+    }
+
+    [Fact]
+    public void Unset_members_are_omitted()
+    {
+        var model = CloudConfigYamlSerializer.Deserialize("hostname: web01");
+
+        var serialized = CloudConfigYamlSerializer.Serialize(model);
+
+        serialized.Should().Contain("hostname: web01");
+        // A non-nullable Empty BoolOrString must not leak into the output.
+        serialized.Should().NotContain("manage_etc_hosts");
+        serialized.Should().NotContain("resize_rootfs");
+        serialized.Should().NotContain("runcmd");
+    }
+
+    [Fact]
+    public void Scalar_and_list_keys_round_trip()
+    {
+        const string yaml = """
+                            hostname: web01
+                            fqdn: web01.example.com
+                            ssh_authorized_keys:
+                              - ssh-ed25519 AAAAkey1 a@h
+                              - ssh-ed25519 AAAAkey2 b@h
+                            """;
+
+        var result = RoundTrip(yaml);
+
+        result.Hostname.Should().Be("web01");
+        result.Fqdn.Should().Be("web01.example.com");
+        result.SshAuthorizedKeys.Should().Equal(
+            "ssh-ed25519 AAAAkey1 a@h", "ssh-ed25519 AAAAkey2 b@h");
+    }
+
+    [Fact]
+    public void Runcmd_shell_and_argv_forms_round_trip()
+    {
+        const string yaml = """
+                            runcmd:
+                              - echo hello
+                              - [ls, -l, /tmp]
+                            """;
+
+        var result = RoundTrip(yaml);
+
+        result.Runcmd.Should().HaveCount(2);
+        result.Runcmd![0].IsShellCommand.Should().BeTrue();
+        result.Runcmd[0].Command.Should().Be("echo hello");
+        result.Runcmd[1].IsShellCommand.Should().BeFalse();
+        result.Runcmd[1].Argv.Should().Equal("ls", "-l", "/tmp");
+    }
+
+    [Fact]
+    public void Bool_or_string_union_round_trips_both_variants()
+    {
+        // manage_etc_hosts is a plain bool token; resize_rootfs the string
+        // "noblock" — the quoting must survive the round-trip so the string
+        // variant does not collapse into a bool.
+        const string yaml = """
+                            manage_etc_hosts: true
+                            resize_rootfs: noblock
+                            """;
+
+        var result = RoundTrip(yaml);
+
+        result.ManageEtcHosts.IsBool.Should().BeTrue();
+        result.ManageEtcHosts.Bool.Should().BeTrue();
+        result.ResizeRootfs.IsString.Should().BeTrue();
+        result.ResizeRootfs.String.Should().Be("noblock");
+    }
+
+    [Fact]
+    public void String_variant_that_looks_like_a_bool_token_stays_a_string()
+    {
+        // A quoted "yes" is a string per PyYAML semantics; serialising it must
+        // re-quote so it is not read back as a Bool.
+        var model = new CloudConfig { ManageEtcHosts = BoolOrString.FromString("yes") };
+
+        var serialized = CloudConfigYamlSerializer.Serialize(model);
+        var result = CloudConfigYamlSerializer.Deserialize(serialized);
+
+        result.ManageEtcHosts.IsString.Should().BeTrue();
+        result.ManageEtcHosts.String.Should().Be("yes");
+    }
+
+    [Fact]
+    public void Users_round_trip_by_name_with_keys()
+    {
+        const string yaml = """
+                            users:
+                              - name: admin
+                                groups: [sudo, docker]
+                                ssh_authorized_keys:
+                                  - ssh-ed25519 AAAAkey admin@host
+                                lock_passwd: false
+                            """;
+
+        var result = RoundTrip(yaml);
+
+        result.Users.Should().ContainSingle();
+        var user = result.Users![0];
+        user.Name.Should().Be("admin");
+        user.Groups.Should().Equal("sudo", "docker");
+        user.SshAuthorizedKeys.Should().Equal("ssh-ed25519 AAAAkey admin@host");
+        user.LockPasswd.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Write_files_with_permissions_round_trip()
+    {
+        const string yaml = """
+                            write_files:
+                              - path: /etc/app.conf
+                                content: key=value
+                                permissions: '0644'
+                                owner: root:root
+                            """;
+
+        var result = RoundTrip(yaml);
+
+        result.WriteFiles.Should().ContainSingle();
+        var file = result.WriteFiles![0];
+        file.Path.Should().Be("/etc/app.conf");
+        file.Content.Should().Be("key=value");
+        file.Permissions.Should().Be("0644");
+        file.Owner.Should().Be("root:root");
+    }
+
+    [Fact]
+    public void Aliased_keys_emit_cloud_init_spelling()
+    {
+        var model = CloudConfigYamlSerializer.Deserialize("ssh_deletekeys: false");
+
+        var serialized = CloudConfigYamlSerializer.Serialize(model);
+
+        // Must emit the cloud-init key spelling, not the property-derived
+        // ssh_delete_keys.
+        serialized.Should().Contain("ssh_deletekeys");
+        serialized.Should().NotContain("ssh_delete_keys");
+    }
+}

--- a/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/MergeDirectiveAndComposerTests.cs
+++ b/test/Eryph.GuestServices.CloudConfig.Yaml.Tests/MergeDirectiveAndComposerTests.cs
@@ -1,0 +1,146 @@
+using AwesomeAssertions;
+using Eryph.GuestServices.CloudConfig;
+using Eryph.GuestServices.CloudConfig.Yaml;
+
+namespace Eryph.GuestServices.CloudConfig.Yaml.Tests;
+
+/// <summary>
+/// merge_how / merge_type directive extraction (RFC 0032) and the composer's
+/// honouring of it when pre-merging fragments.
+/// </summary>
+public sealed class MergeDirectiveAndComposerTests
+{
+    [Fact]
+    public void Absent_directive_reads_as_null()
+    {
+        MergeDirectiveReader.Read("hostname: web01").Should().BeNull();
+    }
+
+    [Fact]
+    public void Reads_string_form_merge_how()
+    {
+        var options = MergeDirectiveReader.Read("merge_how: 'list(replace)+dict(replace)'\nhostname: web01");
+
+        options.Should().NotBeNull();
+        options!.List.Should().Be(ListMergeAction.Replace);
+        options.Dict.Should().Be(DictMergeAction.Replace);
+    }
+
+    [Fact]
+    public void Reads_merge_type_alias()
+    {
+        var options = MergeDirectiveReader.Read("merge_type: list(prepend)");
+
+        options!.List.Should().Be(ListMergeAction.Prepend);
+    }
+
+    [Fact]
+    public void Reads_structured_list_form()
+    {
+        const string yaml = """
+                            merge_how:
+                              - name: list
+                                settings: [replace]
+                              - name: dict
+                                settings: [recurse_list]
+                            ssh_authorized_keys: [k]
+                            """;
+
+        var options = MergeDirectiveReader.Read(yaml);
+
+        options!.List.Should().Be(ListMergeAction.Replace);
+        options.Dict.Should().Be(DictMergeAction.Recurse);
+    }
+
+    [Fact]
+    public void Composer_default_appends_lists()
+    {
+        var model = CloudConfigComposer.MergeToModel(
+        [
+            "ssh_authorized_keys: [a]",
+            "ssh_authorized_keys: [b]",
+        ]);
+
+        model!.SshAuthorizedKeys.Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public void Composer_honours_list_replace_directive_on_incoming_fragment()
+    {
+        var model = CloudConfigComposer.MergeToModel(
+        [
+            "ssh_authorized_keys: [a, b]",
+            "merge_how: list(replace)\nssh_authorized_keys: [c]",
+        ]);
+
+        model!.SshAuthorizedKeys.Should().Equal("c");
+    }
+
+    [Fact]
+    public void Composer_directive_on_first_fragment_does_not_affect_outcome()
+    {
+        // The first fragment has nothing to merge onto, so its directive is moot.
+        var model = CloudConfigComposer.MergeToModel(
+        [
+            "merge_how: list(replace)\nssh_authorized_keys: [a]",
+            "ssh_authorized_keys: [b]",
+        ]);
+
+        model!.SshAuthorizedKeys.Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public void Composer_replace_then_append_keeps_replaced_plus_later()
+    {
+        // a, then b(replace) -> [b], then c(append) -> [b, c]. Each directive
+        // acts on the accumulator produced by the fragments before it.
+        var model = CloudConfigComposer.MergeToModel(
+        [
+            "ssh_authorized_keys: [a]",
+            "merge_how: list(replace)\nssh_authorized_keys: [b]",
+            "ssh_authorized_keys: [c]",
+        ]);
+
+        model!.SshAuthorizedKeys.Should().Equal("b", "c");
+    }
+
+    [Fact]
+    public void Composer_append_then_replace_keeps_only_the_last()
+    {
+        // a, then b(append) -> [a, b], then c(replace) -> [c]. A late replace
+        // drops everything accumulated so far.
+        var model = CloudConfigComposer.MergeToModel(
+        [
+            "ssh_authorized_keys: [a]",
+            "ssh_authorized_keys: [b]",
+            "merge_how: list(replace)\nssh_authorized_keys: [c]",
+        ]);
+
+        model!.SshAuthorizedKeys.Should().Equal("c");
+    }
+
+    [Fact]
+    public void Composer_no_replace_in_the_middle_protects_the_accumulator()
+    {
+        // a, then b(no_replace) -> keeps [a], then c(append) -> [a, c]. The
+        // middle fragment's keys are dropped because the accumulator is non-empty.
+        var model = CloudConfigComposer.MergeToModel(
+        [
+            "ssh_authorized_keys: [a]",
+            "merge_how: list(no_replace)\nssh_authorized_keys: [b]",
+            "ssh_authorized_keys: [c]",
+        ]);
+
+        model!.SshAuthorizedKeys.Should().Equal("a", "c");
+    }
+
+    [Fact]
+    public void Merge_how_key_does_not_warn_as_unknown()
+    {
+        var unknown = new List<string>();
+
+        CloudConfigYamlSerializer.Deserialize("merge_how: list(replace)\nhostname: web01", unknown.Add);
+
+        unknown.Should().NotContain("merge_how");
+    }
+}

--- a/test/Eryph.GuestServices.Provisioning.Tests/UserData/TestResolutionContext.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/UserData/TestResolutionContext.cs
@@ -27,9 +27,12 @@ internal sealed class TestResolutionContext : IUserDataResolutionContext
 
     public List<UserDataPart> NestedParts { get; } = [];
 
-    public void MergeCloudConfig(CloudConfigModel fragment)
+    public void MergeCloudConfig(CloudConfigModel fragment) =>
+        MergeCloudConfig(fragment, CloudInitMergeOptions.CloudInitDefault);
+
+    public void MergeCloudConfig(CloudConfigModel fragment, CloudInitMergeOptions options)
     {
-        CloudConfig = CloudConfigMerge.Merge(CloudConfig, fragment);
+        CloudConfig = CloudConfigMerge.Merge(CloudConfig, fragment, options);
     }
 
     public void AddScript(ScriptPayload script) => Scripts.Add(script);

--- a/test/Eryph.GuestServices.Provisioning.Tests/UserData/UserDataPipelineTests.cs
+++ b/test/Eryph.GuestServices.Provisioning.Tests/UserData/UserDataPipelineTests.cs
@@ -156,6 +156,33 @@ public sealed class UserDataPipelineTests : IDisposable
     }
 
     [Fact]
+    public async Task ResolveAsync_SecondFragmentMergeHowReplace_ReplacesAccumulatedList()
+    {
+        // The second cloud-config part carries merge_how: list(replace) (RFC 0032),
+        // so its runcmd replaces the first part's rather than appending.
+        const string raw =
+            "Content-Type: multipart/mixed; boundary=\"B\"\r\n" +
+            "\r\n" +
+            "--B\r\n" +
+            "Content-Type: text/x-cloud-config\r\n" +
+            "\r\n" +
+            "#cloud-config\nruncmd:\n  - echo first\n" +
+            "\r\n" +
+            "--B\r\n" +
+            "Content-Type: text/x-cloud-config\r\n" +
+            "\r\n" +
+            "#cloud-config\nmerge_how: list(replace)\nruncmd:\n  - echo second\n" +
+            "\r\n" +
+            "--B--\r\n";
+
+        var pipeline = BuildPipeline(out _);
+        var result = await pipeline.ResolveAsync(Encoding.UTF8.GetBytes(raw), CancellationToken.None);
+
+        result.CloudConfig.Runcmd.Should().ContainSingle();
+        result.CloudConfig.Runcmd![0].Command.Should().Be("echo second");
+    }
+
+    [Fact]
     public async Task ResolveAsync_UnrecognisedRoot_ReturnsEmptyAndWarns()
     {
         var pipeline = BuildPipeline(out _);


### PR DESCRIPTION
Implements RFC 0032.

## Pre-merge library
- `CloudConfigComposer` folds multiple cloud-config fragments into one `#cloud-config` document, for building a single NoCloud seed disk instead of shipping fragments.
- Adds the model→YAML serializer the agent never needed (it only reads); shares one naming/alias config with the deserializer so output round-trips.
- `CloudConfig` and `CloudConfig.Yaml` are now packable (`PackageId`s) so eryph can reference them; the source generator ships baked in, not as a dependency.

## merge_how / merge_type
- Fragments can override the default merge with cloud-init's `merge_how` / `merge_type` directive (string and structured forms), e.g. `list(replace)` to own a list instead of appending.
- Parsed into `CloudInitMergeOptions` (list/dict/str actions) and threaded through the source-generated deep-merge. Applied in both the composer and the guest provisioning pipeline; the directive on each fragment governs how it merges onto the accumulator.
- No directive = the existing cloud-init default merge, so current fodder is unaffected.

## Tests
Directive parsing, list/dict actions (incl. users/groups keyed merges), multi-fragment folds, serializer round-trip. Default-merge behaviour and all existing suites unchanged.